### PR TITLE
Harden high-impact performance analyzers

### DIFF
--- a/src/LinqContraband/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs
@@ -83,7 +83,9 @@ public sealed class PrematureMaterializationAnalyzer : DiagnosticAnalyzer
         if (!IsLinqOperator(methodSymbol)) return;
 
         if (CheckFilterAfterMaterializedInvocation(context, invocation, unwrappedReceiver, methodSymbol)) return;
-        CheckFilterAfterMaterializedConstructor(context, invocation, unwrappedReceiver, methodSymbol);
+        if (CheckFilterAfterMaterializedConstructor(context, invocation, unwrappedReceiver, methodSymbol)) return;
+
+        CheckFilterAfterMaterializedLocal(context, invocation, unwrappedReceiver, methodSymbol);
     }
 
     private static bool CheckFilterAfterMaterializedInvocation(
@@ -101,19 +103,116 @@ public sealed class PrematureMaterializationAnalyzer : DiagnosticAnalyzer
         return true;
     }
 
-    private static void CheckFilterAfterMaterializedConstructor(
+    private static bool CheckFilterAfterMaterializedConstructor(
         OperationAnalysisContext context, IInvocationOperation invocation,
         IOperation unwrappedReceiver, IMethodSymbol methodSymbol)
     {
-        if (unwrappedReceiver is not IObjectCreationOperation objectCreation) return;
-        if (objectCreation.Constructor == null || !IsMaterializingConstructor(objectCreation.Constructor)) return;
-        if (objectCreation.Arguments.Length == 0) return;
+        if (unwrappedReceiver is not IObjectCreationOperation objectCreation) return false;
+        if (objectCreation.Constructor == null || !IsMaterializingConstructor(objectCreation.Constructor)) return false;
+        if (objectCreation.Arguments.Length == 0) return false;
 
         var sourceOp = objectCreation.Arguments[0].Value.UnwrapConversions();
-        if (sourceOp?.Type == null || !sourceOp.Type.IsIQueryable()) return;
+        if (sourceOp?.Type == null || !sourceOp.Type.IsIQueryable()) return false;
 
         context.ReportDiagnostic(
             Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), methodSymbol.Name));
+        return true;
+    }
+
+    private static bool CheckFilterAfterMaterializedLocal(
+        OperationAnalysisContext context,
+        IInvocationOperation invocation,
+        IOperation unwrappedReceiver,
+        IMethodSymbol methodSymbol)
+    {
+        if (unwrappedReceiver is not ILocalReferenceOperation localReference) return false;
+
+        var root = context.Operation.FindOwningExecutableRoot();
+        if (root == null) return false;
+
+        if (!TryResolveAssignedValue(root, localReference.Local, invocation.Syntax.SpanStart, new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default), out var assignedValue))
+            return false;
+
+        if (assignedValue is IInvocationOperation materializedInvocation &&
+            IsMaterializingMethod(materializedInvocation.TargetMethod))
+        {
+            var sourceType = materializedInvocation.GetInvocationReceiverType();
+            if (sourceType?.IsIQueryable() == true)
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), methodSymbol.Name));
+                return true;
+            }
+        }
+
+        if (assignedValue is IObjectCreationOperation objectCreation &&
+            objectCreation.Constructor != null &&
+            IsMaterializingConstructor(objectCreation.Constructor) &&
+            objectCreation.Arguments.Length > 0)
+        {
+            var sourceValue = objectCreation.Arguments[0].Value.UnwrapConversions();
+            if (sourceValue.Type?.IsIQueryable() == true)
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), methodSymbol.Name));
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveAssignedValue(
+        IOperation root,
+        ILocalSymbol local,
+        int position,
+        HashSet<ILocalSymbol> visited,
+        out IOperation? value)
+    {
+        value = null;
+        if (!visited.Add(local)) return false;
+
+        IOperation? latestValue = null;
+        var latestPosition = -1;
+        var assignmentCount = 0;
+
+        foreach (var descendant in root.Descendants())
+        {
+            if (descendant.Syntax.SpanStart >= position) continue;
+
+            switch (descendant)
+            {
+                case IVariableDeclaratorOperation declarator when
+                    SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) &&
+                    declarator.Initializer != null &&
+                    declarator.Syntax.SpanStart > latestPosition:
+                    latestValue = declarator.Initializer.Value;
+                    latestPosition = declarator.Syntax.SpanStart;
+                    assignmentCount++;
+                    break;
+
+                case ISimpleAssignmentOperation assignment when
+                    assignment.Target is ILocalReferenceOperation targetLocal &&
+                    SymbolEqualityComparer.Default.Equals(targetLocal.Local, local) &&
+                    assignment.Syntax.SpanStart > latestPosition:
+                    latestValue = assignment.Value;
+                    latestPosition = assignment.Syntax.SpanStart;
+                    assignmentCount++;
+                    break;
+            }
+        }
+
+        if (latestValue == null) return false;
+        if (assignmentCount != 1) return false;
+
+        var resolved = latestValue.UnwrapConversions();
+        if (resolved is ILocalReferenceOperation referencedLocal)
+        {
+            return TryResolveAssignedValue(root, referencedLocal.Local, position, visited, out value);
+        }
+
+        value = resolved;
+        return true;
     }
 
     private bool IsLinqOperator(IMethodSymbol method)

--- a/src/LinqContraband/Analyzers/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -52,77 +55,110 @@ public sealed class CartesianExplosionAnalyzer : DiagnosticAnalyzer
         var invocation = (IInvocationOperation)context.Operation;
         var method = invocation.TargetMethod;
 
-        var methodName = method.Name;
-        if ((methodName != "Include" && methodName != "ThenInclude") ||
-            method.ContainingNamespace?.ToString() != "Microsoft.EntityFrameworkCore")
+        if (method.Name != "Include" || method.ContainingNamespace?.ToString() != "Microsoft.EntityFrameworkCore")
             return;
 
-        // We only flag top-level Include chaining. ThenInclude deep chains are considered valid.
-        if (methodName == "ThenInclude") return;
+        var semanticModel = context.Operation.SemanticModel;
+        if (semanticModel == null) return;
 
-        ITypeSymbol? propertyType = null;
-        if (method.TypeArguments.Length >= 2)
-            propertyType = method.TypeArguments[method.TypeArguments.Length - 1];
+        if (invocation.Syntax is not InvocationExpressionSyntax invocationSyntax) return;
+        if (!TryGetIncludedNavigation(invocationSyntax, semanticModel, out var currentNavigation)) return;
 
