### PR TITLE
feat: Full sweep improvements — fixers, bug fixes, perf, tests, CI, docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -118,3 +118,30 @@ indent_size = 2
 
 # LC016: Avoid DateTime.Now in Queries - Breaks query plan caching
 # dotnet_diagnostic.LC016.severity = warning
+
+# LC017: Whole Entity Projection - Loading entire entity when few properties accessed
+# dotnet_diagnostic.LC017.severity = warning
+
+# LC018: Avoid FromSqlRaw with Interpolation - SQL injection risk from interpolated strings
+# dotnet_diagnostic.LC018.severity = warning
+
+# LC020: String Contains with Comparison - Missing StringComparison argument
+# dotnet_diagnostic.LC020.severity = warning
+
+# LC021: Avoid IgnoreQueryFilters - Bypassing critical global filters
+# dotnet_diagnostic.LC021.severity = warning
+
+# LC023: Find Instead of FirstOrDefault - Using FirstOrDefault when Find is more efficient
+# dotnet_diagnostic.LC023.severity = warning
+
+# LC025: AsNoTracking with Update - Conflicting tracking/update intent
+# dotnet_diagnostic.LC025.severity = warning
+
+# LC026: Missing CancellationToken - Async operations without cancellation support
+# dotnet_diagnostic.LC026.severity = warning
+
+# LC029: Redundant Identity Select - Pointless Select(x => x) projection
+# dotnet_diagnostic.LC029.severity = warning
+
+# LC030: DbContext in Singleton - Potential lifetime mismatch
+# dotnet_diagnostic.LC030.severity = warning

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,12 +7,13 @@ on:
     branches: [ "master" ]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -25,11 +26,22 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore dependencies
         run: dotnet restore
 
       - name: Build
         run: dotnet build --no-restore
+
+      - name: Verify formatting
+        run: dotnet format --verify-no-changes
 
       - name: Test
         run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
@@ -40,6 +52,16 @@ jobs:
           reports: 'coverage/**/coverage.cobertura.xml'
           targetdir: 'coverage-report'
           reporttypes: 'Badges'
+
+      - name: Check coverage threshold
+        run: |
+          COVERAGE=$(grep -oP 'line-rate="\K[^"]+' coverage/**/coverage.cobertura.xml | head -1)
+          COVERAGE_PCT=$(echo "$COVERAGE * 100" | bc)
+          echo "Coverage: ${COVERAGE_PCT}%"
+          if (( $(echo "$COVERAGE < 0.75" | bc -l) )); then
+            echo "Coverage ${COVERAGE_PCT}% is below 75% threshold"
+            exit 1
+          fi
 
       - name: Commit Coverage Badge
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
         
     - name: Restore dependencies
       run: dotnet restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.21.0] - Initial Changelog Entry
+
+### Analyzers
+
+#### Performance
+- LC002: Premature Materialization - early ToList/AsEnumerable before filtering
+- LC003: Prefer Any() over Count() - using Count() > 0 instead of Any()
+- LC005: Multiple OrderBy Calls - chained OrderBy() that cancel each other
+- LC006: Cartesian Explosion Risk - multiple Include() without AsSplitQuery
+- LC007: N+1 Looper - database queries inside loops
+- LC010: SaveChanges Loop Tax - SaveChanges() inside a loop
+- LC012: Optimize Bulk Delete - RemoveRange() instead of ExecuteDelete()
+- LC015: Missing OrderBy Before Skip/Last - non-deterministic results
+- LC017: Whole Entity Projection - loading entire entity when few properties accessed
+- LC029: Redundant Identity Select - pointless Select(x => x) projection
+
+#### Safety
+- LC001: Local Method Smuggler - client-side evaluation from local methods
+- LC004: Deferred Execution Leak - IQueryable passed to IEnumerable parameter
+- LC008: Sync-over-Async - sync methods in async context
+- LC013: Disposed Context Query - returning IQueryable from using-scoped context
+- LC016: Avoid DateTime.Now in Queries - breaks query plan caching
+- LC018: Avoid FromSqlRaw with Interpolation - SQL injection risk
+- LC026: Missing CancellationToken - async operations without cancellation
+
+#### Design
+- LC009: The Tracking Tax - missing AsNoTracking() on read-only queries
+- LC011: Entity Missing Primary Key - no Id, {Name}Id, [Key], or HasKey()
+- LC014: Avoid String Case Conversion - ToLower()/ToUpper() prevents index usage
+- LC020: String Contains with Comparison - missing StringComparison argument
+- LC023: Find Instead of FirstOrDefault - using FirstOrDefault when Find is more efficient
+- LC025: AsNoTracking with Update - conflicting tracking/update intent
+
+#### Security
+- LC021: Avoid IgnoreQueryFilters - bypassing critical global filters
+
+#### Architecture
+- LC030: DbContext in Singleton - potential lifetime mismatch
+
+### Code Fixes
+- LC001: Local Method Smuggler
+- LC002: Premature Materialization
+- LC003: Any Over Count
+- LC005: Multiple OrderBy (ThenBy conversion)
+- LC006: Cartesian Explosion (AsSplitQuery)
+- LC008: Sync Blocker (async conversion)
+- LC009: Missing AsNoTracking
+- LC010: SaveChanges Loop Tax
+- LC011: Entity Missing Primary Key
+- LC012: Optimize RemoveRange
+- LC014: Avoid String Case Conversion
+- LC015: Missing OrderBy
+- LC016: Avoid DateTime.Now (extract to variable)
+- LC017: Whole Entity Projection (add Select)
+- LC018: Avoid FromSqlRaw (use FromSqlInterpolated)
+- LC020: String Contains with Comparison
+- LC021: Avoid IgnoreQueryFilters
+- LC023: Find Instead of FirstOrDefault
+- LC025: AsNoTracking with Update
+- LC026: Missing CancellationToken
+- LC029: Redundant Identity Select

