### PR TITLE
feat(LC011): Comprehensive improvements for entity primary key detection

### DIFF
--- a/src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs
@@ -61,13 +61,13 @@ public class NPlusOneLooperAnalyzer : DiagnosticAnalyzer
                 Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), method.Name));
     }
 
-    private bool IsDbExecutionMethod(IMethodSymbol method, IInvocationOperation invocation)
+    private static bool IsDbExecutionMethod(IMethodSymbol method, IInvocationOperation invocation)
     {
         // Case 1: DbSet.Find / FindAsync
         if (method.Name.StartsWith("Find") && method.ContainingType.IsDbSet()) return true;
 
         // Case 2: IQueryable materializers (ToList, Count, First, etc.)
-        if (!IsMaterializer(method.Name)) return false;
+        if (!method.Name.IsMaterializerMethod()) return false;
 
         ITypeSymbol? receiverType = null;
 
@@ -85,27 +85,6 @@ public class NPlusOneLooperAnalyzer : DiagnosticAnalyzer
         }
 
         return receiverType.IsIQueryable();
-    }
-
-    private bool IsMaterializer(string name)
-    {
-        // List of methods that execute the query
-        return name == "ToList" || name == "ToListAsync" ||
-               name == "ToArray" || name == "ToArrayAsync" ||
-               name == "ToDictionary" || name == "ToDictionaryAsync" ||
-               name == "ToHashSet" || name == "ToHashSetAsync" ||
-               name == "First" || name == "FirstOrDefault" ||
-               name == "FirstAsync" || name == "FirstOrDefaultAsync" ||
-               name == "Single" || name == "SingleOrDefault" ||
-               name == "SingleAsync" || name == "SingleOrDefaultAsync" ||
-               name == "Last" || name == "LastOrDefault" ||
-               name == "LastAsync" || name == "LastOrDefaultAsync" ||
-               name == "Count" || name == "LongCount" ||
-               name == "CountAsync" || name == "LongCountAsync" ||
-               name == "Any" || name == "All" ||
-               name == "AnyAsync" || name == "AllAsync" ||
-               name == "Sum" || name == "Average" || name == "Min" || name == "Max" ||
-               name == "SumAsync" || name == "AverageAsync" || name == "MinAsync" || name == "MaxAsync";
     }
 
     private bool IsInsideLoop(IOperation operation)

--- a/src/LinqContraband/Analyzers/LC009_MissingAsNoTracking/MissingAsNoTrackingAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC009_MissingAsNoTracking/MissingAsNoTrackingAnalyzer.cs
@@ -69,19 +69,13 @@ public class MissingAsNoTrackingAnalyzer : DiagnosticAnalyzer
             Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), containingMethodName));
     }
 
-    private bool IsMaterializer(IMethodSymbol method)
+    private static bool IsMaterializer(IMethodSymbol method)
     {
-        // Quick check
-        if (method.Name.StartsWith("Find")) return false; // AsNoTracking has no effect on Find
+        // Find/FindAsync have no effect with AsNoTracking, so skip them
+        if (method.Name.StartsWith("Find")) return false;
 
-        return method.Name == "ToList" || method.Name == "ToListAsync" ||
-               method.Name == "ToArray" || method.Name == "ToArrayAsync" ||
-               method.Name == "First" || method.Name == "FirstOrDefault" ||
-               method.Name == "FirstAsync" || method.Name == "FirstOrDefaultAsync" ||
-               method.Name == "Single" || method.Name == "SingleOrDefault" ||
-               method.Name == "SingleAsync" || method.Name == "SingleOrDefaultAsync" ||
-               method.Name == "Last" || method.Name == "LastOrDefault" ||
-               method.Name == "LastAsync" || method.Name == "LastOrDefaultAsync";
+        // Use shared extension method for materializer check
+        return method.Name.IsMaterializerMethod();
     }
 
     private ChainAnalysis AnalyzeQueryChain(IInvocationOperation invocation)

