### PR TITLE
LC007 excellence overhaul and 4.4.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.0] - 2026-03-14
+
+### Added
+- `LC007` now has a conservative fixer for unconditional strongly-typed explicit-loading loops, rewriting `Reference(...).Load/LoadAsync` and `Collection(...).Load/LoadAsync` to eager loading with `Include(...)`
+
+### Changed
+- `LC007` now models loop-time database execution explicitly, classifying direct `Find`, explicit loading, navigation-query materialization, EF query materialization, and EF set-based executors
+- `LC007` now reports only when both the EF-backed origin and the per-iteration execution are provable, including `DbContext.Set<T>()`, navigation `Query()`, single-assignment local hops, and set-based executors such as `ExecuteDelete` and `ExecuteUpdate`
+- Updated the LC007 README and rule documentation to describe the execution-focused scope, intentional ignore cases, and the narrow fixer contract
+
+### Fixed
+- `LC007` no longer treats plain `IQueryable` shapes, `AsQueryable()`-backed LINQ-to-Objects queries, fields/properties/parameters with ambiguous provenance, or multi-assignment locals as definite N+1 database execution
+- `LC007` no longer flags loop-source materialization that happens once before iteration, such as the `ToList()` in `foreach (var item in query.ToList())`
+- Expanded LC007 regression coverage with should-report, should-not-report, fix, and no-fix scenarios across sync, async, navigation, and set-based execution paths
+
 ## [4.3.1] - 2026-03-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -224,7 +224,9 @@ var query = db.Users.Include(u => u.Orders).AsSplitQuery().Include(u => u.Roles)
 ### LC007: N+1 Looper
 
 Database queries have high fixed overhead (latency, connection pooling). Executing 100 queries takes ~100x longer than
-executing 1 query that fetches 100 items.
+executing 1 query that fetches 100 items. LC007 covers more than `Find(...)`: it catches explicit loading, query
+materialization, aggregates, and EF set-based executors when they run once per iteration on a provably EF-backed
+source.
 
 **👶 Explain it like I'm a ten year old:** Imagine you need 10 eggs. You drive to the store, buy *one* egg, drive home.
 Drive back, buy *one* egg, drive home. You do this 10 times. You spend all day driving instead of just buying the carton
@@ -239,19 +241,22 @@ foreach (var id in ids)
     var user = db.Users.Find(id);
 }
 
-// Also flags async streams that materialize inside the loop
-await foreach (var user in db.Users.AsAsyncEnumerable())
+// Explicit loading is the same trap in a different disguise.
+foreach (var user in db.Users.ToList())
 {
-    var count = db.Users.Count();
+    db.Entry(user).Collection(u => u.Orders).Load();
 }
 ```
 
 **✅ The Fix:**
-Fetch data in bulk outside the loop.
+Fetch data in bulk outside the loop. When the problem is explicit loading, eager load it.
 
 ```csharp
 // Executes 1 query for all IDs.
 var users = db.Users.Where(u => ids.Contains(u.Id)).ToList();
+
+// LC007 can auto-fix this shape to eager loading.
+var usersWithOrders = db.Users.Include(u => u.Orders).ToList();
 ```
 
 ---

--- a/docs/LC007_NPlusOneLooper.md
+++ b/docs/LC007_NPlusOneLooper.md
@@ -1,37 +1,80 @@
-# Spec: LC007 - N+1 Query in Loop
+# LC007: Database Execution Inside Loop
 
 ## Goal
-Detect database queries (like `Find`, `First`, `ToList`) executed inside a loop.
+Catch EF Core database execution that is provably performed once per loop iteration.
 
-## The Problem
-Executing a query inside a loop is a classic performance anti-pattern. If you have 100 items, you make 100 separate round-trips to the database. This is orders of magnitude slower than fetching all 100 items in a single query.
+## What LC007 Reports
 
-This rule also flags usage of **Explicit Loading** methods like `.Reference()` or `.Collection()` inside loops, as these are often used to trigger additional database queries for each item.
+### 1. Direct EF lookups inside loops
+`Find` and `FindAsync` on `DbSet<T>` are reported when they execute inside `for`, `foreach`, `await foreach`, `while`, or `do` loops.
 
-### Example Violation
 ```csharp
-// 1. Direct Query in Loop
 foreach (var id in ids)
 {
     var user = db.Users.Find(id);
 }
+```
 
-// 2. Explicit Loading in Loop
+### 2. Explicit loading inside loops
+`Reference(...).Load/LoadAsync` and `Collection(...).Load/LoadAsync` are reported because they issue a separate database operation per entity.
+
+```csharp
 foreach (var user in db.Users.ToList())
 {
     db.Entry(user).Collection(u => u.Orders).Load();
 }
 ```
 
-### The Fix
-Fetch all required data in bulk outside the loop, or use `.Include()` for eager loading.
+### 3. Query materialization, aggregates, and set-based executors on proven EF sources
+LC007 reports materializers and executors such as `ToList`, `Count`, `Any`, `ExecuteDelete`, and `ExecuteUpdate` when the query origin is provably EF-backed.
 
 ```csharp