--- a/src/LinqContraband/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopFixer.cs
+++ b/src/LinqContraband/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopFixer.cs
@@ -1,0 +1,84 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace LinqContraband.Analyzers.LC010_SaveChangesInLoop;
+
+/// <summary>
+/// Provides code fixes for LC010. Moves SaveChanges/SaveChangesAsync calls to after the enclosing loop.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SaveChangesInLoopFixer))]
+[Shared]
+public class SaveChangesInLoopFixer : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(SaveChangesInLoopAnalyzer.DiagnosticId);
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        var node = root.FindNode(diagnosticSpan);
+        var invocation = node as InvocationExpressionSyntax
+                         ?? node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+
+        if (invocation == null) return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Move SaveChanges after loop",
+                c => ApplyFixAsync(context.Document, invocation, c),
+                "MoveSaveChangesAfterLoop"),
+            diagnostic);
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocation,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        // Find the expression statement containing SaveChanges
+        var expressionStatement = invocation.AncestorsAndSelf().OfType<ExpressionStatementSyntax>().FirstOrDefault();
+        if (expressionStatement == null)
+        {
+            // May be an await expression: await db.SaveChangesAsync()
+            var awaitExpr = invocation.AncestorsAndSelf().OfType<AwaitExpressionSyntax>().FirstOrDefault();
+            expressionStatement = awaitExpr?.Parent as ExpressionStatementSyntax;
+        }
+
+        if (expressionStatement == null) return document;
+
+        // Find the enclosing loop
+        var loop = expressionStatement.Ancestors().FirstOrDefault(n =>
+            n is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax);
+
+        if (loop == null) return document;
+
+        // Create the new statement to insert after the loop (preserve the full statement including await if present)
+        var newStatement = expressionStatement
+            .WithLeadingTrivia(loop.GetLeadingTrivia())
+            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
+
+        // Remove the statement from inside the loop
+        editor.RemoveNode(expressionStatement);
+
+        // Insert after the loop
+        editor.InsertAfter(loop, newStatement);
+
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/LinqContraband/Analyzers/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersFixer.cs
+++ b/src/LinqContraband/Analyzers/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersFixer.cs
@@ -1,0 +1,63 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace LinqContraband.Analyzers.LC021_AvoidIgnoreQueryFilters;
+
+/// <summary>
+/// Provides code fixes for LC021. Removes IgnoreQueryFilters() calls from query chains.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidIgnoreQueryFiltersFixer))]
+[Shared]
+public class AvoidIgnoreQueryFiltersFixer : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(AvoidIgnoreQueryFiltersAnalyzer.DiagnosticId);
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        var node = root.FindNode(diagnosticSpan);
+        var invocation = node as InvocationExpressionSyntax
+                         ?? node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+
+        if (invocation == null) return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Remove IgnoreQueryFilters()",
+                c => ApplyFixAsync(context.Document, invocation, c),
+                "RemoveIgnoreQueryFilters"),
+            diagnostic);
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocation,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return document;
+
+        var receiver = memberAccess.Expression;
+
+        editor.ReplaceNode(invocation, receiver
+            .WithLeadingTrivia(invocation.GetLeadingTrivia())
+            .WithTrailingTrivia(invocation.GetTrailingTrivia()));
+
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/LinqContraband/Analyzers/LC029_RedundantIdentitySelect/RedundantIdentitySelectFixer.cs
+++ b/src/LinqContraband/Analyzers/LC029_RedundantIdentitySelect/RedundantIdentitySelectFixer.cs
@@ -1,0 +1,66 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace LinqContraband.Analyzers.LC029_RedundantIdentitySelect;
+
+/// <summary>
+/// Provides code fixes for LC029. Removes redundant Select(x => x) identity projections.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RedundantIdentitySelectFixer))]
+[Shared]
+public class RedundantIdentitySelectFixer : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(RedundantIdentitySelectAnalyzer.DiagnosticId);
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        var node = root.FindNode(diagnosticSpan);
+        var invocation = node as InvocationExpressionSyntax
+                         ?? node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+
+        if (invocation == null) return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Remove redundant Select",
+                c => ApplyFixAsync(context.Document, invocation, c),
+                "RemoveRedundantSelect"),
+            diagnostic);
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocation,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        // The invocation is something like: receiver.Select(x => x)
+        // We need to extract the receiver
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return document;
+
+        var receiver = memberAccess.Expression;
+
+        // Replace the Select invocation with just the receiver, preserving trivia
+        editor.ReplaceNode(invocation, receiver
+            .WithLeadingTrivia(invocation.GetLeadingTrivia())
+            .WithTrailingTrivia(invocation.GetTrailingTrivia()));
+
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/LinqContraband/Analyzers/LC030_DbContextInSingleton/DbContextInSingletonFixer.cs
+++ b/src/LinqContraband/Analyzers/LC030_DbContextInSingleton/DbContextInSingletonFixer.cs
@@ -1,0 +1,187 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace LinqContraband.Analyzers.LC030_DbContextInSingleton;
+
+/// <summary>
+/// Provides code fixes for LC030. Changes DbContext field to IDbContextFactory&lt;TContext&gt;.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(DbContextInSingletonFixer))]
+[Shared]
+public class DbContextInSingletonFixer : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DbContextInSingletonAnalyzer.DiagnosticId);
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null) return;
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        var token = root.FindToken(diagnosticSpan.Start);
+        if (token.Parent is null) return;
+
+        var fieldDecl = token.Parent.AncestorsAndSelf().OfType<FieldDeclarationSyntax>().FirstOrDefault();
+        var propDecl = token.Parent.AncestorsAndSelf().OfType<PropertyDeclarationSyntax>().FirstOrDefault();
+
+        if (fieldDecl != null)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Change to IDbContextFactory<T>",
+                    c => ApplyFieldFixAsync(context.Document, fieldDecl, c),
+                    "ChangeToDbContextFactory"),
+                diagnostic);
+        }
+        else if (propDecl != null)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Change to IDbContextFactory<T>",
+                    c => ApplyPropertyFixAsync(context.Document, propDecl, c),
+                    "ChangeToDbContextFactory"),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ApplyFieldFixAsync(Document document, FieldDeclarationSyntax fieldDecl,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        var oldType = fieldDecl.Declaration.Type;
+
+        var factoryType = CreateFactoryType(oldType);
+
+        var newDeclaration = fieldDecl.Declaration.WithType(factoryType.WithTriviaFrom(oldType));
+        var newFieldDecl = fieldDecl.WithDeclaration(newDeclaration);
+
+        // Rename variable to add Factory suffix
+        var variable = fieldDecl.Declaration.Variables.First();
+        var oldName = variable.Identifier.Text;
+        var newName = AddFactorySuffix(oldName);
+
+        if (oldName != newName)
+        {
+            var newVariable = variable.WithIdentifier(
+                SyntaxFactory.Identifier(newName).WithTriviaFrom(variable.Identifier));
+            newFieldDecl = newFieldDecl.WithDeclaration(
+                newFieldDecl.Declaration.WithVariables(
+                    SyntaxFactory.SingletonSeparatedList(newVariable)));
+        }
+
+        editor.ReplaceNode(fieldDecl, newFieldDecl);
+
+        // Update constructor parameters with matching DbContext type
+        if (fieldDecl.Parent is ClassDeclarationSyntax classDecl)
+        {
+            UpdateConstructorParameters(editor, classDecl, oldType, factoryType, oldName, newName);
+        }
+
+        return editor.GetChangedDocument();
+    }
+
+    private static async Task<Document> ApplyPropertyFixAsync(Document document, PropertyDeclarationSyntax propDecl,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        var oldType = propDecl.Type;
+
+        var factoryType = CreateFactoryType(oldType);
+
+        var newPropDecl = propDecl.WithType(factoryType.WithTriviaFrom(oldType));
+        editor.ReplaceNode(propDecl, newPropDecl);
+
+        return editor.GetChangedDocument();
+    }
+
+    private static GenericNameSyntax CreateFactoryType(TypeSyntax dbContextType)
+    {
+        return SyntaxFactory.GenericName(
+            SyntaxFactory.Identifier("IDbContextFactory"),
+            SyntaxFactory.TypeArgumentList(
+                SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
+                    dbContextType.WithoutTrivia())));
+    }
+
+    private static void UpdateConstructorParameters(DocumentEditor editor, ClassDeclarationSyntax classDecl,
+        TypeSyntax dbContextType, TypeSyntax factoryType, string oldFieldName, string newFieldName)
+    {
+        var dbContextTypeName = dbContextType.ToString();
+        foreach (var constructor in classDecl.Members.OfType<ConstructorDeclarationSyntax>())
+        {
+            foreach (var parameter in constructor.ParameterList.Parameters)
+            {
+                if (parameter.Type?.ToString() == dbContextTypeName)
+                {
+                    var newParam = parameter.WithType(factoryType.WithTriviaFrom(parameter.Type));
+
+                    var oldParamName = parameter.Identifier.Text;
+                    var newParamName = AddFactorySuffix(oldParamName);
+                    if (oldParamName != newParamName)
+                    {
+                        newParam = newParam.WithIdentifier(
+                            SyntaxFactory.Identifier(newParamName).WithTriviaFrom(parameter.Identifier));
+                    }
+
+                    editor.ReplaceNode(parameter, newParam);
+
+                    UpdateConstructorBody(editor, constructor, oldFieldName, newFieldName, oldParamName, newParamName);
+                }
+            }
+        }
+    }
+
+    private static void UpdateConstructorBody(DocumentEditor editor, ConstructorDeclarationSyntax constructor,
+        string oldFieldName, string newFieldName, string oldParamName, string newParamName)
+    {
+        if (constructor.ExpressionBody != null)
+        {
+            if (constructor.ExpressionBody.Expression is AssignmentExpressionSyntax assignment)
+            {
+                var newAssignment = assignment;
+
+                if (assignment.Left is IdentifierNameSyntax leftId && leftId.Identifier.Text == oldFieldName &&
+                    oldFieldName != newFieldName)
+                {
+                    newAssignment = newAssignment.WithLeft(
+                        SyntaxFactory.IdentifierName(newFieldName).WithTriviaFrom(leftId));
+                }
+
+                if (assignment.Right is IdentifierNameSyntax rightId && rightId.Identifier.Text == oldParamName &&
+                    oldParamName != newParamName)
+                {
+                    newAssignment = newAssignment.WithRight(
+                        SyntaxFactory.IdentifierName(newParamName).WithTriviaFrom(rightId));
+                }
+
+                if (newAssignment != assignment)
+                {
+                    editor.ReplaceNode(assignment, newAssignment);
+                }
+            }
+        }
+    }
+
+    private static string AddFactorySuffix(string name)
+    {
+        if (name.EndsWith("Factory"))
+            return name;
+        return name + "Factory";
+    }
+}