-        // For string-based Include (no type args), we can't determine collection vs scalar; avoid flagging to prevent false positives.
-        if (propertyType == null) return;
+        var chain = AnalyzeIncludeChain(invocationSyntax, semanticModel);
+        if (HasSplitQueryDownstream(invocationSyntax, semanticModel)) return;
+        if (chain.HasSplitQuery) return;
 
-        if (!IsCollection(propertyType)) return;
+        if (chain.CollectionIncludes.Count > 1)
+        {
+            context.ReportDiagnostic(
+                Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), currentNavigation));
+        }
+    }
 
-        // Now check the chain backwards. Handle extension method syntax.
-        var current = invocation.GetInvocationReceiver();
+    private static IncludeChainAnalysis AnalyzeIncludeChain(
+        InvocationExpressionSyntax invocationSyntax,
+        SemanticModel semanticModel)
+    {
+        var result = new IncludeChainAnalysis();
+        InvocationExpressionSyntax? current = invocationSyntax;
 
-        var foundSplitQuery = false;
-        var previousCollectionIncludes = 0;
+        while (current?.Expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            var symbol = semanticModel.GetSymbolInfo(current).Symbol as IMethodSymbol;
+            if (symbol?.ContainingNamespace?.ToString() != "Microsoft.EntityFrameworkCore")
+            {
+                current = memberAccess.Expression as InvocationExpressionSyntax;
+                continue;
+            }
 
+            var methodName = memberAccess.Name.Identifier.Text;
+            if (methodName == "AsSplitQuery")
+            {
+                result.HasSplitQuery = true;
+            }
+            else if (methodName == "Include" &&
+                     TryGetIncludedNavigation(current, semanticModel, out var navigation))
+            {
+                result.CollectionIncludes.Add(navigation);
+            }
+
+            current = memberAccess.Expression as InvocationExpressionSyntax;
+        }
+
+        result.CollectionIncludes.Reverse();
+        return result;
+    }
+
+    private static bool HasSplitQueryDownstream(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+    {
+        var current = invocation.Parent;
         while (current != null)
         {
-            // Unwrap implicit conversions
-            while (current is IConversionOperation conversion) current = conversion.Operand;
-
-            if (current is IInvocationOperation prevInvocation)
+            if (current is InvocationExpressionSyntax parentInvocation &&
+                parentInvocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Name.Identifier.Text == "AsSplitQuery" &&
+                semanticModel.GetSymbolInfo(parentInvocation).Symbol is IMethodSymbol method &&
+                method.ContainingNamespace?.ToString() == "Microsoft.EntityFrameworkCore")
             {
-                var prevMethod = prevInvocation.TargetMethod;
-
-                if (prevMethod.Name == "AsSplitQuery" &&
-                    prevMethod.ContainingNamespace?.ToString() == "Microsoft.EntityFrameworkCore")
-                {
-                    foundSplitQuery = true;
-                    break;
-                }
-
-                if (prevMethod.Name == "Include" &&
-                    prevMethod.ContainingNamespace?.ToString() == "Microsoft.EntityFrameworkCore")
-                {
-                    // Check if this previous include was ALSO a collection
-                    ITypeSymbol? prevPropType = null;
-                    if (prevMethod.TypeArguments.Length >= 2)
-                        prevPropType = prevMethod.TypeArguments[prevMethod.TypeArguments.Length - 1];
-
-                    // Only count as collection include if we can verify it's a collection type
-                    // When prevPropType is null (string-based Include), we can't determine, so skip counting
-                    if (prevPropType != null && IsCollection(prevPropType)) previousCollectionIncludes++;
-                }
-
-                // Move up the chain
-                current = prevInvocation.GetInvocationReceiver(false);
+                return true;
             }
-            else
-            {
-                // End of chain (variable or other source)
-                break;
-            }
+
+            current = current.Parent;
         }
 
-        if (foundSplitQuery) return;
+        return false;
+    }
 
-        if (previousCollectionIncludes > 0)
+    private static bool TryGetIncludedNavigation(
+        InvocationExpressionSyntax invocationSyntax,
+        SemanticModel semanticModel,
+        out string navigationName)
+    {
+        navigationName = string.Empty;
+        if (invocationSyntax.ArgumentList.Arguments.Count == 0)
         {
-            // This is the 2nd (or later) collection include. Flag it.
-            var display = propertyType?.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat) ?? "string";
-            context.ReportDiagnostic(
-                Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), display));
+            return false;
         }
+
+        var lambdaExpression = invocationSyntax.ArgumentList.Arguments.Last().Expression;
+        var lambdaBody = lambdaExpression switch
+        {
+            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Body,
+            ParenthesizedLambdaExpressionSyntax parenthesizedLambda => parenthesizedLambda.Body,
+            _ => null
+        };
+
+        if (lambdaBody is MemberAccessExpressionSyntax memberAccess)
+        {
+            var propertySymbol = semanticModel.GetSymbolInfo(memberAccess).Symbol as IPropertySymbol;
+            var propertyType = propertySymbol?.Type ?? semanticModel.GetTypeInfo(memberAccess).Type;
+            if (propertyType == null || !IsCollection(propertyType)) return false;
+
+            navigationName = memberAccess.Name.Identifier.Text;
+            return true;
+        }
+
+        return false;
     }
 
     private static bool IsCollection(ITypeSymbol type)
@@ -154,5 +190,12 @@ public sealed class CartesianExplosionAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private sealed class IncludeChainAnalysis
+    {
+        public bool HasSplitQuery { get; set; }
+
+        public List<string> CollectionIncludes { get; } = new();
     }
 }

--- a/src/LinqContraband/Analyzers/LC006_CartesianExplosion/CartesianExplosionFixer.cs
+++ b/src/LinqContraband/Analyzers/LC006_CartesianExplosion/CartesianExplosionFixer.cs
@@ -52,14 +52,10 @@ public class CartesianExplosionFixer : CodeFixProvider
 
         editor.EnsureUsing("Microsoft.EntityFrameworkCore");
 
-        // Target: .Include(Roles)
-        // We want to insert .AsSplitQuery() before this call.
-        // Currently: Source.Include(Roles)
-        // New: Source.AsSplitQuery().Include(Roles)
+        var firstInclude = FindFirstIncludeInvocation(invocation);
+        if (firstInclude?.Expression is not MemberAccessExpressionSyntax memberAccess) return document;
 
-        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return document;
         var source = memberAccess.Expression;
-
         if (IsInvocationOf(source, "AsSplitQuery")) return document;
 
         // Create .AsSplitQuery() invocation
@@ -74,6 +70,23 @@ public class CartesianExplosionFixer : CodeFixProvider
         editor.ReplaceNode(source, asSplitQueryInvocation.WithTriviaFrom(source));
 
         return editor.GetChangedDocument();