--- a/src/LinqContraband/Extensions/AnalysisExtensions.cs
+++ b/src/LinqContraband/Extensions/AnalysisExtensions.cs
@@ -151,4 +151,37 @@ public static class AnalysisExtensions
 
         return false;
     }
+
+    /// <summary>
+    /// Determines whether the method name is a query materializer that triggers database execution.
+    /// </summary>
+    /// <param name="methodName">The method name to check.</param>
+    /// <returns><c>true</c> if the method is a materializer; otherwise, <c>false</c>.</returns>
+    /// <remarks>
+    /// Materializers are methods that execute the query and return results, such as ToList, First, Count, etc.
+    /// This includes both synchronous and asynchronous variants.
+    /// </remarks>
+    public static bool IsMaterializerMethod(this string methodName)
+    {
+        return methodName is
+            // Collection materializers
+            "ToList" or "ToListAsync" or
+            "ToArray" or "ToArrayAsync" or
+            "ToDictionary" or "ToDictionaryAsync" or
+            "ToHashSet" or "ToHashSetAsync" or
+            // Single element materializers
+            "First" or "FirstOrDefault" or
+            "FirstAsync" or "FirstOrDefaultAsync" or
+            "Single" or "SingleOrDefault" or
+            "SingleAsync" or "SingleOrDefaultAsync" or
+            "Last" or "LastOrDefault" or
+            "LastAsync" or "LastOrDefaultAsync" or
+            // Aggregate materializers
+            "Count" or "LongCount" or
+            "CountAsync" or "LongCountAsync" or
+            "Any" or "All" or
+            "AnyAsync" or "AllAsync" or
+            "Sum" or "Average" or "Min" or "Max" or
+            "SumAsync" or "AverageAsync" or "MinAsync" or "MaxAsync";
+    }
 }

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>2.12.0</Version>
+        <Version>2.14.0</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzerTests.cs
@@ -11,20 +11,24 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using TestNamespace;
+using Microsoft.EntityFrameworkCore;
 ";
 
     private const string MockNamespace = @"
 namespace TestNamespace
 {
     public class User { public int Id { get; set; } }
-    
-    public class DbContext : IDisposable 
-    { 
+}
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class DbContext : IDisposable
+    {
         public void Dispose() {}
         public DbSet<User> Users { get; set; }
         public void RemoveRange(IEnumerable<object> entities) {}
     }
-    
+
     public class DbSet<T> : IQueryable<T>
     {
         public Type ElementType => typeof(T);
@@ -35,13 +39,6 @@ namespace TestNamespace
 
         public void RemoveRange(IEnumerable<T> entities) {}
         public void RemoveRange(params T[] entities) {}
-    }
-
-    namespace Microsoft.EntityFrameworkCore
-    {
-        // Mock for detection of EF Core usage
-        public class DbContext {}
-        public class DbSet<T> {}
     }
 }
 ";


### PR DESCRIPTION
## Summary
- Add HasNoKey() fluent API detection in OnModelCreating
- Add owned type detection (OwnsOne/OwnsMany) - owned entities don't need keys
- Add HasKey() string parameter support (e.g., `HasKey("MyKey")`)
- Add DbSet field support (not just properties)
- Fix private Id property detection (must be public with public getter)
- Fix navigation property validation (Id must be scalar, not reference type)
- Fix IEntityTypeConfiguration without HasKey (now properly warns)
- Add comprehensive test coverage (12 new tests, 146 total)
- Bump version to 2.14.0

## Test plan
- [x] All 146 tests pass
- [x] Build succeeds with no errors
- [x] Sample project correctly shows LC011 warning for `Product` entity missing primary key
- [x] IDE live analysis works (no CompilationEnd pattern)

## Breaking Changes
Entities with private Id properties or navigation properties named Id will now correctly trigger LC011 warnings.