--- a/src/LinqContraband/Constants/SyncAsyncMappings.cs
+++ b/src/LinqContraband/Constants/SyncAsyncMappings.cs
@@ -43,6 +43,8 @@ public static class SyncAsyncMappings
 
         // DbContext / DbSet methods
         { "SaveChanges", "SaveChangesAsync" },
-        { "Find", "FindAsync" }
+        { "Find", "FindAsync" },
+        { "ExecuteUpdate", "ExecuteUpdateAsync" },
+        { "ExecuteDelete", "ExecuteDeleteAsync" }
     };
 }

--- a/src/LinqContraband/Extensions/AnalysisExtensions.cs
+++ b/src/LinqContraband/Extensions/AnalysisExtensions.cs
@@ -108,7 +108,7 @@ public static class AnalysisExtensions
             break;
         }
 
-        return current!;
+        return current ?? operation;
     }
 
     /// <summary>
@@ -203,6 +203,7 @@ public static class AnalysisExtensions
             "ToArray" or "ToArrayAsync" or
             "ToDictionary" or "ToDictionaryAsync" or
             "ToHashSet" or "ToHashSetAsync" or
+            "AsEnumerable" or
             // Single element materializers
             "First" or "FirstOrDefault" or
             "FirstAsync" or "FirstOrDefaultAsync" or
@@ -216,7 +217,13 @@ public static class AnalysisExtensions
             "Any" or "All" or
             "AnyAsync" or "AllAsync" or
             "Sum" or "Average" or "Min" or "Max" or
-            "SumAsync" or "AverageAsync" or "MinAsync" or "MaxAsync";
+            "SumAsync" or "AverageAsync" or "MinAsync" or "MaxAsync" or
+            // Execution materializers
+            "Load" or "LoadAsync" or
+            "ForEachAsync" or
+            // Bulk operation materializers
+            "ExecuteDelete" or "ExecuteDeleteAsync" or
+            "ExecuteUpdate" or "ExecuteUpdateAsync";
     }
 
     /// <summary>

--- a/tests/LinqContraband.Tests/Analyzers/LC001_LocalMethod/LocalMethodSmugglerEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC001_LocalMethod/LocalMethodSmugglerEdgeCasesTests.cs
@@ -1,0 +1,200 @@
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    LinqContraband.Analyzers.LC001_LocalMethod.LocalMethodAnalyzer>;
+
+namespace LinqContraband.Tests.Analyzers.LC001_LocalMethod;
+
+public class LocalMethodSmugglerEdgeCasesTests
+{
+    private const string Usings = @"
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Collections.Generic;
+using TestNamespace;
+";
+
+    private const string MockNamespace = @"
+namespace TestNamespace
+{
+    public class User
+    {
+        public int Age { get; set; }
+        public DateTime Dob { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class DbContext
+    {
+        public IQueryable<User> Users => new List<User>().AsQueryable();
+    }
+}";
+
+    [Fact]
+    public async Task TestCrime_NestedLambda_LocalMethodInInnerLambda_ShouldTriggerLC001()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users
+            .Where(u => db.Users
+                .Any(inner => IsMatch(inner.Name, u.Name)));
+    }
+
+    bool IsMatch(string a, string b) => a == b;
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC001")
+            .WithSpan(15, 31, 15, 58)
+            .WithArguments("IsMatch");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_NestedLambda_LocalMethodInOuterLambda_ShouldTriggerLC001()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users
+            .Where(u => CalculateAge(u.Dob) > 18 && u.Age > 0);
+    }
+
+    int CalculateAge(DateTime dob) => 0;
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC001")
+            .WithSpan(14, 25, 14, 44)
+            .WithArguments("CalculateAge");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_ExpressionBodiedMember_CallingLocalMethod_ShouldTriggerLC001()
+    {
+        var test = Usings + @"
+class Program
+{
+    DbContext db = new DbContext();
+
+    IQueryable<User> Adults => db.Users.Where(u => IsAdult(u.Age));
+
+    bool IsAdult(int age) => age >= 18;
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC001")
+            .WithSpan(12, 52, 12, 66)
+            .WithArguments("IsAdult");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestInnocent_MethodGroupOnList_ShouldNotTrigger()
+    {
+        // Method groups on non-IQueryable (List) should not trigger
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var list = new List<User>();
+        var results = list.Where(IsValid);
+    }
+
+    bool IsValid(User u) => u.Age > 18;
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_SelectWithPropertyAccess_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Select(u => u.Name);
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_LinqMethodChainNoLocalMethod_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users
+            .Where(u => u.Age > 18)
+            .Select(u => u.Name);
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_LocalMethodInSelect_ShouldTriggerLC001()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Select(u => FormatName(u.Name));
+    }
+
+    string FormatName(string name) => name.Trim();
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC001")
+            .WithSpan(13, 42, 13, 60)
+            .WithArguments("FormatName");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestInnocent_LambdaOnIEnumerable_ShouldNotTrigger()
+    {
+        // Calling a local method on IEnumerable (not IQueryable) should not trigger
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        IEnumerable<User> users = new List<User>();
+        var results = users.Where(u => IsAdult(u.Age));
+    }
+
+    bool IsAdult(int age) => age >= 18;
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC003_AnyOverCount/AnyOverCountTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC003_AnyOverCount/AnyOverCountTests.cs
@@ -206,4 +206,39 @@ namespace LinqContraband.Test
             
         await VerifyCS.VerifyAnalyzerAsync(test2, expected);
     }
+
+    [Fact]
+    public async Task ZeroLessThanCountAsync_ShouldTriggerLC003()
+    {
+        var test = Usings + @"
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static Task<int> CountAsync<TSource>(this IQueryable<TSource> source, System.Threading.CancellationToken cancellationToken = default) => Task.FromResult(0);
+    }
+}
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public async Task TestMethod()
+        {
+            var query = new List<int>().AsQueryable();
+            if (0 < await query.CountAsync())
+            {
+            }
+        }
+    }
+}
+";
+
+        var expected = VerifyCS.Diagnostic("LC003")
+            .WithSpan(23, 17, 23, 45);
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC005_MultipleOrderBy/MultipleOrderByTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC005_MultipleOrderBy/MultipleOrderByTests.cs
@@ -123,4 +123,52 @@ class Test
 }";
         await VerifyCS.VerifyCodeFixAsync(test, fix);
     }