+    }
+
+    private static InvocationExpressionSyntax? FindFirstIncludeInvocation(InvocationExpressionSyntax invocation)
+    {
+        InvocationExpressionSyntax? firstInclude = null;
+        ExpressionSyntax? current = invocation;
+
+        while (current is InvocationExpressionSyntax currentInvocation &&
+               currentInvocation.Expression is MemberAccessExpressionSyntax currentMemberAccess)
+        {
+            if (currentMemberAccess.Name.Identifier.Text == "Include")
+                firstInclude = currentInvocation;
+
+            current = currentMemberAccess.Expression;
+        }
+
+        return firstInclude;
     }
 
     private static bool IsInvocationOf(ExpressionSyntax expression, string methodName)

--- a/src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs
@@ -67,11 +67,12 @@ public sealed class NPlusOneLooperAnalyzer : DiagnosticAnalyzer
         // Case 1: DbSet.Find / FindAsync
         if (method.Name.StartsWith("Find", StringComparison.Ordinal) && method.ContainingType.IsDbSet()) return true;
 
-        // Case 2: Explicit loading entry points (might trigger lazy loading later or be used with .Load())
-        if (method.Name is "Reference" or "Collection")
+        // Case 2: Explicit loading operations on EF navigation entry objects
+        if (method.Name is "Load" or "LoadAsync")
         {
-            var ns = method.ContainingType?.ContainingNamespace?.ToString();
-            if (ns == "Microsoft.EntityFrameworkCore" || ns == "Microsoft.EntityFrameworkCore.ChangeTracking")
+            var explicitLoadReceiverType = invocation.GetInvocationReceiverType();
+            var ns = explicitLoadReceiverType?.ContainingNamespace?.ToString();
+            if (ns == "Microsoft.EntityFrameworkCore.ChangeTracking")
                 return true;
         }
 

--- a/src/LinqContraband/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopFixer.cs
+++ b/src/LinqContraband/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopFixer.cs
@@ -37,6 +37,7 @@ public class SaveChangesInLoopFixer : CodeFixProvider
                          ?? node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
 
         if (invocation == null) return;
+        if (!TryGetMovableSaveStatement(invocation, out _, out _)) return;
 
         context.RegisterCodeFix(
             CodeAction.Create(
@@ -52,21 +53,7 @@ public class SaveChangesInLoopFixer : CodeFixProvider
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
         // Find the expression statement containing SaveChanges
-        var expressionStatement = invocation.AncestorsAndSelf().OfType<ExpressionStatementSyntax>().FirstOrDefault();
-        if (expressionStatement == null)
-        {
-            // May be an await expression: await db.SaveChangesAsync()
-            var awaitExpr = invocation.AncestorsAndSelf().OfType<AwaitExpressionSyntax>().FirstOrDefault();
-            expressionStatement = awaitExpr?.Parent as ExpressionStatementSyntax;
-        }
-
-        if (expressionStatement == null) return document;
-
-        // Find the enclosing loop
-        var loop = expressionStatement.Ancestors().FirstOrDefault(n =>
-            n is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax);
-
-        if (loop == null) return document;
+        if (!TryGetMovableSaveStatement(invocation, out var expressionStatement, out var loop)) return document;
 
         // Create the new statement to insert after the loop (preserve the full statement including await if present)
         var newStatement = expressionStatement
@@ -80,5 +67,82 @@ public class SaveChangesInLoopFixer : CodeFixProvider
         editor.InsertAfter(loop, newStatement);
 
         return editor.GetChangedDocument();
+    }
+
+    private static bool TryGetMovableSaveStatement(
+        InvocationExpressionSyntax invocation,
+        out ExpressionStatementSyntax expressionStatement,
+        out StatementSyntax loop)
+    {
+        var statement = invocation.AncestorsAndSelf().OfType<ExpressionStatementSyntax>().FirstOrDefault();
+        if (statement == null)
+        {
+            var awaitExpr = invocation.AncestorsAndSelf().OfType<AwaitExpressionSyntax>().FirstOrDefault();
+            statement = awaitExpr?.Parent as ExpressionStatementSyntax;
+        }
+
+        if (statement == null)
+        {
+            expressionStatement = null!;
+            loop = null!;
+            return false;
+        }
+
+        var containingLoop = statement.Ancestors().FirstOrDefault(n =>
+            n is ForStatementSyntax or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax) as StatementSyntax;
+
+        if (containingLoop == null)
+        {
+            expressionStatement = null!;
+            loop = null!;
+            return false;
+        }
+
+        expressionStatement = statement;
+        loop = containingLoop;
+
+        if (ContainsUnsafeControlFlow(loop)) return false;
+        if (!IsDirectTerminalStatement(expressionStatement, loop)) return false;
+        if (CountSaveStatements(loop) != 1) return false;
+
+        return true;
+    }
+
+    private static bool ContainsUnsafeControlFlow(StatementSyntax loop)
+    {
+        return loop.DescendantNodes().Any(node =>
+            node is BreakStatementSyntax or ContinueStatementSyntax or ReturnStatementSyntax or ThrowStatementSyntax or
+                YieldStatementSyntax or TryStatementSyntax or GotoStatementSyntax);
+    }
+
+    private static bool IsDirectTerminalStatement(ExpressionStatementSyntax statement, StatementSyntax loop)
+    {
+        if (loop switch
+            {
+                ForStatementSyntax forLoop => forLoop.Statement,
+                ForEachStatementSyntax forEachLoop => forEachLoop.Statement,
+                WhileStatementSyntax whileLoop => whileLoop.Statement,
+                DoStatementSyntax doLoop => doLoop.Statement,
+                _ => null
+            } is not StatementSyntax body)
+        {
+            return false;
+        }
+
+        if (body is BlockSyntax block)
+        {
+            return block.Statements.LastOrDefault() == statement;
+        }
+
+        return body == statement;
+    }
+
+    private static int CountSaveStatements(StatementSyntax loop)
+    {
+        return loop.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Count(invocation =>
+                invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Name.Identifier.Text is "SaveChanges" or "SaveChangesAsync");
     }
 }

--- a/src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -76,21 +77,13 @@ public sealed class WholeEntityProjectionAnalyzer : DiagnosticAnalyzer
         var variableInfo = FindVariableAssignment(invocation);
         if (variableInfo == null) return;
 