-// Correct: Eagerly load in one query
-var users = db.Users.Include(u => u.Orders).ToList();
+foreach (var user in db.Users.ToList())
+{
+    var orderCount = db.Entry(user).Collection(u => u.Orders).Query().Count();
+}
+
+while (hasWork)
+{
+    db.Users.Where(u => u.Inactive).ExecuteDelete();
+}
 ```
 
-## Analyzer Logic
+The analyzer follows direct EF roots such as `DbSet<T>`, `DbContext.Set<T>()`, navigation `Query()` calls, and single-assignment local hops when the origin stays provable.
+
+## What LC007 Intentionally Ignores
+- Plain LINQ-to-Objects or `AsQueryable()` sources
+- Ambiguous `IQueryable` provenance through parameters, fields, properties, or multi-assignment locals
+- Query construction inside loops when no execution method is invoked
+- `Reference(...)` and `Collection(...)` access without `Load`, `LoadAsync`, or `Query()` execution
+- Invocations nested inside lambdas or local functions declared in the loop body
+- Loop-source materialization that happens once before iteration, such as the `db.Users.ToList()` part of a `foreach`
+
+## Fixer Behavior
+LC007 offers a fixer only for conservative, analyzer-proven explicit-loading cases.
+
+- It rewrites unconditional strongly-typed `Reference(...).Load/LoadAsync` and `Collection(...).Load/LoadAsync` inside `foreach` or `await foreach` loops to eager loading with `Include(...)`.
+- It updates the loop source query and removes the per-item load statement.
+- It does not offer a fix for string-based navigation access, `Find`, aggregates, `Query().Count()`, filtered navigation queries, conditional loads, or control-flow-heavy loops.
+
+## Example Fix
+
+```csharp
+// Before
+foreach (var user in db.Users.ToList())
+{
+    db.Entry(user).Collection(u => u.Orders).Load();
+    Console.WriteLine(user.Id);
+}
+
+// After
+foreach (var user in db.Users.Include(u => u.Orders).ToList())
+{
+    Console.WriteLine(user.Id);
+}
+```
+
+## Metadata
 
 ### ID: `LC007`
 ### Category: `Performance`

--- a/src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperAnalysis.cs
@@ -1,0 +1,402 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC007_NPlusOneLooper;
+
+internal static class NPlusOneLooperDiagnosticProperties
+{
+    public const string PatternKind = "LC007.PatternKind";
+    public const string MethodName = "LC007.MethodName";
+    public const string LoopKind = "LC007.LoopKind";
+    public const string FixerEligible = "LC007.FixerEligible";
+
+    public const string Find = "Find";
+    public const string ExplicitLoad = "ExplicitLoad";
+    public const string NavigationQueryMaterializer = "NavigationQueryMaterializer";
+    public const string EfQueryMaterializer = "EfQueryMaterializer";
+    public const string EfSetBasedExecutor = "EfSetBasedExecutor";
+}
+
+internal sealed class NPlusOneLoopMatch
+{
+    public NPlusOneLoopMatch(string patternKind, string methodName, string loopKind, bool fixerEligible)
+    {
+        PatternKind = patternKind;
+        MethodName = methodName;
+        LoopKind = loopKind;
+        FixerEligible = fixerEligible;
+    }
+
+    public string PatternKind { get; }
+    public string MethodName { get; }
+    public string LoopKind { get; }
+    public bool FixerEligible { get; }
+}
+
+internal static class NPlusOneLooperAnalysis
+{
+    private static readonly HashSet<string> ImmediateQueryExecutionMethods = new(StringComparer.Ordinal)
+    {
+        "ToList",
+        "ToListAsync",
+        "ToArray",
+        "ToArrayAsync",
+        "ToDictionary",
+        "ToDictionaryAsync",
+        "ToHashSet",
+        "ToHashSetAsync",
+        "First",
+        "FirstOrDefault",
+        "FirstAsync",
+        "FirstOrDefaultAsync",
+        "Single",
+        "SingleOrDefault",
+        "SingleAsync",
+        "SingleOrDefaultAsync",
+        "Last",
+        "LastOrDefault",
+        "LastAsync",
+        "LastOrDefaultAsync",
+        "Count",
+        "LongCount",
+        "CountAsync",
+        "LongCountAsync",
+        "Any",
+        "All",
+        "AnyAsync",
+        "AllAsync",
+        "Sum",
+        "Average",
+        "Min",
+        "Max",
+        "SumAsync",
+        "AverageAsync",
+        "MinAsync",
+        "MaxAsync",
+        "ForEachAsync"
+    };
+
+    private static readonly HashSet<string> SetBasedExecutorMethods = new(StringComparer.Ordinal)
+    {
+        "ExecuteDelete",
+        "ExecuteDeleteAsync",
+        "ExecuteUpdate",
+        "ExecuteUpdateAsync"
+    };
+
+    public static NPlusOneLoopMatch? AnalyzeInvocation(IInvocationOperation invocation)
+    {
+        var loop = invocation.FindEnclosingLoop();
+        if (loop == null || !invocation.SharesOwningExecutableRoot(loop))
+            return null;
+
+        if (!IsPerIterationInvocation(invocation, loop))
+            return null;
+
+        if (!TryMatchDatabaseExecution(invocation, out var match))
+            return null;
+
+        return new NPlusOneLoopMatch(match.PatternKind, match.MethodName, loop.GetLoopKind(), match.FixerEligible);
+    }
+
+    private static bool IsPerIterationInvocation(IInvocationOperation invocation, ILoopOperation loop)
+    {
+        var spanStart = invocation.Syntax.SpanStart;
+
+        return loop.Syntax switch
+        {
+            ForEachStatementSyntax forEach => forEach.Statement.Span.Contains(spanStart),
+            ForStatementSyntax forStatement =>
+                forStatement.Statement.Span.Contains(spanStart) ||
+                (forStatement.Condition?.Span.Contains(spanStart) == true) ||
+                forStatement.Incrementors.Any(incrementor => incrementor.Span.Contains(spanStart)),
+            WhileStatementSyntax whileStatement =>
+                whileStatement.Statement.Span.Contains(spanStart) ||
+                whileStatement.Condition.Span.Contains(spanStart),
+            DoStatementSyntax doStatement =>
+                doStatement.Statement.Span.Contains(spanStart) ||
+                doStatement.Condition.Span.Contains(spanStart),
+            _ => false
+        };
+    }
+
+    public static bool IsProvenEfQuerySource(IOperation? operation)
+    {
+        return AnalyzeQueryProvenance(operation, operation).Kind == QueryProvenanceKind.Proven;
+    }
+
+    public static bool HasStronglyTypedNavigationAccessor(IInvocationOperation loadInvocation)
+    {
+        if (loadInvocation.GetInvocationReceiver() is not IInvocationOperation accessInvocation)
+            return false;
+
+        if (!IsNavigationAccessInvocation(accessInvocation))
+            return false;
+
+        return accessInvocation.Arguments.Length == 1 &&
+               accessInvocation.Arguments[0].Value is IAnonymousFunctionOperation;
+    }
+
+    private static bool TryMatchDatabaseExecution(IInvocationOperation invocation, out NPlusOneLoopMatch match)
+    {
+        var method = invocation.TargetMethod;
+
+        if (method.Name is "Find" or "FindAsync" && method.ContainingType.IsDbSet())
+        {
+            match = new NPlusOneLoopMatch(
+                NPlusOneLooperDiagnosticProperties.Find,
+                method.Name,
+                string.Empty,
+                false);
+            return true;
+        }
+
+        if (method.Name is "Load" or "LoadAsync" && IsExplicitLoadReceiver(invocation.GetInvocationReceiverType()))
+        {
+            match = new NPlusOneLoopMatch(
+                NPlusOneLooperDiagnosticProperties.ExplicitLoad,
+                method.Name,
+                string.Empty,
+                HasStronglyTypedNavigationAccessor(invocation));
+            return true;
+        }
+
+        if (!ImmediateQueryExecutionMethods.Contains(method.Name) && !SetBasedExecutorMethods.Contains(method.Name))
+        {
+            match = null!;
+            return false;
+        }
+
+        var provenance = AnalyzeQueryProvenance(invocation.GetInvocationReceiver(), invocation);
+        if (provenance.Kind != QueryProvenanceKind.Proven)
+        {
+            match = null!;
+            return false;
+        }
+
+        match = new NPlusOneLoopMatch(
+            SetBasedExecutorMethods.Contains(method.Name)
+                ? NPlusOneLooperDiagnosticProperties.EfSetBasedExecutor
+                : provenance.IsNavigationQuery
+                    ? NPlusOneLooperDiagnosticProperties.NavigationQueryMaterializer
+                    : NPlusOneLooperDiagnosticProperties.EfQueryMaterializer,
+            method.Name,
+            string.Empty,
+            false);
+        return true;
+    }
+
+    private static QueryProvenance AnalyzeQueryProvenance(IOperation? operation, IOperation? analysisScope)
+    {
+        if (operation == null || analysisScope == null)
+            return QueryProvenance.None;
+
+        var visitedLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+        var current = operation.UnwrapConversions();
+
+        while (current != null)
+        {
+            current = current.UnwrapConversions();
+
+            switch (current)
+            {
+                case IInvocationOperation invocation:
+                    if (IsDbContextSetInvocation(invocation))
+                        return QueryProvenance.Proven;
+
+                    if (IsNavigationQueryInvocation(invocation))
+                        return QueryProvenance.NavigationQuery;
+
+                    if (IsAsQueryableInvocation(invocation))
+                        return QueryProvenance.Ambiguous;
+
+                    current = invocation.GetInvocationReceiver();
+                    continue;
+
+                case IPropertyReferenceOperation propertyReference:
+                    if (propertyReference.Type.IsDbSet())
+                        return QueryProvenance.Proven;
+
+                    if (propertyReference.Type.IsIQueryable())
+                        return QueryProvenance.Ambiguous;
+
+                    return QueryProvenance.None;
+
+                case IFieldReferenceOperation fieldReference:
+                    if (fieldReference.Type.IsDbSet())
+                        return QueryProvenance.Proven;
+
+                    if (fieldReference.Type.IsIQueryable())
+                        return QueryProvenance.Ambiguous;
+
+                    return QueryProvenance.None;
+
+                case ILocalReferenceOperation localReference:
+                    if (!visitedLocals.Add(localReference.Local))
+                        return QueryProvenance.Ambiguous;
+
+                    if (!TryGetSingleAssignedLocalValue(localReference.Local, analysisScope, out var valueOperation))
+                    {
+                        if (localReference.Type.IsDbSet() || localReference.Type.IsIQueryable())
+                            return QueryProvenance.Ambiguous;
+
+                        return QueryProvenance.None;
+                    }
+
+                    current = valueOperation;
+                    continue;
+
+                case IParameterReferenceOperation parameterReference:
+                    if (parameterReference.Type.IsDbSet() ||
+                        parameterReference.Type.IsIQueryable() ||
+                        parameterReference.Type.IsDbContext())
+                    {
+                        return QueryProvenance.Ambiguous;
+                    }
+
+                    return QueryProvenance.None;
+
+                default:
+                    if (current.Type?.IsDbSet() == true)
+                        return QueryProvenance.Proven;
+
+                    if (current.Type?.IsIQueryable() == true)
+                        return QueryProvenance.Ambiguous;
+
+                    return QueryProvenance.None;
+            }
+        }
+
+        return QueryProvenance.None;
+    }
+
+    private static bool TryGetSingleAssignedLocalValue(ILocalSymbol local, IOperation analysisScope, out IOperation valueOperation)
+    {
+        valueOperation = null!;
+
+        if (local.DeclaringSyntaxReferences.Length != 1)
+            return false;
+
+        var declarator = local.DeclaringSyntaxReferences[0].GetSyntax() as VariableDeclaratorSyntax;
+        if (declarator?.Initializer?.Value == null)
+            return false;
+
+        var semanticModel = analysisScope.SemanticModel;
+        var executableRoot = analysisScope.FindOwningExecutableRoot();
+        if (semanticModel == null || executableRoot == null)
+            return false;
+
+        if (HasLocalWrites(local, executableRoot.Syntax, semanticModel))
+            return false;
+
+        var operation = semanticModel.GetOperation(declarator.Initializer.Value);
+        if (operation == null)
+            return false;
+
+        valueOperation = operation;
+        return true;
+    }
+
+    private static bool HasLocalWrites(ILocalSymbol local, SyntaxNode executableRootSyntax, SemanticModel semanticModel)
+    {
+        foreach (var assignment in executableRootSyntax.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left).Symbol, local))
+                return true;
+        }
+
+        foreach (var prefix in executableRootSyntax.DescendantNodes().OfType<PrefixUnaryExpressionSyntax>())
+        {
+            if (!prefix.IsKind(SyntaxKind.PreIncrementExpression) &&
+                !prefix.IsKind(SyntaxKind.PreDecrementExpression))
+            {
+                continue;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(prefix.Operand).Symbol, local))
+                return true;
+        }
+
+        foreach (var postfix in executableRootSyntax.DescendantNodes().OfType<PostfixUnaryExpressionSyntax>())
+        {
+            if (!postfix.IsKind(SyntaxKind.PostIncrementExpression) &&
+                !postfix.IsKind(SyntaxKind.PostDecrementExpression))
+            {
+                continue;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(postfix.Operand).Symbol, local))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsDbContextSetInvocation(IInvocationOperation invocation)
+    {
+        return invocation.TargetMethod.Name == "Set" &&
+               invocation.TargetMethod.ContainingType.IsDbContext();
+    }
+
+    private static bool IsNavigationQueryInvocation(IInvocationOperation invocation)
+    {
+        return invocation.TargetMethod.Name == "Query" &&
+               IsChangeTrackingNamespace(invocation.TargetMethod.ContainingType.ContainingNamespace);
+    }
+
+    private static bool IsNavigationAccessInvocation(IInvocationOperation invocation)
+    {
+        return invocation.TargetMethod.Name is "Reference" or "Collection" &&
+               IsChangeTrackingNamespace(invocation.TargetMethod.ContainingType.ContainingNamespace);
+    }
+
+    private static bool IsAsQueryableInvocation(IInvocationOperation invocation)
+    {
+        return invocation.TargetMethod.Name == "AsQueryable" &&
+               invocation.TargetMethod.IsFrameworkMethod();
+    }
+
+    private static bool IsExplicitLoadReceiver(ITypeSymbol? type)
+    {
+        if (type == null)
+            return false;
+
+        return type.Name is "ReferenceEntry" or "CollectionEntry" &&
+               IsChangeTrackingNamespace(type.ContainingNamespace);
+    }
+
+    private static bool IsChangeTrackingNamespace(INamespaceSymbol? ns)
+    {
+        return ns?.ToString() == "Microsoft.EntityFrameworkCore.ChangeTracking";
+    }
+
+    private enum QueryProvenanceKind
+    {
+        None,
+        Proven,
+        Ambiguous
+    }
+
+    private readonly struct QueryProvenance
+    {
+        public static QueryProvenance None => new(QueryProvenanceKind.None, false);
+        public static QueryProvenance Proven => new(QueryProvenanceKind.Proven, false);
+        public static QueryProvenance NavigationQuery => new(QueryProvenanceKind.Proven, true);
+        public static QueryProvenance Ambiguous => new(QueryProvenanceKind.Ambiguous, false);
+
+        public QueryProvenance(QueryProvenanceKind kind, bool isNavigationQuery)
+        {
+            Kind = kind;
+            IsNavigationQuery = isNavigationQuery;
+        }
+
+        public QueryProvenanceKind Kind { get; }
+        public bool IsNavigationQuery { get; }
+    }
+}

--- a/src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Immutable;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
@@ -8,27 +7,28 @@ using Microsoft.CodeAnalysis.Operations;
 namespace LinqContraband.Analyzers.LC007_NPlusOneLooper;
 
 /// <summary>
-/// Analyzes database query execution inside loops, causing N+1 query problems. Diagnostic ID: LC007
+/// Analyzes database execution inside loops, causing N+1 query problems. Diagnostic ID: LC007
 /// </summary>
 /// <remarks>
-/// <para><b>Why this matters:</b> Executing database queries inside a loop creates a separate database roundtrip for every
-/// loop iteration, resulting in N+1 total queries (1 query to get the collection + N queries inside the loop). Each database
-/// roundtrip adds network latency (typically 1-50ms), which multiplies catastrophically with large collections. For example,
-/// a loop over 1000 items with 10ms latency per query adds 10 seconds of pure waiting time. Always fetch required data in
-/// bulk outside the loop using techniques like Include(), joins, or dictionary lookups.</para>
+/// <para><b>Why this matters:</b> Executing database work once per loop iteration multiplies latency, load, and query cost.
+/// This includes direct lookups, explicit loading, query materialization, and EF set-based executors when they run inside
+/// a loop body. The rule intentionally prefers proof over guesswork: it reports only when EF-backed execution and
+/// per-iteration execution are both provable.</para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class NPlusOneLooperAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC007";
     private const string Category = "Performance";
-    private static readonly LocalizableString Title = "N+1 Problem: Database query inside loop";
+    private const string HelpLinkUri = "https://github.com/georgewall/LinqContraband/blob/main/docs/LC007_NPlusOneLooper.md";
+
+    private static readonly LocalizableString Title = "N+1 Problem: Database execution inside loop";
 
     private static readonly LocalizableString MessageFormat =
-        "Executing '{0}' inside a loop causes N+1 queries. Fetch data in bulk outside the loop.";
+        "Executing '{0}' inside a loop causes N+1 database operations. Fetch data in bulk or eager load before the loop.";
 
     private static readonly LocalizableString Description =
-        "Performing database queries inside a loop results in a database roundtrip for every iteration. This destroys performance via network latency.";
+        "Running EF Core database execution inside a loop causes one database operation per iteration. This includes Find/FindAsync, explicit loading, query materializers, aggregates, and EF set-based executors when the query source is provably EF-backed.";
 
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
@@ -37,7 +37,8 @@ public sealed class NPlusOneLooperAnalyzer : DiagnosticAnalyzer
         Category,
         DiagnosticSeverity.Warning,
         true,
-        Description);
+        Description,
+        helpLinkUri: HelpLinkUri);
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -48,44 +49,24 @@ public sealed class NPlusOneLooperAnalyzer : DiagnosticAnalyzer
         context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
     }
 
-    private void AnalyzeInvocation(OperationAnalysisContext context)
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
     {
         var invocation = (IInvocationOperation)context.Operation;
-        var method = invocation.TargetMethod;
+        var match = NPlusOneLooperAnalysis.AnalyzeInvocation(invocation);
+        if (match == null)
+            return;
 
-        // 1. Check if this is a DB execution method
-        if (!IsDbExecutionMethod(method, invocation)) return;
+        var properties = ImmutableDictionary.CreateBuilder<string, string?>();
+        properties[NPlusOneLooperDiagnosticProperties.PatternKind] = match.PatternKind;
+        properties[NPlusOneLooperDiagnosticProperties.MethodName] = match.MethodName;
+        properties[NPlusOneLooperDiagnosticProperties.LoopKind] = match.LoopKind;
+        properties[NPlusOneLooperDiagnosticProperties.FixerEligible] = match.FixerEligible ? "true" : "false";
 
-        // 2. Check if inside a loop
-        if (IsInsideLoop(invocation))
-            context.ReportDiagnostic(
-                Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), method.Name));
-    }
-
-    private static bool IsDbExecutionMethod(IMethodSymbol method, IInvocationOperation invocation)
-    {
-        // Case 1: DbSet.Find / FindAsync
-        if (method.Name.StartsWith("Find", StringComparison.Ordinal) && method.ContainingType.IsDbSet()) return true;
-
-        // Case 2: Explicit loading operations on EF navigation entry objects
-        if (method.Name is "Load" or "LoadAsync")
-        {
-            var explicitLoadReceiverType = invocation.GetInvocationReceiverType();
-            var ns = explicitLoadReceiverType?.ContainingNamespace?.ToString();
-            if (ns == "Microsoft.EntityFrameworkCore.ChangeTracking")
-                return true;
-        }
-
-        // Case 3: IQueryable materializers (ToList, Count, First, etc.)
-        if (!method.Name.IsMaterializerMethod()) return false;
-
-        var receiverType = invocation.GetInvocationReceiverType();
-
-        return receiverType?.IsIQueryable() == true;
-    }
-
-    private bool IsInsideLoop(IOperation operation)
-    {
-        return operation.IsInsideLoop() || operation.IsInsideAsyncForEach();
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                Rule,
+                invocation.Syntax.GetLocation(),
+                properties.ToImmutable(),
+                match.MethodName));
     }
 }

--- a/src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperFixer.cs
+++ b/src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperFixer.cs
@@ -1,0 +1,322 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Text;
+
+namespace LinqContraband.Analyzers.LC007_NPlusOneLooper;
+
+/// <summary>
+/// Provides conservative code fixes for LC007. Converts unconditional explicit loading inside foreach loops into eager loading.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(NPlusOneLooperFixer))]
+[Shared]
+public sealed class NPlusOneLooperFixer : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(NPlusOneLooperAnalyzer.DiagnosticId);
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root == null)
+            return;
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+        var invocation = root.FindNode(diagnosticSpan) as InvocationExpressionSyntax
+                         ?? root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf()
+                             .OfType<InvocationExpressionSyntax>()
+                             .FirstOrDefault();
+        if (invocation == null)
+            return;
+
+        var fixContext = await TryCreateFixContextAsync(context.Document, invocation, context.CancellationToken).ConfigureAwait(false);
+        if (fixContext == null)
+            return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Use Include() and remove per-item load",
+                c => ApplyFixAsync(context.Document, diagnostic.Location.SourceSpan, c),
+                "UseIncludeForExplicitLoad"),
+            diagnostic);
+    }
+
+    private static async Task<Document> ApplyFixAsync(Document document, TextSpan invocationSpan, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root == null)
+            return document;
+
+        var invocation = root.FindNode(invocationSpan) as InvocationExpressionSyntax
+                         ?? root.FindToken(invocationSpan.Start).Parent?.AncestorsAndSelf()
+                             .OfType<InvocationExpressionSyntax>()
+                             .FirstOrDefault();
+        if (invocation == null)
+            return document;
+
+        var fixContext = await TryCreateFixContextAsync(document, invocation, cancellationToken).ConfigureAwait(false);
+        if (fixContext == null)
+            return document;
+
+        var currentLoadStatement = root.FindNode(fixContext.LoadStatement.Span) as ExpressionStatementSyntax
+                                   ?? root.FindToken(fixContext.LoadStatement.Span.Start).Parent?.AncestorsAndSelf()
+                                       .OfType<ExpressionStatementSyntax>()
+                                       .FirstOrDefault();
+        if (currentLoadStatement == null)
+            return document;
+
+        var removedLoadRoot = root.RemoveNode(currentLoadStatement, SyntaxRemoveOptions.KeepNoTrivia);
+        if (removedLoadRoot == null)
+            return document;
+
+        var currentQueryTarget = removedLoadRoot.FindNode(fixContext.QueryTargetNode.Span) as ExpressionSyntax;
+        if (currentQueryTarget == null)
+            return document;
+
+        var updatedRoot = removedLoadRoot.ReplaceNode(currentQueryTarget, fixContext.RewrittenQuerySource);
+        var updatedDocument = document.WithSyntaxRoot(updatedRoot);
+        var editor = await DocumentEditor.CreateAsync(updatedDocument, cancellationToken).ConfigureAwait(false);
+        editor.EnsureUsing("Microsoft.EntityFrameworkCore");
+
+        return editor.GetChangedDocument();
+    }
+
+    private static async Task<ExplicitLoadFixContext?> TryCreateFixContextAsync(
+        Document document,
+        InvocationExpressionSyntax loadInvocation,
+        CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel == null)
+            return null;
+
+        if (!TryGetDirectLoadStatement(loadInvocation, out var loadStatement))
+            return null;
+
+        var loop = loadStatement.Ancestors().OfType<ForEachStatementSyntax>().FirstOrDefault();
+        if (loop == null)
+            return null;
+
+        if (!IsDirectLoopStatement(loop, loadStatement))
+            return null;
+
+        if (ContainsUnsafeControlFlow(loop.Statement))
+            return null;
+
+        if (CountExplicitLoads(loop.Statement) != 1)
+            return null;
+
+        var loopVariableName = loop.Identifier.ValueText;
+        if (string.IsNullOrWhiteSpace(loopVariableName))
+            return null;
+
+        if (!TryGetNavigationLambda(loadInvocation, loopVariableName, out var navigationLambda))
+            return null;
+
+        if (!TryResolveQuerySourceTarget(loop.Expression, semanticModel, cancellationToken, out var queryTargetNode, out var querySourceExpression))
+            return null;
+
+        if (!TryAddInclude(querySourceExpression, navigationLambda, semanticModel, cancellationToken, out var rewrittenQuerySource))
+            return null;
+
+        return new ExplicitLoadFixContext(loadStatement, queryTargetNode, rewrittenQuerySource);
+    }
+
+    private static bool TryGetDirectLoadStatement(
+        InvocationExpressionSyntax invocation,
+        out ExpressionStatementSyntax loadStatement)
+    {
+        loadStatement = invocation.AncestorsAndSelf().OfType<ExpressionStatementSyntax>().FirstOrDefault()!;
+        return loadStatement != null;
+    }
+
+    private static bool IsDirectLoopStatement(ForEachStatementSyntax loop, StatementSyntax statement)
+    {
+        if (loop.Statement is BlockSyntax block)
+            return block.Statements.Contains(statement);
+
+        return loop.Statement == statement;
+    }
+
+    private static bool ContainsUnsafeControlFlow(StatementSyntax loopBody)
+    {
+        return loopBody.DescendantNodes().Any(node =>
+            node is IfStatementSyntax or SwitchStatementSyntax or ReturnStatementSyntax or BreakStatementSyntax or
+                ContinueStatementSyntax or ThrowStatementSyntax or TryStatementSyntax or GotoStatementSyntax or
+                YieldStatementSyntax);
+    }
+
+    private static int CountExplicitLoads(StatementSyntax loopBody)
+    {
+        return loopBody.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Count(IsExplicitLoadInvocation);
+    }
+
+    private static bool IsExplicitLoadInvocation(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+               memberAccess.Name.Identifier.Text is "Load" or "LoadAsync";
+    }
+
+    private static bool TryGetNavigationLambda(
+        InvocationExpressionSyntax loadInvocation,
+        string loopVariableName,
+        out LambdaExpressionSyntax navigationLambda)
+    {
+        navigationLambda = null!;
+
+        if (loadInvocation.Expression is not MemberAccessExpressionSyntax loadMember ||
+            loadMember.Expression is not InvocationExpressionSyntax accessInvocation ||
+            accessInvocation.Expression is not MemberAccessExpressionSyntax accessMember ||
+            accessMember.Expression is not InvocationExpressionSyntax entryInvocation ||
+            entryInvocation.Expression is not MemberAccessExpressionSyntax entryMember)
+        {
+            return false;
+        }
+
+        if (accessMember.Name.Identifier.Text is not ("Collection" or "Reference"))
+            return false;
+
+        if (entryMember.Name.Identifier.Text != "Entry" || entryInvocation.ArgumentList.Arguments.Count != 1)
+            return false;
+
+        if (entryInvocation.ArgumentList.Arguments[0].Expression is not IdentifierNameSyntax identifier)
+            return false;
+
+        if (identifier.Identifier.ValueText != loopVariableName)
+            return false;
+
+        if (accessInvocation.ArgumentList.Arguments.Count != 1 ||
+            accessInvocation.ArgumentList.Arguments[0].Expression is not LambdaExpressionSyntax lambda)
+        {
+            return false;
+        }
+
+        navigationLambda = lambda;
+        return true;
+    }
+
+    private static bool TryResolveQuerySourceTarget(
+        ExpressionSyntax loopExpression,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax queryTargetNode,
+        out ExpressionSyntax querySourceExpression)
+    {
+        queryTargetNode = null!;
+        querySourceExpression = null!;
+
+        if (loopExpression is IdentifierNameSyntax identifier &&
+            semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol is ILocalSymbol local &&
+            TryGetLocalInitializerExpression(local, semanticModel, cancellationToken, out var initializerExpression))
+        {
+            queryTargetNode = initializerExpression;
+            querySourceExpression = initializerExpression;
+            return true;
+        }
+
+        queryTargetNode = loopExpression;
+        querySourceExpression = loopExpression;
+        return true;
+    }
+
+    private static bool TryGetLocalInitializerExpression(
+        ILocalSymbol local,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax initializerExpression)
+    {
+        initializerExpression = null!;
+
+        if (local.DeclaringSyntaxReferences.Length != 1)
+            return false;
+
+        var declarator = local.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken) as VariableDeclaratorSyntax;
+        if (declarator?.Initializer?.Value == null)
+            return false;
+
+        var executableRoot = declarator.Ancestors().OfType<MemberDeclarationSyntax>().FirstOrDefault();
+        if (executableRoot == null)
+            return false;
+
+        foreach (var assignment in executableRoot.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (assignment.Span.Contains(declarator.Span))
+                continue;
+
+            if (SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol, local))
+                return false;
+        }
+
+        initializerExpression = declarator.Initializer.Value;
+        return true;
+    }
+
+    private static bool TryAddInclude(
+        ExpressionSyntax querySourceExpression,
+        LambdaExpressionSyntax navigationLambda,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax rewrittenExpression)
+    {
+        rewrittenExpression = null!;
+
+        if (querySourceExpression is not InvocationExpressionSyntax terminalInvocation ||
+            terminalInvocation.Expression is not MemberAccessExpressionSyntax terminalMember)
+        {
+            return false;
+        }
+
+        var source = terminalMember.Expression;
+        if (semanticModel.GetTypeInfo(source, cancellationToken).Type?.IsIQueryable() != true)
+            return false;
+
+        var includeMember = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            source.WithoutTrivia(),
+            SyntaxFactory.IdentifierName("Include"));
+
+        var includeInvocation = SyntaxFactory.InvocationExpression(
+                includeMember,
+                SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Argument(navigationLambda.WithoutTrivia()))))
+            .WithTriviaFrom(source);
+
+        rewrittenExpression = terminalInvocation
+            .WithExpression(terminalMember.WithExpression(includeInvocation))
+            .WithTriviaFrom(querySourceExpression);
+
+        return true;
+    }
+
+    private sealed class ExplicitLoadFixContext
+    {
+        public ExplicitLoadFixContext(
+            ExpressionStatementSyntax loadStatement,
+            ExpressionSyntax queryTargetNode,
+            ExpressionSyntax rewrittenQuerySource)
+        {
+            LoadStatement = loadStatement;
+            QueryTargetNode = queryTargetNode;
+            RewrittenQuerySource = rewrittenQuerySource;
+        }
+
+        public ExpressionStatementSyntax LoadStatement { get; }
+        public ExpressionSyntax QueryTargetNode { get; }
+        public ExpressionSyntax RewrittenQuerySource { get; }
+    }
+}

--- a/src/LinqContraband/Extensions/AnalysisExtensions.cs
+++ b/src/LinqContraband/Extensions/AnalysisExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace LinqContraband.Extensions;
@@ -187,6 +188,43 @@ public static class AnalysisExtensions
     }
 
     /// <summary>
+    /// Finds the nearest enclosing loop operation.
+    /// </summary>
+    /// <param name="operation">The operation to inspect.</param>
+    /// <returns>The nearest enclosing loop, or null if none was found.</returns>
+    public static ILoopOperation? FindEnclosingLoop(this IOperation operation)
+    {
+        var current = operation.Parent;
+        while (current != null)
+        {
+            if (current is ILoopOperation loop)
+                return loop;
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns a stable, human-readable loop kind for diagnostics.
+    /// </summary>
+    /// <param name="loop">The loop to classify.</param>
+    /// <returns>A loop kind such as <c>for</c>, <c>foreach</c>, or <c>await foreach</c>.</returns>
+    public static string GetLoopKind(this ILoopOperation loop)
+    {
+        return loop.Syntax switch
+        {
+            ForEachStatementSyntax forEach when forEach.AwaitKeyword != default => "await foreach",
+            ForEachStatementSyntax => "foreach",
+            ForStatementSyntax => "for",
+            WhileStatementSyntax => "while",
+            DoStatementSyntax => "do",
+            _ => "loop"
+        };
+    }
+
+    /// <summary>
     /// Finds the nearest executable root that owns the operation, such as a method body, local function, or lambda.
     /// </summary>
     /// <param name="operation">The operation to inspect.</param>
@@ -203,6 +241,20 @@ public static class AnalysisExtensions
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Determines whether two operations belong to the same executable root.
+    /// </summary>
+    /// <param name="operation">The first operation.</param>
+    /// <param name="other">The second operation.</param>
+    /// <returns><c>true</c> if both operations are owned by the same method, local function, or lambda body.</returns>
+    public static bool SharesOwningExecutableRoot(this IOperation operation, IOperation other)
+    {
+        var left = operation.FindOwningExecutableRoot();
+        var right = other.FindOwningExecutableRoot();
+
+        return left != null && right != null && ReferenceEquals(left, right);
     }
 
     /// <summary>

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>4.3.1</Version>
+        <Version>4.4.0</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperFixerTests.cs
@@ -1,0 +1,236 @@
+using Microsoft.CodeAnalysis.Testing;
+using VerifyFix = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+    LinqContraband.Analyzers.LC007_NPlusOneLooper.NPlusOneLooperAnalyzer,
+    LinqContraband.Analyzers.LC007_NPlusOneLooper.NPlusOneLooperFixer>;
+
+namespace LinqContraband.Tests.Analyzers.LC007_NPlusOneLooper;
+
+public class NPlusOneLooperFixerTests
+{
+    private const string Usings = @"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Query;
+using TestNamespace;
+";
+
+    private const string MockNamespace = @"
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public interface IIncludableQueryable<out TEntity, out TProperty> : IQueryable<TEntity> { }
+}
+
+namespace Microsoft.EntityFrameworkCore
+{
+    using Microsoft.EntityFrameworkCore.Query;
+
+    public class DbContext : IDisposable
+    {
+        public void Dispose() { }
+        public DbSet<T> Set<T>() where T : class => new DbSet<T>();
+        public Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<T> Entry<T>(T entity) where T : class => null;
+    }
+
+    public class DbSet<T> : IQueryable<T> where T : class
+    {
+        public Type ElementType => typeof(T);
+        public Expression Expression => Expression.Constant(this);
+        public IQueryProvider Provider => null;
+        public IEnumerator<T> GetEnumerator() => null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null;
+    }
+
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IQueryable<T> source) => null;
+
+        public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TProperty>(
+            this IQueryable<TEntity> source,
+            Expression<Func<TEntity, TProperty>> navigationPropertyPath)
+            => null;
+    }
+}
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    public class EntityEntry<TEntity> where TEntity : class
+    {
+        public ReferenceEntry Reference(string name) => null;
+        public CollectionEntry Collection(string name) => null;
+
+        public ReferenceEntry<TEntity, TProperty> Reference<TProperty>(Expression<Func<TEntity, TProperty>> navigationPropertyPath) => null;
+        public CollectionEntry<TEntity, TProperty> Collection<TProperty>(Expression<Func<TEntity, IEnumerable<TProperty>>> navigationPropertyPath) => null;
+    }
+
+    public class ReferenceEntry
+    {
+        public void Load() { }
+        public Task LoadAsync() => Task.CompletedTask;
+    }
+
+    public class CollectionEntry
+    {
+        public void Load() { }
+        public Task LoadAsync() => Task.CompletedTask;
+    }
+
+    public class ReferenceEntry<TEntity, TProperty>
+    {
+        public void Load() { }
+        public Task LoadAsync() => Task.CompletedTask;
+    }
+
+    public class CollectionEntry<TEntity, TProperty>
+    {
+        public void Load() { }
+        public Task LoadAsync() => Task.CompletedTask;
+    }
+}
+
+namespace TestNamespace
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public List<Order> Orders { get; set; }
+        public Profile Profile { get; set; }
+    }
+
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public class Profile
+    {
+        public int Id { get; set; }
+    }
+
+    public class MyDbContext : Microsoft.EntityFrameworkCore.DbContext
+    {
+        public Microsoft.EntityFrameworkCore.DbSet<User> Users { get; set; }
+    }
+}";
+
+    [Fact]
+    public async Task CollectionLoad_InForeach_AddsIncludeAndRemovesLoad()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        foreach (var user in db.Users.ToList())
+        {
+            {|#0:db.Entry(user).Collection(u => u.Orders).Load()|};
+            Console.WriteLine(user.Id);
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        foreach (var user in db.Users.Include(u => u.Orders).ToList())
+        {
+            Console.WriteLine(user.Id);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyFix.Diagnostic("LC007").WithLocation(0).WithArguments("Load");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ReferenceLoadAsync_InAwaitForeach_AddsIncludeBeforeAsyncEnumeration()
+    {
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        await foreach (var user in db.Users.AsAsyncEnumerable())
+        {
+            await {|#0:db.Entry(user).Reference(u => u.Profile).LoadAsync()|};
+            Console.WriteLine(user.Id);
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        await foreach (var user in db.Users.Include(u => u.Profile).AsAsyncEnumerable())
+        {
+            Console.WriteLine(user.Id);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyFix.Diagnostic("LC007").WithLocation(0).WithArguments("LoadAsync");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task StringBasedExplicitLoad_DoesNotRegisterFixer()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        foreach (var user in db.Users.ToList())
+        {
+            {|#0:db.Entry(user).Collection(""Orders"").Load()|};
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyFix.Diagnostic("LC007").WithLocation(0).WithArguments("Load");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, test);
+    }
+
+    [Fact]
+    public async Task ConditionalExplicitLoad_DoesNotRegisterFixer()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main(bool includeOrders)
+    {
+        var db = new MyDbContext();
+        foreach (var user in db.Users.ToList())
+        {
+            if (includeOrders)
+            {
+                {|#0:db.Entry(user).Collection(u => u.Orders).Load()|};
+            }
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyFix.Diagnostic("LC007").WithLocation(0).WithArguments("Load");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, test);
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperTests.cs
@@ -9,14 +9,24 @@ public class NPlusOneLooperTests
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Query;
+using TestNamespace;
 ";
 
     private const string MockNamespace = @"
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public interface IIncludableQueryable<out TEntity, out TProperty> : IQueryable<TEntity> { }
+}
+
 namespace Microsoft.EntityFrameworkCore
 {
+    using Microsoft.EntityFrameworkCore.Query;
+
     public class DbContext : IDisposable
     {
         public void Dispose() { }
@@ -27,251 +37,285 @@ namespace Microsoft.EntityFrameworkCore
     public class DbSet<T> : IQueryable<T> where T : class
     {
         public Type ElementType => typeof(T);
-        public System.Linq.Expressions.Expression Expression => System.Linq.Expressions.Expression.Constant(this);
+        public Expression Expression => Expression.Constant(this);
         public IQueryProvider Provider => null;
         public IEnumerator<T> GetEnumerator() => null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null;
-        
+
         public T Find(params object[] keyValues) => null;
+        public Task<T> FindAsync(params object[] keyValues) => Task.FromResult<T>(null);
     }
 
-    public static class AsyncEnumerableExtensions
+    public static class EntityFrameworkQueryableExtensions
     {
         public static IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IQueryable<T> source) => null;
+        public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source) => Task.FromResult(new List<T>());
+        public static Task<int> CountAsync<T>(this IQueryable<T> source) => Task.FromResult(0);
+        public static Task<bool> AnyAsync<T>(this IQueryable<T> source) => Task.FromResult(false);
+        public static int ExecuteDelete<T>(this IQueryable<T> source) => 0;
+        public static Task<int> ExecuteDeleteAsync<T>(this IQueryable<T> source) => Task.FromResult(0);
+        public static int ExecuteUpdate<T>(this IQueryable<T> source, Expression<Func<T, T>> updateExpression) => 0;
+        public static Task<int> ExecuteUpdateAsync<T>(this IQueryable<T> source, Expression<Func<T, T>> updateExpression) => Task.FromResult(0);
+
+        public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TProperty>(
+            this IQueryable<TEntity> source,
+            Expression<Func<TEntity, TProperty>> navigationPropertyPath)
+            => null;
     }
 }
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
-    public class EntityEntry<T> where T : class
+    public class EntityEntry<TEntity> where TEntity : class
     {
         public ReferenceEntry Reference(string name) => null;
         public CollectionEntry Collection(string name) => null;
+
+        public ReferenceEntry<TEntity, TProperty> Reference<TProperty>(Expression<Func<TEntity, TProperty>> navigationPropertyPath) => null;
+        public CollectionEntry<TEntity, TProperty> Collection<TProperty>(Expression<Func<TEntity, IEnumerable<TProperty>>> navigationPropertyPath) => null;
     }
+
     public class ReferenceEntry
     {
         public void Load() { }
         public Task LoadAsync() => Task.CompletedTask;
     }
+
     public class CollectionEntry
     {
         public void Load() { }
         public Task LoadAsync() => Task.CompletedTask;
         public IQueryable<T> Query<T>() => null;
     }
+
+    public class ReferenceEntry<TEntity, TProperty>
+    {
+        public void Load() { }
+        public Task LoadAsync() => Task.CompletedTask;
+    }
+
+    public class CollectionEntry<TEntity, TProperty>
+    {
+        public void Load() { }
+        public Task LoadAsync() => Task.CompletedTask;
+        public IQueryable<TProperty> Query() => null;
+    }
 }
 
 namespace TestNamespace
 {
-    public class User { public int Id { get; set; } }
-    
+    public class User
+    {
+        public int Id { get; set; }
+        public List<Order> Orders { get; set; }
+        public Profile Profile { get; set; }
+    }
+
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public class Profile
+    {
+        public int Id { get; set; }
+    }
+
     public class MyDbContext : Microsoft.EntityFrameworkCore.DbContext
     {
         public Microsoft.EntityFrameworkCore.DbSet<User> Users { get; set; }
+        public IQueryable<User> AmbiguousUsers { get; set; }
     }
 }";
 
     [Fact]
-    public async Task TestInnocent_ForeachLoop_WithReferenceAccessorOnly_NoDiagnostic()
+    public async Task Find_InForLoop_TriggersDiagnostic()
     {
         var test = Usings + @"
-using TestNamespace;
 class Program
 {
     void Main()
     {
         var db = new MyDbContext();
-        var users = new List<User>();
 
-        foreach (var user in users)
+        for (var i = 0; i < 10; i++)
         {
-            db.Entry(user).Reference(""abc"");
+            var user = {|#0:db.Users.Find(i)|};
         }
     }
 }
 " + MockNamespace;
 
-        await VerifyCS.VerifyAnalyzerAsync(test);
-    }
-
-    [Fact]
-    public async Task TestInnocent_ForeachLoop_WithCollectionAccessorOnly_NoDiagnostic()
-    {
-        var test = Usings + @"
-using TestNamespace;
-class Program
-{
-    void Main()
-    {
-        var db = new MyDbContext();
-        var users = new List<User>();
-
-        foreach (var user in users)
-        {
-            db.Entry(user).Collection(""abc"");
-        }
-    }
-}
-" + MockNamespace;
-
-        await VerifyCS.VerifyAnalyzerAsync(test);
-    }
-
-    [Fact]
-    public async Task TestCrime_ForeachLoop_WithCollectionLoad_TriggersDiagnostic()
-    {
-        var test = Usings + @"
-using TestNamespace;
-class Program
-{
-    void Main()
-    {
-        var db = new MyDbContext();
-        var users = new List<User>();
-
-        foreach (var user in users)
-        {
-            db.Entry(user).Collection(""abc"").Load();
-        }
-    }
-}
-" + MockNamespace;
-
-        var expected = VerifyCS.Diagnostic("LC007")
-            .WithLocation(19, 13)
-            .WithArguments("Load");
-
+        var expected = VerifyCS.Diagnostic("LC007").WithLocation(0).WithArguments("Find");
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
     [Fact]
-    public async Task TestCrime_ForeachLoop_WithCollectionLoadAsync_TriggersDiagnostic()
+    public async Task FindAsync_InForeachLoop_TriggersDiagnostic()
     {
         var test = Usings + @"
-using TestNamespace;
 class Program
 {
     async Task Main()
-    {
-        var db = new MyDbContext();
-        var users = new List<User>();
-
-        foreach (var user in users)
-        {
-            await db.Entry(user).Collection(""abc"").LoadAsync();
-        }
-    }
-}
-" + MockNamespace;
-
-        var expected = VerifyCS.Diagnostic("LC007")
-            .WithLocation(19, 19)
-            .WithArguments("LoadAsync");
-
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
-    }
-
-    [Fact]
-    public async Task TestCrime_ForeachLoop_WithToList_TriggersDiagnostic()
-    {
-        var test = Usings + @"
-using TestNamespace;
-class Program
-{
-    void Main()
     {
         var db = new MyDbContext();
         var ids = new List<int> { 1, 2, 3 };
 
         foreach (var id in ids)
         {
-            // Crime: Query inside loop
-            var user = db.Users.AsQueryable().Where(u => u.Id == id).ToList();
+            var user = await {|#0:db.Users.FindAsync(id)|};
         }
     }
 }
 " + MockNamespace;
 
-        var expected = VerifyCS.Diagnostic("LC007")
-            .WithLocation(20, 24)
-            .WithArguments("ToList");
-
+        var expected = VerifyCS.Diagnostic("LC007").WithLocation(0).WithArguments("FindAsync");
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
     [Fact]
-    public async Task TestCrime_ForLoop_WithFind_TriggersDiagnostic()
+    public async Task ExplicitLoad_StringAccessor_StillTriggersDiagnostic()
     {
         var test = Usings + @"
-using TestNamespace;
 class Program
 {
     void Main()
     {
         var db = new MyDbContext();
-        
-        for (int i = 0; i < 10; i++)
+        foreach (var user in db.Users.ToList())
         {
-            // Crime: Find inside loop
-            var user = db.Users.Find(i);
+            {|#0:db.Entry(user).Collection(""Orders"").Load()|};
         }
     }
 }
 " + MockNamespace;
 
-        var expected = VerifyCS.Diagnostic("LC007")
-            .WithLocation(19, 24)
-            .WithArguments("Find");
-
+        var expected = VerifyCS.Diagnostic("LC007").WithLocation(0).WithArguments("Load");
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
     [Fact]
-    public async Task TestCrime_WhileLoop_WithCount_TriggersDiagnostic()
+    public async Task TypedNavigationQuery_Count_TriggersDiagnostic()
     {
         var test = Usings + @"
-using TestNamespace;
 class Program
 {
     void Main()
     {
         var db = new MyDbContext();
-        int i = 0;
-        while (i < 10)
+        foreach (var user in db.Users.ToList())
         {
-            // Crime: Count inside loop
-            var count = db.Users.Count();
+            var count = {|#0:db.Entry(user).Collection(u => u.Orders).Query().Count()|};
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC007").WithLocation(0).WithArguments("Count");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task DbContextSetQueryMaterializer_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        foreach (var id in new[] { 1, 2, 3 })
+        {
+            var users = {|#0:db.Set<User>().Where(u => u.Id == id).ToList()|};
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC007").WithLocation(0).WithArguments("ToList");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task SingleAssignmentLocalEfQuery_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var query = db.Users.Where(u => u.Id > 0);
+
+        foreach (var id in new[] { 1, 2, 3 })
+        {
+            var any = {|#0:query.Any(u => u.Id == id)|};
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC007").WithLocation(0).WithArguments("Any");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ExecuteDelete_InWhileLoop_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var i = 0;
+        while (i < 5)
+        {
+            {|#0:db.Users.Where(u => u.Id == i).ExecuteDelete()|};
             i++;
         }
     }
 }
 " + MockNamespace;
 
-        var expected = VerifyCS.Diagnostic("LC007")
-            .WithLocation(19, 25)
-            .WithArguments("Count");
-
+        var expected = VerifyCS.Diagnostic("LC007").WithLocation(0).WithArguments("ExecuteDelete");
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
     [Fact]
-    public async Task TestInnocent_QueryOutsideLoop_NoDiagnostic()
+    public async Task Count_InAwaitForeach_TriggersDiagnostic()
     {
         var test = Usings + @"
-using TestNamespace;
+class Program
+{
+    async Task Run()
+    {
+        var db = new MyDbContext();
+        await foreach (var user in db.Users.AsAsyncEnumerable())
+        {
+            var count = {|#0:db.Users.Count()|};
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC007").WithLocation(0).WithArguments("Count");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task InMemoryAsQueryable_IsIgnored()
+    {
+        var test = Usings + @"
 class Program
 {
     void Main()
     {
-        var db = new MyDbContext();
-        var ids = new List<int> { 1, 2, 3 };
-        
-        // Innocent: Query outside
-        var users = db.Users.ToList();
+        var users = new List<User>().AsQueryable();
 
-        foreach (var user in users)
+        foreach (var id in new[] { 1, 2, 3 })
         {
-            Console.WriteLine(user.Id);
+            var count = users.Count(u => u.Id == id);
         }
     }
 }
@@ -281,73 +325,121 @@ class Program
     }
 
     [Fact]
-    public async Task TestCrime_AwaitForeach_WithCount_TriggersDiagnostic()
+    public async Task IQueryableParameter_IsIgnoredAsAmbiguous()
     {
         var test = Usings + @"
-using TestNamespace;
 class Program
 {
-    public async Task Run()
+    void Main(IQueryable<User> query)
     {
-        var db = new MyDbContext();
-        await foreach (var user in db.Users.AsAsyncEnumerable())
+        foreach (var id in new[] { 1, 2, 3 })
         {
-            var count = db.Users.Count();
+            var count = query.Count(u => u.Id == id);
         }
     }
 }
 " + MockNamespace;
 
-        var expected = VerifyCS.Diagnostic("LC007")
-            .WithLocation(17, 25)
-            .WithArguments("Count");
-
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
-    public async Task TestCrime_ForeachLoop_WithCollectionQueryMaterialization_TriggersDiagnostic()
+    public async Task IQueryableProperty_IsIgnoredAsAmbiguous()
     {
         var test = Usings + @"
-using TestNamespace;
 class Program
 {
+    private readonly MyDbContext _db = new MyDbContext();
+
     void Main()
     {
-        var db = new MyDbContext();
-        var users = new List<User>();
-
-        foreach (var user in users)
+        foreach (var id in new[] { 1, 2, 3 })
         {
-            var roles = db.Entry(user).Collection(""abc"").Query<User>().ToList();
+            var count = _db.AmbiguousUsers.Count(u => u.Id == id);
         }
     }
 }
 " + MockNamespace;
 
-        var expected = VerifyCS.Diagnostic("LC007")
-            .WithLocation(19, 25)
-            .WithArguments("ToList");
-
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
-    public async Task TestInnocent_DeferredExecution_InsideLoop_NoDiagnostic()
+    public async Task MultiAssignedLocal_IsIgnoredAsAmbiguous()
     {
         var test = Usings + @"
-using TestNamespace;
 class Program
 {
     void Main()
     {
         var db = new MyDbContext();
-        var ids = new List<int> { 1, 2, 3 };
+        IQueryable<User> query = db.Users;
+        query = db.Users.Where(u => u.Id > 10);
 
-        foreach (var id in ids)
+        foreach (var id in new[] { 1, 2, 3 })
         {
-            // Innocent: Just building query, not executing (yet)
-            var query = db.Users.Where(u => u.Id == id); 
+            var count = query.Count(u => u.Id == id);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task QueryConstructionOnly_IsIgnored()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        foreach (var id in new[] { 1, 2, 3 })
+        {
+            var query = db.Users.Where(u => u.Id == id);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AccessorsWithoutExecution_AreIgnored()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        foreach (var user in db.Users.ToList())
+        {
+            db.Entry(user).Reference(u => u.Profile);
+            db.Entry(user).Collection(u => u.Orders);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task InvocationInsideLambdaDeclaredInLoop_IsIgnored()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        foreach (var id in new[] { 1, 2, 3 })
+        {
+            Func<int> countUsers = () => db.Users.Count(u => u.Id == id);
         }
     }
 }


### PR DESCRIPTION
## Summary
- rebuild LC007 around proven EF-backed, per-iteration database execution detection
- add a conservative LC007 fixer that converts safe explicit-loading loops to `Include(...)`
- bump the package to `4.4.0` and document the release details in the changelog and rule docs

## Validation
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net9.0`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net9.0 --filter LC007`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --filter LC007`

## Release Notes
- `LC007` now distinguishes proven EF execution paths from ambiguous `IQueryable` usage and skips loop-source materialization false positives
- `LC007` now covers `Find`, explicit loading, navigation `Query()` execution, aggregates, and EF set-based executors when the origin is provable
- Added the first LC007 fixer for unconditional strongly-typed explicit-loading loops, rewriting them to eager loading with `Include(...)`