+
+    [Fact]
+    public async Task Diagnostic_OrderByOrderBy_WithAsyncMaterializer()
+    {
+        var test = @"
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source) => Task.FromResult(source.ToList());
+    }
+}
+
+class Test
+{
+    async Task Method()
+    {
+        var q = await new List<int>().AsQueryable().OrderBy(x => x).{|LC005:OrderBy|}(x => x).ToListAsync();
+    }
+}";
+        var fix = @"
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source) => Task.FromResult(source.ToList());
+    }
+}
+
+class Test
+{
+    async Task Method()
+    {
+        var q = await new List<int>().AsQueryable().OrderBy(x => x).ThenBy(x => x).ToListAsync();
+    }
+}";
+        await VerifyCS.VerifyCodeFixAsync(test, fix);
+    }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC008_SyncBlocker/SyncBlockerEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC008_SyncBlocker/SyncBlockerEdgeCasesTests.cs
@@ -1,0 +1,222 @@
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    LinqContraband.Analyzers.LC008_SyncBlocker.SyncBlockerAnalyzer>;
+
+namespace LinqContraband.Tests.Analyzers.LC008_SyncBlocker;
+
+public class SyncBlockerEdgeCasesTests
+{
+    private const string Usings = @"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TestNamespace;
+";
+
+    private const string MockNamespace = @"
+namespace Microsoft.EntityFrameworkCore
+{
+    public class DbContext : IDisposable
+    {
+        public void Dispose() { }
+        public DbSet<T> Set<T>() where T : class => new DbSet<T>();
+        public int SaveChanges() => 0;
+        public Task<int> SaveChangesAsync() => Task.FromResult(0);
+    }
+
+    public class DbSet<T> : IQueryable<T> where T : class
+    {
+        public Type ElementType => typeof(T);
+        public System.Linq.Expressions.Expression Expression => System.Linq.Expressions.Expression.Constant(this);
+        public IQueryProvider Provider => null;
+        public IEnumerator<T> GetEnumerator() => null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null;
+
+        public T Find(params object[] keyValues) => null;
+        public Task<T> FindAsync(params object[] keyValues) => Task.FromResult<T>(null);
+    }
+
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source) => Task.FromResult(new List<T>());
+        public static Task<int> CountAsync<T>(this IQueryable<T> source) => Task.FromResult(0);
+        public static Task<T> FirstAsync<T>(this IQueryable<T> source) => Task.FromResult<T>(default);
+    }
+}
+
+namespace TestNamespace
+{
+    public class User { public int Id { get; set; } }
+
+    public class MyDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+}";
+
+    [Fact]
+    public async Task TestCrime_SyncCallInsideAsyncLambdaInsideAsyncMethod_ShouldTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        Func<Task> action = async () =>
+        {
+            // Sync call inside async lambda inside async method
+            var users = db.Users.ToList();
+            await Task.Delay(1);
+        };
+        await action();
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC008")
+            .WithSpan(17, 25, 17, 42)
+            .WithArguments("ToList", "ToListAsync");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_SyncCallInsideNonAsyncLambdaInsideAsyncMethod_ShouldTrigger()
+    {
+        // The analyzer walks up to find async context even through non-async lambdas
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        Action action = () =>
+        {
+            // Sync call inside non-async lambda but enclosing method is async
+            var users = db.Users.ToList();
+        };
+        action();
+        await Task.Delay(1);
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC008")
+            .WithSpan(17, 25, 17, 42)
+            .WithArguments("ToList", "ToListAsync");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_ValueTaskReturnType_WithSyncCall_ShouldTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    async ValueTask<int> GetCount()
+    {
+        var db = new MyDbContext();
+        return db.Users.Count();
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC008")
+            .WithSpan(14, 16, 14, 32)
+            .WithArguments("Count", "CountAsync");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_AsyncMethodWithFind_ShouldTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    async Task<User> GetUser()
+    {
+        var db = new MyDbContext();
+        return db.Users.Find(1);
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC008")
+            .WithSpan(14, 16, 14, 32)
+            .WithArguments("Find", "FindAsync");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestInnocent_SyncMethodWithSyncCalls_NoDiagnostic()
+    {
+        // Sync call inside a non-async method is fine
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var users = db.Users.ToList();
+        var count = db.Users.Count();
+        db.SaveChanges();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_AsyncMethod_MultipleSyncCalls_ShouldTriggerMultiple()
+    {
+        var test = Usings + @"
+class Program
+{
+    async Task DoWork()
+    {
+        var db = new MyDbContext();
+        var users = db.Users.ToList();
+        db.SaveChanges();
+        await Task.Delay(1);
+    }
+}
+" + MockNamespace;
+
+        var expected1 = VerifyCS.Diagnostic("LC008")
+            .WithSpan(14, 21, 14, 38)
+            .WithArguments("ToList", "ToListAsync");
+
+        var expected2 = VerifyCS.Diagnostic("LC008")
+            .WithSpan(15, 9, 15, 25)
+            .WithArguments("SaveChanges", "SaveChangesAsync");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected1, expected2);
+    }
+
+    [Fact]
+    public async Task TestInnocent_SyncLambdaInSyncMethod_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        Action action = () =>
+        {
+            var users = db.Users.ToList();
+        };
+        action();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopFixerTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.CodeAnalysis.Testing;
+using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
+    LinqContraband.Analyzers.LC010_SaveChangesInLoop.SaveChangesInLoopAnalyzer,
+    LinqContraband.Analyzers.LC010_SaveChangesInLoop.SaveChangesInLoopFixer,
+    Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+
+namespace LinqContraband.Tests.Analyzers.LC010_SaveChangesInLoop;
+
+public class SaveChangesInLoopFixerTests
+{
+    private const string Usings = @"
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TestNamespace;
+";
+
+    private const string MockNamespace = @"
+namespace Microsoft.EntityFrameworkCore
+{
+    public class DbContext : IDisposable
+    {
+        public int SaveChanges() => 0;
+        public Task<int> SaveChangesAsync() => Task.FromResult(0);
+        public void Dispose() {}
+    }
+}
+
+namespace TestNamespace
+{
+    public class MyDbContext : Microsoft.EntityFrameworkCore.DbContext
+    {
+    }
+}";
+
+    [Fact]
+    public async Task SaveChangesInForeach_ShouldMoveAfterLoop()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        using var db = new MyDbContext();
+        var items = new List<int> { 1, 2, 3 };
+
+        foreach (var item in items)
+        {
+            {|LC010:db.SaveChanges()|};
+        }
+    }
+}" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        using var db = new MyDbContext();
+        var items = new List<int> { 1, 2, 3 };
+
+        foreach (var item in items)
+        {
+        }
+
+        db.SaveChanges();
+    }
+}" + MockNamespace;
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsyncInFor_ShouldMoveAfterLoop()
+    {
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        using var db = new MyDbContext();
+
+        for (int i = 0; i < 10; i++)
+        {
+            await {|LC010:db.SaveChangesAsync()|};
+        }
+    }
+}" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        using var db = new MyDbContext();
+
+        for (int i = 0; i < 10; i++)
+        {
+        }
+
+        await db.SaveChangesAsync();
+    }
+}" + MockNamespace;
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task SaveChangesInWhile_ShouldMoveAfterLoop()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        using var db = new MyDbContext();
+        int i = 0;
+        while (i < 10)
+        {
+            {|LC010:db.SaveChanges()|};
+            i++;
+        }
+    }
+}" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        using var db = new MyDbContext();
+        int i = 0;
+        while (i < 10)
+        {
+            i++;
+        }
+        db.SaveChanges();
+    }
+}" + MockNamespace;
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    private static async Task VerifyFix(string test, string fixedCode)
+    {
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CompilerDiagnostics = CompilerDiagnostics.None
+        };
+
+        await testObj.RunAsync();
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyEdgeCasesTests.cs
@@ -1,0 +1,311 @@
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    LinqContraband.Analyzers.LC011_EntityMissingPrimaryKey.EntityMissingPrimaryKeyAnalyzer>;
+
+namespace LinqContraband.Tests.Analyzers.LC011_EntityMissingPrimaryKey;
+
+public class EntityMissingPrimaryKeyEdgeCasesTests
+{
+    private const string Usings = @"
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+using TestNamespace;
+";
+
+    private const string MockAttributes = @"
+namespace System.ComponentModel.DataAnnotations
+{
+    public class KeyAttribute : Attribute {}
+}
+namespace Microsoft.EntityFrameworkCore
+{
+    public class KeylessAttribute : Attribute {}
+    public class PrimaryKeyAttribute : Attribute
+    {
+        public PrimaryKeyAttribute(params string[] propertyNames) {}
+    }
+    public class DbContext : IDisposable
+    {
+        public void Dispose() {}
+        protected virtual void OnModelCreating(ModelBuilder modelBuilder) {}
+    }
+    public class DbSet<T> where T : class {}
+
+    public interface IEntityTypeConfiguration<T> where T : class
+    {
+        void Configure(EntityTypeBuilder<T> builder);
+    }
+
+    public class ModelBuilder
+    {
+        public EntityTypeBuilder<T> Entity<T>() where T : class => new EntityTypeBuilder<T>();
+    }
+
+    public class EntityTypeBuilder<T> where T : class
+    {
+        public EntityTypeBuilder<T> HasKey(params string[] propertyNames) => this;
+        public EntityTypeBuilder<T> HasKey(System.Linq.Expressions.Expression<Func<T, object>> keyExpression) => this;
+        public OwnedNavigationBuilder<T, TOwned> OwnsOne<TOwned>(System.Linq.Expressions.Expression<Func<T, TOwned>> navigationExpression) where TOwned : class => new OwnedNavigationBuilder<T, TOwned>();
+    }
+
+    public class OwnedNavigationBuilder<T, TOwned> where T : class where TOwned : class {}
+}
+
+namespace TestNamespace
+{
+    public class MyDbContext : Microsoft.EntityFrameworkCore.DbContext
+    {
+";
+
+    private const string MockEnd = @"
+    }
+}";
+
+    [Fact]
+    public async Task TestInnocent_EntityInheritsIdFromBaseClass_ShouldNotTrigger()
+    {
+        var test = Usings + MockAttributes + @"
+        public DbSet<DerivedEntity> DerivedEntities { get; set; }
+    }
+
+    public abstract class EntityBase
+    {
+        public int Id { get; set; }
+    }
+
+    public class DerivedEntity : EntityBase
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_EntityInheritsIdFromDeepBaseClass_ShouldNotTrigger()
+    {
+        var test = Usings + MockAttributes + @"
+        public DbSet<GrandChildEntity> GrandChildren { get; set; }
+    }
+
+    public abstract class RootBase
+    {
+        public int Id { get; set; }
+    }
+
+    public abstract class MiddleBase : RootBase
+    {
+        public string CreatedBy { get; set; }
+    }
+
+    public class GrandChildEntity : MiddleBase
+    {
+        public string Name { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_EntityInheritsTypeNameIdFromBaseClass_ShouldNotTrigger()
+    {
+        // Base class has EntityNameId pattern - should be recognized via convention
+        var test = Usings + MockAttributes + @"
+        public DbSet<Product> Products { get; set; }
+    }
+
+    public abstract class BaseEntity
+    {
+        public Guid ProductId { get; set; }
+    }
+
+    public class Product : BaseEntity
+    {
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_CompositeKeyViaKeyAttributes_ShouldNotTrigger()
+    {
+        var test = Usings + MockAttributes + @"
+        public DbSet<OrderItem> OrderItems { get; set; }
+    }
+
+    public class OrderItem
+    {
+        [Key]
+        public int OrderId { get; set; }
+        public int ProductId { get; set; }
+        public int Quantity { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_CompositeKeyViaFluentApi_ShouldNotTrigger()
+    {
+        var test = Usings + MockAttributes + @"
+        public DbSet<OrderItem> OrderItems { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<OrderItem>().HasKey(""OrderId"", ""ProductId"");
+        }
+    }
+
+    public class OrderItem
+    {
+        public int OrderId { get; set; }
+        public int ProductId { get; set; }
+        public int Quantity { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_OwnedTypeViaOwnsOne_ShouldNotTrigger()
+    {
+        var test = Usings + MockAttributes + @"
+        public DbSet<Order> Orders { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>().OwnsOne<ShippingAddress>(o => o.ShippingAddress);
+        }
+    }
+
+    public class Order
+    {
+        public int Id { get; set; }
+        public ShippingAddress ShippingAddress { get; set; }
+    }
+
+    // Owned type - no primary key needed
+    public class ShippingAddress
+    {
+        public string Street { get; set; }
+        public string City { get; set; }
+        public string ZipCode { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_EntityWithNonPublicId_ShouldTrigger()
+    {
+        // A private Id property does not count as a valid key
+        var test = Usings + MockAttributes + @"
+        public DbSet<SecretEntity> Secrets { get; set; }
+    }
+
+    public class SecretEntity
+    {
+        private int Id { get; set; }
+        internal string Name { get; set; }
+    }
+}";
+
+        var expected = VerifyCS.Diagnostic("LC011")
+            .WithSpan(51, 36, 51, 43)
+            .WithArguments("SecretEntity");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_EntityWithOnlyNavigationProperties_ShouldTrigger()
+    {
+        // Entity with no valid key type properties should trigger
+        var test = Usings + MockAttributes + @"
+        public DbSet<BadEntity> BadEntities { get; set; }
+    }
+
+    public class OtherThing
+    {
+        public int Id { get; set; }
+    }
+
+    public class BadEntity
+    {
+        public OtherThing Parent { get; set; }
+        public string Name { get; set; }
+    }
+}";
+
+        var expected = VerifyCS.Diagnostic("LC011")
+            .WithSpan(51, 33, 51, 44)
+            .WithArguments("BadEntity");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestInnocent_EntityWithKeyAttributeOnNonConventionalName_ShouldNotTrigger()
+    {
+        var test = Usings + MockAttributes + @"
+        public DbSet<CustomKeyEntity> CustomKeys { get; set; }
+    }
+
+    public class CustomKeyEntity
+    {
+        [Key]
+        public int MySpecialIdentifier { get; set; }
+        public string Data { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_EntityWithPrimaryKeyAttributeComposite_ShouldNotTrigger()
+    {
+        var test = Usings + MockAttributes + @"
+        public DbSet<CompositePkEntity> CompositePks { get; set; }
+    }
+
+    [PrimaryKey(nameof(TenantId), nameof(Code))]
+    public class CompositePkEntity
+    {
+        public int TenantId { get; set; }
+        public string Code { get; set; }
+        public string Description { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_KeylessEntityWithNoProperties_ShouldNotTrigger()
+    {
+        var test = Usings + MockAttributes + @"
+        public DbSet<ViewResult> ViewResults { get; set; }
+    }
+
+    [Keyless]
+    public class ViewResult
+    {
+        public string Value { get; set; }
+        public int Count { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersFixerTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.CodeAnalysis.Testing;
+using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
+    LinqContraband.Analyzers.LC021_AvoidIgnoreQueryFilters.AvoidIgnoreQueryFiltersAnalyzer,
+    LinqContraband.Analyzers.LC021_AvoidIgnoreQueryFilters.AvoidIgnoreQueryFiltersFixer,
+    Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+
+namespace LinqContraband.Tests.Analyzers.LC021_AvoidIgnoreQueryFilters;
+
+public class AvoidIgnoreQueryFiltersFixerTests
+{
+    private const string EFCoreMock = @"
+using System;
+using System.Linq;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static IQueryable<TEntity> IgnoreQueryFilters<TEntity>(this IQueryable<TEntity> source) => source;
+    }
+}
+";
+
+    [Fact]
+    public async Task IgnoreQueryFilters_InChain_ShouldBeRemoved()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new int[0].AsQueryable();
+            var result = {|LC021:query.IgnoreQueryFilters()|}.ToList();
+        }
+    }
+}";
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new int[0].AsQueryable();
+            var result = query.ToList();
+        }
+    }
+}";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task IgnoreQueryFilters_AfterWhere_ShouldBeRemoved()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new int[0].AsQueryable();
+            var result = {|LC021:query.Where(x => x > 0).IgnoreQueryFilters()|}.ToList();
+        }
+    }
+}";
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new int[0].AsQueryable();
+            var result = query.Where(x => x > 0).ToList();
+        }
+    }
+}";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task IgnoreQueryFilters_Standalone_ShouldBeRemoved()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new int[0].AsQueryable();
+            var result = {|LC021:query.IgnoreQueryFilters()|};
+        }
+    }
+}";
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new int[0].AsQueryable();
+            var result = query;
+        }
+    }
+}";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    private static async Task VerifyFix(string test, string fixedCode)
+    {
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CompilerDiagnostics = CompilerDiagnostics.None
+        };
+
+        await testObj.RunAsync();
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC029_RedundantIdentitySelect/RedundantIdentitySelectFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC029_RedundantIdentitySelect/RedundantIdentitySelectFixerTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.CodeAnalysis.Testing;
+using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
+    LinqContraband.Analyzers.LC029_RedundantIdentitySelect.RedundantIdentitySelectAnalyzer,
+    LinqContraband.Analyzers.LC029_RedundantIdentitySelect.RedundantIdentitySelectFixer,
+    Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+
+namespace LinqContraband.Tests.Analyzers.LC029_RedundantIdentitySelect;
+
+public class RedundantIdentitySelectFixerTests
+{
+    private const string Usings = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+";
+
+    [Fact]
+    public async Task SelectIdentity_InChain_ShouldBeRemoved()
+    {
+        var test = Usings + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new List<int>().AsQueryable();
+            var result = {|LC029:query.Select(x => x)|}.ToList();
+        }
+    }
+}";
+        var fixedCode = Usings + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new List<int>().AsQueryable();
+            var result = query.ToList();
+        }
+    }
+}";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task SelectIdentity_Standalone_ShouldBeRemoved()
+    {
+        var test = Usings + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new List<int>().AsQueryable();
+            var result = {|LC029:query.Select(x => x)|};
+        }
+    }
+}";
+        var fixedCode = Usings + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new List<int>().AsQueryable();
+            var result = query;
+        }
+    }
+}";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    private static async Task VerifyFix(string test, string fixedCode)
+    {
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CompilerDiagnostics = CompilerDiagnostics.None
+        };
+
+        await testObj.RunAsync();
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC030_DbContextInSingleton/DbContextInSingletonFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC030_DbContextInSingleton/DbContextInSingletonFixerTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.CodeAnalysis.Testing;
+using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
+    LinqContraband.Analyzers.LC030_DbContextInSingleton.DbContextInSingletonAnalyzer,
+    LinqContraband.Analyzers.LC030_DbContextInSingleton.DbContextInSingletonFixer,
+    Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+
+namespace LinqContraband.Tests.Analyzers.LC030_DbContextInSingleton;
+
+public class DbContextInSingletonFixerTests
+{
+    private const string EFCoreMock = @"
+namespace Microsoft.EntityFrameworkCore
+{
+    public class DbContext { }
+    public interface IDbContextFactory<TContext> where TContext : DbContext
+    {
+        TContext CreateDbContext();
+    }
+}
+";
+
+    [Fact]
+    public async Task Fixer_ShouldChangeFieldTypeToFactory()
+    {
+        var test = EFCoreMock + @"
+public class AppDbContext : Microsoft.EntityFrameworkCore.DbContext { }
+
+public class MyService
+{
+    private readonly AppDbContext {|LC030:_db|};
+}
+";
+
+        var fixedCode = EFCoreMock + @"
+public class AppDbContext : Microsoft.EntityFrameworkCore.DbContext { }
+
+public class MyService
+{
+    private readonly IDbContextFactory<AppDbContext> _dbFactory;
+}
+";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldChangeFieldAndConstructorParameter()
+    {
+        var test = EFCoreMock + @"
+public class AppDbContext : Microsoft.EntityFrameworkCore.DbContext { }
+
+public class MyService
+{
+    private readonly AppDbContext {|LC030:_db|};
+
+    public MyService(AppDbContext db)
+    {
+    }
+}
+";
+
+        var fixedCode = EFCoreMock + @"
+public class AppDbContext : Microsoft.EntityFrameworkCore.DbContext { }
+
+public class MyService
+{
+    private readonly IDbContextFactory<AppDbContext> _dbFactory;
+
+    public MyService(IDbContextFactory<AppDbContext> dbFactory)
+    {
+    }
+}
+";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldChangePropertyTypeToFactory()
+    {
+        var test = EFCoreMock + @"
+public class AppDbContext : Microsoft.EntityFrameworkCore.DbContext { }
+
+public class MyService
+{
+    public AppDbContext {|LC030:Db|} { get; set; }
+}
+";
+
+        var fixedCode = EFCoreMock + @"
+public class AppDbContext : Microsoft.EntityFrameworkCore.DbContext { }
+
+public class MyService
+{
+    public IDbContextFactory<AppDbContext> Db { get; set; }
+}
+";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldNotDoubleAppendFactory()
+    {
+        var test = EFCoreMock + @"
+public class AppDbContext : Microsoft.EntityFrameworkCore.DbContext { }
+
+public class MyService
+{
+    private readonly AppDbContext {|LC030:_dbFactory|};
+}
+";
+
+        var fixedCode = EFCoreMock + @"
+public class AppDbContext : Microsoft.EntityFrameworkCore.DbContext { }
+
+public class MyService
+{
+    private readonly IDbContextFactory<AppDbContext> _dbFactory;
+}
+";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldHandleFullyQualifiedDbContextField()
+    {
+        var test = EFCoreMock + @"
+public class MyService
+{
+    private readonly Microsoft.EntityFrameworkCore.DbContext {|LC030:_db|};
+}
+";
+
+        var fixedCode = EFCoreMock + @"
+public class MyService
+{
+    private readonly IDbContextFactory<Microsoft.EntityFrameworkCore.DbContext> _dbFactory;
+}
+";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    private static async Task VerifyFix(string test, string fixedCode)
+    {
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CompilerDiagnostics = CompilerDiagnostics.None
+        };
+
+        await testObj.RunAsync();
+    }
+}

--- a/tests/LinqContraband.Tests/CrossAnalyzerTests.cs
+++ b/tests/LinqContraband.Tests/CrossAnalyzerTests.cs
@@ -1,0 +1,428 @@
+using VerifyCS_LC008 =
+    Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+        LinqContraband.Analyzers.LC008_SyncBlocker.SyncBlockerAnalyzer>;
+using VerifyCS_LC009 =
+    Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+        LinqContraband.Analyzers.LC009_MissingAsNoTracking.MissingAsNoTrackingAnalyzer>;
+using VerifyCS_LC010 =
+    Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+        LinqContraband.Analyzers.LC010_SaveChangesInLoop.SaveChangesInLoopAnalyzer>;
+using VerifyCS_LC025 =
+    Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+        LinqContraband.Analyzers.LC025_AsNoTrackingWithUpdate.AsNoTrackingWithUpdateAnalyzer>;
+
+namespace LinqContraband.Tests;
+
+/// <summary>
+/// Tests verifying that multiple analyzers interact correctly on the same code.
+/// Each analyzer is run independently on shared test code to verify expected diagnostics
+/// and confirm no conflicts between rules.
+/// </summary>
+public class CrossAnalyzerTests
+{
+    // Shared mock infrastructure covering types needed by LC008, LC009, LC010, and LC025
+    private const string Usings = @"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TestNamespace;
+";
+
+    private const string MockEfCore = @"
+namespace Microsoft.EntityFrameworkCore
+{
+    public class DbContext : IDisposable
+    {
+        public void Dispose() { }
+        public DbSet<T> Set<T>() where T : class => new DbSet<T>();
+        public int SaveChanges() => 0;
+        public System.Threading.Tasks.Task<int> SaveChangesAsync() => System.Threading.Tasks.Task.FromResult(0);
+        public void Add<T>(T entity) { }
+        public void Update(object entity) { }
+        public void Remove(object entity) { }
+    }
+
+    public class DbSet<T> : IQueryable<T> where T : class
+    {
+        public Type ElementType => typeof(T);
+        public System.Linq.Expressions.Expression Expression => System.Linq.Expressions.Expression.Constant(this);
+        public IQueryProvider Provider => null;
+        public IEnumerator<T> GetEnumerator() => null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null;
+        public T Find(params object[] keyValues) => null;
+        public System.Threading.Tasks.Task<T> FindAsync(params object[] keyValues) => System.Threading.Tasks.Task.FromResult<T>(null);
+        public void Add(T entity) { }
+        public void Update(T entity) { }
+        public void Remove(T entity) { }
+    }
+
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static IQueryable<T> AsNoTracking<T>(this IQueryable<T> source) => source;
+        public static IQueryable<T> AsTracking<T>(this IQueryable<T> source) => source;
+        public static System.Threading.Tasks.Task<System.Collections.Generic.List<T>> ToListAsync<T>(this IQueryable<T> source) => System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<T>());
+        public static System.Threading.Tasks.Task<int> CountAsync<T>(this IQueryable<T> source) => System.Threading.Tasks.Task.FromResult(0);
+    }
+}
+
+namespace TestNamespace
+{
+    public class Item { public int Id { get; set; } public string Name { get; set; } }
+
+    public class MyDbContext : DbContext
+    {
+        public DbSet<Item> Items { get; set; }
+    }
+}";
+
+    #region Test 1: LC010 + LC008 (SaveChanges in loop inside async method)
+
+    /// <summary>
+    /// SaveChanges() inside a foreach loop within an async method should trigger LC010.
+    /// </summary>
+    [Fact]
+    public async Task LC010_SaveChangesInLoop_InAsyncMethod_Triggers()
+    {
+        // Usings: lines 1-7 (empty first line + 6 using lines + empty trailing line)
+        // Line  8: (empty - start of inline code block)
+        // Line  9: class Program
+        // Line 10: {
+        // Line 11:     async Task ProcessItems()
+        // Line 12:     {
+        // Line 13:         var db = new MyDbContext();
+        // Line 14:         var items = new List<Item> { new Item(), new Item() };
+        // Line 15:         (empty)
+        // Line 16:         foreach (var item in items)
+        // Line 17:         {
+        // Line 18:             db.Items.Add(item);
+        // Line 19:             db.SaveChanges();
+        var test = Usings + @"
+class Program
+{
+    async Task ProcessItems()
+    {
+        var db = new MyDbContext();
+        var items = new List<Item> { new Item(), new Item() };
+
+        foreach (var item in items)
+        {
+            db.Items.Add(item);
+            db.SaveChanges();
+        }
+        await Task.CompletedTask;
+    }
+}" + MockEfCore;
+
+        var expected = VerifyCS_LC010.Diagnostic("LC010")
+            .WithSpan(19, 13, 19, 29)
+            .WithArguments("SaveChanges");
+
+        await VerifyCS_LC010.VerifyAnalyzerAsync(test, expected);
+    }
+
+    /// <summary>
+    /// SaveChanges() inside a foreach loop within an async method should also trigger LC008
+    /// (sync call in async context).
+    /// </summary>
+    [Fact]
+    public async Task LC008_SyncSaveChangesInAsyncMethod_WithLoop_Triggers()
+    {
+        var test = Usings + @"
+class Program
+{
+    async Task ProcessItems()
+    {
+        var db = new MyDbContext();
+        var items = new List<Item> { new Item(), new Item() };
+
+        foreach (var item in items)
+        {
+            db.Items.Add(item);
+            db.SaveChanges();
+        }
+        await Task.CompletedTask;
+    }
+}" + MockEfCore;
+
+        var expected = VerifyCS_LC008.Diagnostic("LC008")
+            .WithSpan(19, 13, 19, 29)
+            .WithArguments("SaveChanges", "SaveChangesAsync");
+
+        await VerifyCS_LC008.VerifyAnalyzerAsync(test, expected);
+    }
+
+    #endregion
+
+    #region Test 2: LC009 + LC025 mutual exclusivity
+
+    /// <summary>
+    /// Code with AsNoTracking() that only reads should NOT trigger LC009
+    /// (missing AsNoTracking) because AsNoTracking is already present.
+    /// </summary>
+    [Fact]
+    public async Task LC009_WithAsNoTracking_ReadOnly_DoesNotTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    public List<Item> GetItems()
+    {
+        var db = new MyDbContext();
+        return db.Items.AsNoTracking().ToList();
+    }
+}" + MockEfCore;
+
+        await VerifyCS_LC009.VerifyAnalyzerAsync(test);
+    }
+
+    /// <summary>
+    /// Code without AsNoTracking() in a read-only method should trigger LC009.
+    /// </summary>
+    [Fact]
+    public async Task LC009_WithoutAsNoTracking_ReadOnly_Triggers()
+    {
+        // Usings: lines 1-7
+        // Line  8: (empty)
+        // Line  9: class Program
+        // Line 10: {
+        // Line 11:     public List<Item> GetItems()
+        // Line 12:     {
+        // Line 13:         var db = new MyDbContext();
+        // Line 14:         return db.Items.Where(i => i.Id > 0).ToList();
+        var test = Usings + @"
+class Program
+{
+    public List<Item> GetItems()
+    {
+        var db = new MyDbContext();
+        return db.Items.Where(i => i.Id > 0).ToList();
+    }
+}" + MockEfCore;
+
+        var expected = VerifyCS_LC009.Diagnostic("LC009")
+            .WithSpan(14, 16, 14, 54)
+            .WithArguments("GetItems");
+
+        await VerifyCS_LC009.VerifyAnalyzerAsync(test, expected);
+    }
+
+    /// <summary>
+    /// Code without AsNoTracking() but calling SaveChanges should NOT trigger LC009
+    /// because tracking is needed for updates.
+    /// </summary>
+    [Fact]
+    public async Task LC009_WithUpdate_DoesNotTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    public void UpdateItems()
+    {
+        var db = new MyDbContext();
+        var items = db.Items.ToList();
+        db.SaveChanges();
+    }
+}" + MockEfCore;
+
+        await VerifyCS_LC009.VerifyAnalyzerAsync(test);
+    }
+
+    /// <summary>
+    /// LC025 should trigger when AsNoTracking() query result is passed to Update().
+    /// Uses the markup syntax that LC025 tests use.
+    /// </summary>
+    [Fact]
+    public async Task LC025_AsNoTracking_ThenUpdate_Triggers()
+    {
+        var test = @"using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+" + MockEfCore + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod(DbSet<TestNamespace.Item> items)
+        {
+            var item = items.AsNoTracking().FirstOrDefault(x => x.Id == 1);
+            if (item != null)
+            {
+                items.Update({|LC025:item|});
+            }
+        }
+    }
+}";
+
+        await VerifyCS_LC025.VerifyAnalyzerAsync(test);
+    }
+
+    /// <summary>
+    /// LC025 should NOT trigger when query does not use AsNoTracking().
+    /// Tracked entities can be safely updated.
+    /// </summary>
+    [Fact]
+    public async Task LC025_WithoutAsNoTracking_ThenUpdate_DoesNotTrigger()
+    {
+        var test = @"using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+" + MockEfCore + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod(DbSet<TestNamespace.Item> items)
+        {
+            var item = items.FirstOrDefault(x => x.Id == 1);
+            if (item != null)
+            {
+                items.Update(item);
+            }
+        }
+    }
+}";
+
+        await VerifyCS_LC025.VerifyAnalyzerAsync(test);
+    }
+
+    #endregion
+
+    #region Test 3: No duplicate diagnostics
+
+    /// <summary>
+    /// A single SaveChanges() in a loop should produce exactly one LC010 diagnostic,
+    /// not duplicates.
+    /// </summary>
+    [Fact]
+    public async Task LC010_SingleCallInLoop_ProducesExactlyOneDiagnostic()
+    {
+        // Usings: lines 1-7
+        // Line  8: (empty)
+        // Line  9: class Program
+        // Line 10: {
+        // Line 11:     void Main()
+        // Line 12:     {
+        // Line 13:         var db = new MyDbContext();
+        // Line 14:         var items = new List<int> { 1, 2, 3 };
+        // Line 15:         (empty)
+        // Line 16:         foreach (var item in items)
+        // Line 17:         {
+        // Line 18:             db.SaveChanges();
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var items = new List<int> { 1, 2, 3 };
+
+        foreach (var item in items)
+        {
+            db.SaveChanges();
+        }
+    }
+}" + MockEfCore;
+
+        // Exactly one diagnostic expected - VerifyAnalyzerAsync will fail if more are produced
+        var expected = VerifyCS_LC010.Diagnostic("LC010")
+            .WithSpan(18, 13, 18, 29)
+            .WithArguments("SaveChanges");
+
+        await VerifyCS_LC010.VerifyAnalyzerAsync(test, expected);
+    }
+
+    /// <summary>
+    /// Multiple distinct SaveChanges() calls in separate loops should each produce
+    /// their own diagnostic - one per call site.
+    /// </summary>
+    [Fact]
+    public async Task LC010_MultipleCallsInSeparateLoops_ProducesDistinctDiagnostics()
+    {
+        // Usings: lines 1-7
+        // Line  8: (empty)
+        // Line  9: class Program
+        // Line 10: {
+        // Line 11:     void Main()
+        // Line 12:     {
+        // Line 13:         var db = new MyDbContext();
+        // Line 14:         var items = new List<int> { 1, 2, 3 };
+        // Line 15:         (empty)
+        // Line 16:         foreach (var item in items)
+        // Line 17:         {
+        // Line 18:             db.SaveChanges();
+        // Line 19:         }
+        // Line 20:         (empty)
+        // Line 21:         for (int i = 0; i < 5; i++)
+        // Line 22:         {
+        // Line 23:             db.SaveChanges();
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var items = new List<int> { 1, 2, 3 };
+
+        foreach (var item in items)
+        {
+            db.SaveChanges();
+        }
+
+        for (int i = 0; i < 5; i++)
+        {
+            db.SaveChanges();
+        }
+    }
+}" + MockEfCore;
+
+        var expected1 = VerifyCS_LC010.Diagnostic("LC010")
+            .WithSpan(18, 13, 18, 29)
+            .WithArguments("SaveChanges");
+
+        var expected2 = VerifyCS_LC010.Diagnostic("LC010")
+            .WithSpan(23, 13, 23, 29)
+            .WithArguments("SaveChanges");
+
+        await VerifyCS_LC010.VerifyAnalyzerAsync(test, expected1, expected2);
+    }
+
+    /// <summary>
+    /// A single sync call in an async method should produce exactly one LC008 diagnostic.
+    /// </summary>
+    [Fact]
+    public async Task LC008_SingleSyncCall_ProducesExactlyOneDiagnostic()
+    {
+        // Usings: lines 1-7
+        // Line  8: (empty)
+        // Line  9: class Program
+        // Line 10: {
+        // Line 11:     async Task Main()
+        // Line 12:     {
+        // Line 13:         var db = new MyDbContext();
+        // Line 14:         var users = db.Items.ToList();
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        var users = db.Items.ToList();
+        await Task.Delay(1);
+    }
+}" + MockEfCore;
+
+        var expected = VerifyCS_LC008.Diagnostic("LC008")
+            .WithSpan(14, 21, 14, 38)
+            .WithArguments("ToList", "ToListAsync");
+
+        await VerifyCS_LC008.VerifyAnalyzerAsync(test, expected);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Comprehensive improvement sweep across the entire LinqContraband project covering bug fixes, new fixers, performance, CI/CD, tests, and documentation.