-        // 5. Check if entity is returned from method (can't track usage)
-        if (IsEntityReturned(invocation, variableInfo.Value.Symbol)) return;
-
-        // 6. Check if entity is passed to external methods
-        if (IsPassedToMethod(invocation, variableInfo.Value.Symbol)) return;
-
-        // 7. Check if entity is used in lambda/delegate
-        if (IsUsedInLambda(invocation, variableInfo.Value.Symbol)) return;
-
-        // 8. Count actual property accesses
-        var accessedProperties = CountPropertyAccesses(invocation, variableInfo.Value.Symbol, analysis.EntityType);
+        // 5. Analyze usage in a single pass to avoid repeated full-body scans
+        var usage = AnalyzeVariableUsage(invocation, variableInfo.Value.Symbol, analysis.EntityType);
+        if (usage.HasEscapingUsage) return;
 
         // 9. Conservative: only flag if 1-2 properties accessed
-        if (accessedProperties.Count > MaxAccessedProperties) return;
-        if (accessedProperties.Count == 0) return; // No properties accessed, might be passed somewhere
+        if (usage.AccessedProperties.Count > MaxAccessedProperties) return;
+        if (usage.AccessedProperties.Count == 0) return; // No properties accessed, might be passed somewhere
 
         // Report diagnostic
         context.ReportDiagnostic(
@@ -98,7 +91,7 @@ public sealed class WholeEntityProjectionAnalyzer : DiagnosticAnalyzer
                 Rule,
                 invocation.Syntax.GetLocation(),
                 analysis.EntityType.Name,
-                accessedProperties.Count,
+                usage.AccessedProperties.Count,
                 properties.Count));
     }
 
@@ -208,111 +201,216 @@ public sealed class WholeEntityProjectionAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
-    private static bool IsEntityReturned(IInvocationOperation invocation, ILocalSymbol variable)
-    {
-        // Find containing method body
-        var root = FindMethodBody(invocation);
-        if (root == null) return true; // Conservative: can't analyze, assume returned
-
-        // Check for return statements using this variable
-        foreach (var descendant in root.Descendants())
-        {
-            if (descendant is IReturnOperation returnOp &&
-                returnOp.ReturnedValue != null)
-            {
-                if (ReferencesVariable(returnOp.ReturnedValue, variable))
-                    return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool IsPassedToMethod(IInvocationOperation invocation, ILocalSymbol variable)
-    {
-        var root = FindMethodBody(invocation);
-        if (root == null) return true;
-
-        foreach (var descendant in root.Descendants())
-        {
-            if (descendant is IInvocationOperation call && call != invocation)
-            {
-                foreach (var arg in call.Arguments)
-                {
-                    if (ReferencesVariable(arg.Value, variable))
-                        return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private static bool IsUsedInLambda(IInvocationOperation invocation, ILocalSymbol variable)
-    {
-        var root = FindMethodBody(invocation);
-        if (root == null) return true;
-
-        foreach (var descendant in root.Descendants())
-        {
-            if (descendant is IAnonymousFunctionOperation lambda)
-            {
-                foreach (var lambdaDescendant in lambda.Descendants())
-                {
-                    if (lambdaDescendant is ILocalReferenceOperation localRef &&
-                        SymbolEqualityComparer.Default.Equals(localRef.Local, variable))
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private static HashSet<string> CountPropertyAccesses(
+    private static VariableUsageAnalysis AnalyzeVariableUsage(
         IInvocationOperation invocation,
         ILocalSymbol variable,
         ITypeSymbol entityType)
     {
-        var accessedProperties = new HashSet<string>();
+        var result = new VariableUsageAnalysis();
         var root = FindMethodBody(invocation);
-        if (root == null) return accessedProperties;
+        if (root == null)
+        {
+            result.HasEscapingUsage = true;
+            return result;
+        }
 
-        // Find property accesses on the variable or its elements (in foreach)
+        var foreachLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+        var manualIterationLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+
         foreach (var descendant in root.Descendants())
         {
-            if (descendant is IPropertyReferenceOperation propRef)
+            switch (descendant)
             {
-                // Check if this is a property of the entity type
-                if (!SymbolEqualityComparer.Default.Equals(propRef.Property.ContainingType, entityType) &&
-                    !entityType.AllInterfaces.Contains(propRef.Property.ContainingType, SymbolEqualityComparer.Default) &&
-                    !InheritsFrom(entityType, propRef.Property.ContainingType))
-                {
-                    continue;
-                }
+                case IForEachLoopOperation forEach when
+                    forEach.Collection.UnwrapConversions() is ILocalReferenceOperation collectionRef &&
+                    SymbolEqualityComparer.Default.Equals(collectionRef.Local, variable):
+                    foreach (var local in forEach.Locals)
+                        foreachLocals.Add(local);
+                    break;
 
-                // Check if accessed on our variable or a foreach iteration variable
-                var instance = propRef.Instance?.UnwrapConversions();
+                case IVariableDeclaratorOperation declarator when
+                    declarator.Initializer != null &&
+                    IsIndexedAccessOf(declarator.Initializer.Value, variable):
+                    manualIterationLocals.Add(declarator.Symbol);
+                    break;
 
-                if (instance is ILocalReferenceOperation localRef)
-                {
-                    // Direct access on variable or foreach variable iterating over our collection
-                    if (SymbolEqualityComparer.Default.Equals(localRef.Local, variable))
-                    {
-                        accessedProperties.Add(propRef.Property.Name);
-                    }
-                    else if (IsForEachVariableOver(localRef.Local, variable, root) ||
-                             IsManualIterationVariableOver(localRef.Local, variable, root))
-                    {
-                        accessedProperties.Add(propRef.Property.Name);
-                    }
-                }
+                case ISimpleAssignmentOperation assignment when
+                    assignment.Target is ILocalReferenceOperation targetLocal &&
+                    IsIndexedAccessOf(assignment.Value, variable):
+                    manualIterationLocals.Add(targetLocal.Local);
+                    break;
             }
         }
 
-        return accessedProperties;
+        foreach (var descendant in root.Descendants())
+        {
+            switch (descendant)
+            {
+                case IReturnOperation returnOperation when
+                    returnOperation.ReturnedValue != null &&
+                    IsDirectVariableEscape(returnOperation.ReturnedValue, variable, foreachLocals, manualIterationLocals):
+                    result.HasEscapingUsage = true;
+                    break;
+
+                case IInvocationOperation call when call != invocation &&
+                    call.Arguments.Any(arg => IsDirectVariableEscape(arg.Value, variable, foreachLocals, manualIterationLocals)):
+                    result.HasEscapingUsage = true;
+                    break;
+
+                case IAnonymousFunctionOperation lambda when
+                    LambdaDirectlyReferences(lambda, variable, foreachLocals, manualIterationLocals):
+                    result.HasEscapingUsage = true;
+                    break;
+
+                case IPropertyReferenceOperation propertyReference when
+                    IsPropertyOfType(propertyReference.Property, entityType) &&
+                    IsTrackedEntityReference(propertyReference.Instance, variable, foreachLocals, manualIterationLocals):
+                    result.AccessedProperties.Add(propertyReference.Property.Name);
+                    break;
+            }
+
+            if (result.HasEscapingUsage) return result;
+        }
+
+        CollectSyntaxBasedPropertyAccesses(invocation, variable, entityType, foreachLocals, manualIterationLocals, result.AccessedProperties);
+        return result;
+    }
+
+    private static bool IsTrackedEntityReference(
+        IOperation? operation,
+        ILocalSymbol variable,
+        HashSet<ILocalSymbol> foreachLocals,
+        HashSet<ILocalSymbol> manualIterationLocals)
+    {
+        if (operation == null) return false;
+
+        var unwrapped = operation.UnwrapConversions();
+        if (unwrapped is ILocalReferenceOperation localReference)
+        {
+            return SymbolEqualityComparer.Default.Equals(localReference.Local, variable) ||
+                   foreachLocals.Contains(localReference.Local) ||
+                   manualIterationLocals.Contains(localReference.Local);
+        }
+
+        return false;
+    }
+
+    private static bool IsDirectVariableEscape(
+        IOperation operation,
+        ILocalSymbol variable,
+        HashSet<ILocalSymbol> foreachLocals,
+        HashSet<ILocalSymbol> manualIterationLocals)
+    {
+        var unwrapped = operation.UnwrapConversions();
+        if (unwrapped is not ILocalReferenceOperation localReference) return false;
+
+        return SymbolEqualityComparer.Default.Equals(localReference.Local, variable) ||
+               foreachLocals.Contains(localReference.Local) ||
+               manualIterationLocals.Contains(localReference.Local);
+    }
+
+    private static bool LambdaDirectlyReferences(
+        IAnonymousFunctionOperation lambda,
+        ILocalSymbol variable,
+        HashSet<ILocalSymbol> foreachLocals,
+        HashSet<ILocalSymbol> manualIterationLocals)
+    {
+        foreach (var descendant in lambda.Descendants())
+        {
+            if (descendant is not ILocalReferenceOperation localReference) continue;
+
+            if (SymbolEqualityComparer.Default.Equals(localReference.Local, variable) ||
+                foreachLocals.Contains(localReference.Local) ||
+                manualIterationLocals.Contains(localReference.Local))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsPropertyOfType(IPropertySymbol property, ITypeSymbol entityType)
+    {
+        if (SymbolEqualityComparer.Default.Equals(property.ContainingType, entityType)) return true;
+        if (entityType.AllInterfaces.Contains(property.ContainingType, SymbolEqualityComparer.Default)) return true;
+        return InheritsFrom(entityType, property.ContainingType);
+    }
+
+    private static void CollectSyntaxBasedPropertyAccesses(
+        IInvocationOperation invocation,
+        ILocalSymbol variable,
+        ITypeSymbol entityType,
+        HashSet<ILocalSymbol> foreachLocals,
+        HashSet<ILocalSymbol> manualIterationLocals,
+        HashSet<string> accessedProperties)
+    {
+        var semanticModel = invocation.SemanticModel;
+        if (semanticModel == null) return;
+
+        var scope = invocation.Syntax.FirstAncestorOrSelf<MethodDeclarationSyntax>() as SyntaxNode ??
+                    invocation.Syntax.FirstAncestorOrSelf<LocalFunctionStatementSyntax>() ??
+                    invocation.Syntax.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>() as SyntaxNode;
+        if (scope == null) return;
+
+        foreach (var conditionalAccess in scope.DescendantNodes().OfType<ConditionalAccessExpressionSyntax>())
+        {
+            if (!IsTrackedEntitySyntax(conditionalAccess.Expression, variable, foreachLocals, manualIterationLocals, semanticModel))
+                continue;
+
+            if (conditionalAccess.WhenNotNull is MemberBindingExpressionSyntax memberBinding &&
+                semanticModel.GetSymbolInfo(memberBinding).Symbol is IPropertySymbol property &&
+                IsPropertyOfType(property, entityType))
+            {
+                accessedProperties.Add(property.Name);
+            }
+        }
+
+        foreach (var memberAccess in scope.DescendantNodes().OfType<MemberAccessExpressionSyntax>())
+        {
+            if (memberAccess.Expression is not ElementAccessExpressionSyntax elementAccess) continue;
+            if (!IsCollectionElementAccess(elementAccess, variable, semanticModel)) continue;
+
+            if (semanticModel.GetSymbolInfo(memberAccess).Symbol is IPropertySymbol property &&
+                IsPropertyOfType(property, entityType))
+            {
+                accessedProperties.Add(property.Name);
+            }
+        }
+    }
+
+    private static bool IsTrackedEntitySyntax(
+        ExpressionSyntax expression,
+        ILocalSymbol variable,
+        HashSet<ILocalSymbol> foreachLocals,
+        HashSet<ILocalSymbol> manualIterationLocals,
+        SemanticModel semanticModel)
+    {
+        if (expression is ElementAccessExpressionSyntax elementAccess)
+            return IsCollectionElementAccess(elementAccess, variable, semanticModel);
+
+        var symbol = semanticModel.GetSymbolInfo(expression).Symbol as ILocalSymbol;
+        if (symbol == null) return false;
+
+        return SymbolEqualityComparer.Default.Equals(symbol, variable) ||
+               foreachLocals.Contains(symbol) ||
+               manualIterationLocals.Contains(symbol);
+    }
+
+    private static bool IsCollectionElementAccess(
+        ElementAccessExpressionSyntax elementAccess,
+        ILocalSymbol variable,
+        SemanticModel semanticModel)
+    {
+        var symbol = semanticModel.GetSymbolInfo(elementAccess.Expression).Symbol as ILocalSymbol;
+        return symbol != null && SymbolEqualityComparer.Default.Equals(symbol, variable);
+    }
+
+    private sealed class VariableUsageAnalysis
+    {
+        public HashSet<string> AccessedProperties { get; } = new();
+
+        public bool HasEscapingUsage { get; set; }
     }
 
     private static bool IsManualIterationVariableOver(ILocalSymbol iterationVar, ILocalSymbol collectionVar, IOperation root)
@@ -381,25 +479,6 @@ public sealed class WholeEntityProjectionAnalyzer : DiagnosticAnalyzer
                 return true;
             current = current.BaseType;
         }
-        return false;
-    }
-
-    private static bool ReferencesVariable(IOperation operation, ILocalSymbol variable)
-    {
-        var unwrapped = operation.UnwrapConversions();
-
-        if (unwrapped is ILocalReferenceOperation localRef &&
-            SymbolEqualityComparer.Default.Equals(localRef.Local, variable))
-        {
-            return true;
-        }
-
-        foreach (var child in operation.ChildOperations)
-        {
-            if (ReferencesVariable(child, variable))
-                return true;
-        }
-
         return false;
     }
 

--- a/src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs
+++ b/src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs
@@ -49,6 +49,7 @@ public class WholeEntityProjectionFixer : CodeFixProvider
         // Find the variable that stores the result
         var variableDeclarator = invocation.FirstAncestorOrSelf<VariableDeclaratorSyntax>();
         if (variableDeclarator == null) return;
+        if (variableDeclarator.Parent is not VariableDeclarationSyntax declaration || !declaration.Type.IsVar) return;
 
         var variableSymbol = semanticModel.GetDeclaredSymbol(variableDeclarator, context.CancellationToken) as ILocalSymbol;
         if (variableSymbol == null) return;

--- a/src/LinqContraband/Analyzers/LC022_ToListInSelectProjection/ToListInSelectProjectionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC022_ToListInSelectProjection/ToListInSelectProjectionAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -88,7 +89,12 @@ public sealed class ToListInSelectProjectionAnalyzer : DiagnosticAnalyzer
                 if (selectInvocation.TargetMethod.Name == "Select")
                 {
                     var receiverType = selectInvocation.GetInvocationReceiverType();
-                    if (receiverType.IsIQueryable())
+                    var lambdaParameter = lambda.Symbol.Parameters.FirstOrDefault();
+                    var materializerReceiver = invocation.GetInvocationReceiver();
+                    if (receiverType.IsIQueryable() &&
+                        lambdaParameter != null &&
+                        materializerReceiver != null &&
+                        materializerReceiver.ReferencesParameter(lambdaParameter))
                     {
                         context.ReportDiagnostic(
                             Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), method.Name));

--- a/src/LinqContraband/Analyzers/LC022_ToListInSelectProjection/ToListInSelectProjectionFixer.cs
+++ b/src/LinqContraband/Analyzers/LC022_ToListInSelectProjection/ToListInSelectProjectionFixer.cs
@@ -36,6 +36,7 @@ public class ToListInSelectProjectionFixer : CodeFixProvider
                          ?? node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
 
         if (invocation == null) return;
+        if (!CanSafelyRemoveMaterializer(invocation)) return;
 
         context.RegisterCodeFix(
             CodeAction.Create(
@@ -61,5 +62,16 @@ public class ToListInSelectProjectionFixer : CodeFixProvider
             .WithTrailingTrivia(invocation.GetTrailingTrivia()));
 
         return editor.GetChangedDocument();
+    }
+
+    private static bool CanSafelyRemoveMaterializer(InvocationExpressionSyntax invocation)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return false;
+        if (invocation.Ancestors().Any(ancestor =>
+                ancestor is InitializerExpressionSyntax or AnonymousObjectMemberDeclaratorSyntax))
+        {
+            return false;
+        }
+        return memberAccess.Name.Identifier.Text == "ToList";
     }
 }

--- a/src/LinqContraband/Extensions/AnalysisExtensions.cs
+++ b/src/LinqContraband/Extensions/AnalysisExtensions.cs
@@ -187,6 +187,25 @@ public static class AnalysisExtensions
     }
 
     /// <summary>
+    /// Finds the nearest executable root that owns the operation, such as a method body, local function, or lambda.
+    /// </summary>
+    /// <param name="operation">The operation to inspect.</param>
+    /// <returns>The owning executable root, or null if none was found.</returns>
+    public static IOperation? FindOwningExecutableRoot(this IOperation operation)
+    {
+        var current = operation;
+        while (current != null)
+        {
+            if (current is IMethodBodyOperation or ILocalFunctionOperation or IAnonymousFunctionOperation)
+                return current;
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Determines whether the method name is a query materializer that triggers database execution.
     /// </summary>
     /// <param name="methodName">The method name to check.</param>
@@ -224,6 +243,54 @@ public static class AnalysisExtensions
             // Bulk operation materializers
             "ExecuteDelete" or "ExecuteDeleteAsync" or
             "ExecuteUpdate" or "ExecuteUpdateAsync";
+    }
+
+    /// <summary>
+    /// Determines whether an operation tree references the specified parameter symbol.
+    /// </summary>
+    /// <param name="operation">The operation to inspect.</param>
+    /// <param name="parameter">The parameter symbol to find.</param>
+    /// <returns><c>true</c> if the parameter is referenced anywhere within the operation tree; otherwise, <c>false</c>.</returns>
+    public static bool ReferencesParameter(this IOperation operation, IParameterSymbol parameter)
+    {
+        var unwrapped = operation.UnwrapConversions();
+        if (unwrapped is IParameterReferenceOperation parameterReference &&
+            SymbolEqualityComparer.Default.Equals(parameterReference.Parameter, parameter))
+        {
+            return true;
+        }
+
+        foreach (var child in operation.ChildOperations)
+        {
+            if (child.ReferencesParameter(parameter))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether an operation tree references the specified local symbol.
+    /// </summary>
+    /// <param name="operation">The operation to inspect.</param>
+    /// <param name="local">The local symbol to find.</param>
+    /// <returns><c>true</c> if the local is referenced anywhere within the operation tree; otherwise, <c>false</c>.</returns>
+    public static bool ReferencesLocal(this IOperation operation, ILocalSymbol local)
+    {
+        var unwrapped = operation.UnwrapConversions();
+        if (unwrapped is ILocalReferenceOperation localReference &&
+            SymbolEqualityComparer.Default.Equals(localReference.Local, local))
+        {
+            return true;
+        }
+
+        foreach (var child in operation.ChildOperations)
+        {
+            if (child.ReferencesLocal(local))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationEdgeCasesTests.cs
@@ -55,4 +55,52 @@ class Program
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
+
+    [Fact]
+    public async Task MaterializedLocal_ThenWhere_ShouldTriggerLC002()
+    {
+        var test = @"
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    void Main()
+    {
+        var query = new List<int>().AsQueryable();
+        var materialized = query.ToList();
+        var result = materialized.Where(x => x > 0);
+    }
+}";
+
+        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
+            .WithSpan(11, 22, 11, 52)
+            .WithArguments("Where");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ConstructorMaterializedLocal_ThenCount_ShouldTriggerLC002()
+    {
+        var test = @"
+using System.Collections.Generic;
+using System.Linq;
+
+class Program
+{
+    void Main()
+    {
+        var query = new List<int>().AsQueryable();
+        var materialized = new HashSet<int>(query);
+        var result = materialized.Count();
+    }
+}";
+
+        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
+            .WithSpan(11, 22, 11, 42)
+            .WithArguments("Count");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC006_CartesianExplosion/CartesianExplosionFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC006_CartesianExplosion/CartesianExplosionFixerTests.cs
@@ -53,6 +53,7 @@ namespace Microsoft.EntityFrameworkCore
             => null;
 
         public static IQueryable<T> AsSplitQuery<T>(this IQueryable<T> source) => source;
+        public static IQueryable<T> AsSingleQuery<T>(this IQueryable<T> source) => source;
     }
 }
 
@@ -95,7 +96,7 @@ class Program
     void Main()
     {
         var db = new DbContext();
-        var query = db.Users.Include(u => u.Orders).AsSplitQuery().Include(u => u.Roles).ToList();
+        var query = db.Users.AsSplitQuery().Include(u => u.Orders).Include(u => u.Roles).ToList();
     }
 }
 " + MockNamespace;
@@ -109,7 +110,45 @@ class Program
         // The diagnostic is on the second Include. Line 14 in this file structure.
         testObj.ExpectedDiagnostics.Add(new DiagnosticResult("LC006", DiagnosticSeverity.Warning)
             .WithSpan(14, 21, 14, 74)
-            .WithArguments("List<Role>"));
+            .WithArguments("Roles"));
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixCrime_WithWhereClause_InjectsAsSplitQueryBeforeFirstInclude()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Where(u => u.Id > 0).Include(u => u.Orders).Include(u => u.Roles).ToList();
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Where(u => u.Id > 0).AsSplitQuery().Include(u => u.Orders).Include(u => u.Roles).ToList();
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        testObj.ExpectedDiagnostics.Add(new DiagnosticResult("LC006", DiagnosticSeverity.Warning)
+            .WithSpan(14, 21, 14, 95)
+            .WithArguments("Roles"));
 
         await testObj.RunAsync();
     }

--- a/tests/LinqContraband.Tests/Analyzers/LC006_CartesianExplosion/CartesianExplosionTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC006_CartesianExplosion/CartesianExplosionTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.EntityFrameworkCore
             => null;
 
         public static IQueryable<T> AsSplitQuery<T>(this IQueryable<T> source) => source;
+        public static IQueryable<T> AsSingleQuery<T>(this IQueryable<T> source) => source;
     }
 }
 
@@ -91,7 +92,7 @@ class Program
         // The usage `db.Users...` starts at column 21.
         var expected = VerifyCS.Diagnostic("LC006")
             .WithSpan(15, 21, 15, 74)
-            .WithArguments("List<Role>");
+            .WithArguments("Roles");
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
@@ -148,5 +149,43 @@ class Program
 " + MockNamespace;
 
         await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_WithTrailingAsSplitQuery_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Include(u => u.Orders).Include(u => u.Roles).AsSplitQuery().ToList();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_WithAsSingleQuery_StillTriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.AsSingleQuery().Include(u => u.Orders).Include(u => u.Roles).ToList();
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC006")
+            .WithSpan(14, 21, 14, 90)
+            .WithArguments("Roles");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperTests.cs
@@ -48,8 +48,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public ReferenceEntry Reference(string name) => null;
         public CollectionEntry Collection(string name) => null;
     }
-    public class ReferenceEntry { public void Load() { } }
-    public class CollectionEntry { public void Load() { } }
+    public class ReferenceEntry
+    {
+        public void Load() { }
+        public Task LoadAsync() => Task.CompletedTask;
+    }
+    public class CollectionEntry
+    {
+        public void Load() { }
+        public Task LoadAsync() => Task.CompletedTask;
+        public IQueryable<T> Query<T>() => null;
+    }
 }
 
 namespace TestNamespace
@@ -63,7 +72,7 @@ namespace TestNamespace
 }";
 
     [Fact]
-    public async Task TestCrime_ForeachLoop_WithExplicitLoading_TriggersDiagnostic()
+    public async Task TestInnocent_ForeachLoop_WithReferenceAccessorOnly_NoDiagnostic()
     {
         var test = Usings + @"
 using TestNamespace;
@@ -76,22 +85,17 @@ class Program
 
         foreach (var user in users)
         {
-            // Crime: Reference().Load() inside loop
-            db.Entry(user).Reference(""abc"").Load();
+            db.Entry(user).Reference(""abc"");
         }
     }
 }
 " + MockNamespace;
 
-        var expected = VerifyCS.Diagnostic("LC007")
-            .WithLocation(20, 13)
-            .WithArguments("Reference");
-
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
-    public async Task TestCrime_ForeachLoop_WithCollectionLoading_TriggersDiagnostic()
+    public async Task TestInnocent_ForeachLoop_WithCollectionAccessorOnly_NoDiagnostic()
     {
         var test = Usings + @"
 using TestNamespace;
@@ -104,7 +108,29 @@ class Program
 
         foreach (var user in users)
         {
-            // Crime: Collection().Load() inside loop
+            db.Entry(user).Collection(""abc"");
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_ForeachLoop_WithCollectionLoad_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+using TestNamespace;
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var users = new List<User>();
+
+        foreach (var user in users)
+        {
             db.Entry(user).Collection(""abc"").Load();
         }
     }
@@ -112,8 +138,35 @@ class Program
 " + MockNamespace;
 
         var expected = VerifyCS.Diagnostic("LC007")
-            .WithLocation(20, 13)
-            .WithArguments("Collection");
+            .WithLocation(19, 13)
+            .WithArguments("Load");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_ForeachLoop_WithCollectionLoadAsync_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+using TestNamespace;
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        var users = new List<User>();
+
+        foreach (var user in users)
+        {
+            await db.Entry(user).Collection(""abc"").LoadAsync();
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC007")
+            .WithLocation(19, 19)
+            .WithArguments("LoadAsync");
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
@@ -248,6 +301,33 @@ class Program
         var expected = VerifyCS.Diagnostic("LC007")
             .WithLocation(17, 25)
             .WithArguments("Count");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_ForeachLoop_WithCollectionQueryMaterialization_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+using TestNamespace;
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var users = new List<User>();
+
+        foreach (var user in users)
+        {
+            var roles = db.Entry(user).Collection(""abc"").Query<User>().ToList();
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC007")
+            .WithLocation(19, 25)
+            .WithArguments("ToList");
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }

--- a/tests/LinqContraband.Tests/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopFixerTests.cs
@@ -118,8 +118,8 @@ class Program
         int i = 0;
         while (i < 10)
         {
-            {|LC010:db.SaveChanges()|};
             i++;
+            {|LC010:db.SaveChanges()|};
         }
     }
 }" + MockNamespace;
@@ -140,6 +140,28 @@ class Program
 }" + MockNamespace;
 
         await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task SaveChanges_WithControlFlowInsideLoop_HasNoFix()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        using var db = new MyDbContext();
+        foreach (var item in new List<int> { 1, 2, 3 })
+        {
+            if (item == 2)
+                break;
+
+            {|LC010:db.SaveChanges()|};
+        }
+    }
+}" + MockNamespace;
+
+        await VerifyFix(test, test);
     }
 
     private static async Task VerifyFix(string test, string fixedCode)