### Bug Fixes (P0)
- Fix `UnwrapConversions` null suppression — fallback to original input instead of `null`
- Fix broken README LC030 section with full documentation content

### New Code Fixers
- **LC010**: Move `SaveChanges`/`SaveChangesAsync` after enclosing loop
- **LC021**: Remove `IgnoreQueryFilters()` from query chains
- **LC029**: Remove redundant `Select(x => x)` identity projections
- **LC030**: Change DbContext field to `IDbContextFactory<T>`

### Quick Wins (P1)
- Fix hardcoded `"now"` variable name in LC016 fixer with collision-avoiding logic
- Add missing `.editorconfig` entries for LC017–LC030
- Add `ExecuteUpdate`/`ExecuteDelete` sync-async mappings
- Add 8 missing materializer methods (`AsEnumerable`, `Load`, `ForEachAsync`, etc.)

### Refactoring
- **LC002**: Extract nested conditionals into focused helper methods
- **LC011**: Extract `TryAddResolvedType` helper, flatten `HasFluentKeyConfiguration`
- **LC017**: Extract `TryExtractDbSetInfo` to reduce `AnalyzeQueryChain` duplication

### Performance
- **LC011**: Scan source assembly only (not all referenced assemblies) for `IEntityTypeConfiguration` implementations

### CI/CD
- Scope top-level permissions to `read`, job-level `write` for badge commit
- Add `dotnet format --verify-no-changes` step
- Add NuGet package cache (`actions/cache@v4`)
- Add 75% coverage threshold check
- Add .NET 8 to `publish.yml` test matrix

### Tests (+41 new, 282 total)
- Edge case tests for LC001, LC008, LC011
- Async variant tests for LC002, LC003, LC005, LC009, LC015
- Cross-analyzer interaction tests
- Fixer tests for LC010, LC021, LC029, LC030

### Docs
- Create `CHANGELOG.md` (Keep a Changelog format)
- Add rule numbering note for reserved IDs (LC019, LC022, LC024, LC027, LC028)

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test --framework net9.0` — 282 tests pass
- [ ] CI pipeline runs successfully on push
- [ ] Verify new fixers work in IDE (VS/Rider)