--- a/tests/LinqContraband.Tests/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionEdgeCasesTests.cs
@@ -85,7 +85,7 @@ namespace TestNamespace
     /// The analyzer doesn't track through conditional access.
     /// </summary>
     [Fact]
-    public async Task TestInnocent_NullConditionalPropertyAccess_NoDiagnostic()
+    public async Task TestCrime_NullConditionalPropertyAccess_TriggersDiagnostic()
     {
         var test = Usings + @"
 class Program
@@ -102,9 +102,11 @@ class Program
 }
 " + MockNamespace;
 
-        // Null-conditional changes the operation tree - property access is wrapped
-        // The analyzer doesn't currently track through IConditionalAccessOperation
-        await VerifyCS.VerifyAnalyzerAsync(test);
+        var expected = VerifyCS.Diagnostic("LC017")
+            .WithSpan(14, 24, 14, 49)
+            .WithArguments("LargeEntity", 1, 13);
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
     /// <summary>
@@ -199,7 +201,7 @@ class Program
     /// Innocent: For loop with indexer - analyzer only tracks foreach iteration variables.
     /// </summary>
     [Fact]
-    public async Task TestInnocent_ForLoopWithIndexer_NoDiagnostic()
+    public async Task TestCrime_ForLoopWithIndexer_TriggersDiagnostic()
     {
         var test = Usings + @"
 class Program
@@ -216,16 +218,18 @@ class Program
 }
 " + MockNamespace;
 
-        // For loop with indexer: property access is on indexer element, not iteration variable
-        // The analyzer conservatively doesn't track indexer access patterns
-        await VerifyCS.VerifyAnalyzerAsync(test);
+        var expected = VerifyCS.Diagnostic("LC017")
+            .WithSpan(14, 24, 14, 49)
+            .WithArguments("LargeEntity", 1, 13);
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
     /// <summary>
     /// Innocent: Direct indexer access - analyzer only tracks foreach iteration variables.
     /// </summary>
     [Fact]
-    public async Task TestInnocent_DirectIndexerAccess_NoDiagnostic()
+    public async Task TestCrime_DirectIndexerAccess_TriggersDiagnostic()
     {
         var test = Usings + @"
 class Program
@@ -242,8 +246,11 @@ class Program
 }
 " + MockNamespace;
 
-        // Direct indexer access: not tracked by the analyzer (conservative)
-        await VerifyCS.VerifyAnalyzerAsync(test);
+        var expected = VerifyCS.Diagnostic("LC017")
+            .WithSpan(14, 24, 14, 49)
+            .WithArguments("LargeEntity", 1, 13);
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
     #endregion

--- a/tests/LinqContraband.Tests/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionFixerTests.cs
@@ -257,4 +257,25 @@ class Program
         await VerifyCS.VerifyCodeFixAsync(test, expected, fixedCode);
     }
 
+    [Fact]
+    public async Task ExplicitlyTypedCollection_HasNoFix()
+    {
+        var test = CommonUsings + MockEfCore + LargeEntity + @"
+class Program
+{
+    public void Process()
+    {
+        var db = new AppDbContext();
+        List<LargeEntity> entities = db.LargeEntities.ToList();
+        foreach (var e in entities)
+        {
+            Console.WriteLine(e.Name);
+        }
+    }
+}";
+
+        var expected = VerifyCS.Diagnostic("LC017").WithLocation(46, 38).WithArguments("LargeEntity", "1", "12");
+        await VerifyCS.VerifyCodeFixAsync(test, expected, test);
+    }
+
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC022_ToListInSelectProjection/ToListInSelectProjectionTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC022_ToListInSelectProjection/ToListInSelectProjectionTests.cs
@@ -123,7 +123,22 @@ class TestClass
     }
 
     [Fact]
-    public async Task Fixer_ShouldRemoveToArray()
+    public async Task Select_WithUnrelatedMaterializerInsideLambda_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+class TestClass
+{
+    void TestMethod(DbSet<User> users)
+    {
+        var result = users.Select(u => new List<int>().ToList());
+    }
+}" + MockNamespaces;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldNotRemoveToArray_WhenTypesWouldChange()
     {
         var test = Usings + @"
 class TestClass
@@ -134,16 +149,7 @@ class TestClass
     }
 }" + MockNamespaces;
 
-        var fixedCode = Usings + @"
-class TestClass
-{
-    void TestMethod(DbSet<User> users)
-    {
-        var result = users.Select(u => u.Orders);
-    }
-}" + MockNamespaces;
-
-        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+        await VerifyFix.VerifyCodeFixAsync(test, test);
     }
 
     [Fact]
@@ -168,5 +174,25 @@ class TestClass
 }" + MockNamespaces;
 
         await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldNotRemoveToList_InsideObjectInitializer()
+    {
+        var test = Usings + @"
+class UserDto
+{
+    public List<Order> Items { get; set; }
+}
+
+class TestClass
+{
+    void TestMethod(DbSet<User> users)
+    {
+        var result = users.Select(u => new UserDto { Items = {|LC022:u.Orders.ToList()|} });
+    }
+}" + MockNamespaces;
+
+        await VerifyFix.VerifyCodeFixAsync(test, test);
     }
 }

--- a/tests/LinqContraband.Tests/CoverageBoostTests.cs
+++ b/tests/LinqContraband.Tests/CoverageBoostTests.cs
@@ -86,7 +86,7 @@ class Program {
         // Corrected line: 59
         var expected = VerifyCS_LC006.Diagnostic("LC006")
             .WithSpan(59, 21, 59, 77)
-            .WithArguments("string[]"); // Int32[] or string[]? The second one is string[]. "Tags".
+            .WithArguments("Tags");
 
         await VerifyCS_LC006.VerifyAnalyzerAsync(test, expected);
     }


### PR DESCRIPTION
## Summary
- improve LC002, LC006, LC007, LC010, LC017, and LC022 precision and fixer safety
- add regression coverage for new analyzer behavior, safe/no-fix cases, and include-chain handling
- address follow-up review findings before commit, including conservative local-variable resolution and cleanup

## Validation
- dotnet test LinqContraband.sln -f net9.0 --no-restore
- dotnet test LinqContraband.sln -f net10.0 --no-restore

## Notes
- Claude CLI review was run before commit and its findings were folded into this branch
- net8.0 remains unvalidated locally because the .NET 8 runtime is not installed on this machine