### PR TITLE
feat: harden LC004 and prep 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.0] - 2026-03-18
+
+### Added
+- `LC004` now has a guarded fixer that materializes proven generic query sources with `.ToList()` at the call site
+
+### Changed
+- `LC004` now uses compilation-cached same-compilation analysis to prove whether an `IEnumerable` parameter is actually consumed before reporting
+- `LC004` only reports when the callee body is inspectable and the parameter is proven hazardous through direct enumeration, terminal/materializing `Enumerable` usage, or forwarding into another proven sink
+- Updated the LC004 README and rule documentation to describe the proof-based reporting model and explicit caller-side materialization fix
+
+### Fixed
+- `LC004` no longer flags framework sinks, delegate invocations, methods without source bodies, pure pass-through helpers, or already materialized arguments
+- Expanded LC004 regression coverage with should-report, should-not-report, fix, and no-fix scenarios for the new analyzer and fixer contract
+
 ## [4.4.0] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ if (db.Users.Any()) { ... }
 
 ### LC004: Deferred Execution Leak
 
-Passing `IQueryable<T>` to a method that takes `IEnumerable<T>` forces implicit materialization if the method iterates
-it. This prevents you from composing the query further (e.g., adding `.Where()` or `.Take()`) inside that method.
+Passing `IQueryable<T>` to a method that takes `IEnumerable<T>` is only flagged when LinqContraband can prove that the
+callee actually forces in-memory execution by iterating, counting, or materializing that parameter. This prevents
+further provider-side composition and hides the real query cost.
 
 **👶 Explain it like I'm a ten year old:** Imagine you have a coupon for "Build Your Own Burger". You give it to the
 chef, but instead of letting you choose toppings, he immediately hands you a plain burger and says "Too late, I already
@@ -157,8 +158,8 @@ ProcessUsers(db.Users);
 
 **✅ The Fix:**
 
-Change the parameter to `IQueryable<T>` to allow composition, or explicitly call `.ToList()` if you *intend* to fetch
-everything.
+Change the parameter to `IQueryable<T>` to allow composition, or explicitly call `.ToList()` at the call site if you
+*intend* to fetch everything.
 
 ```csharp
 public void ProcessUsers(IQueryable<User> users)

--- a/docs/LC004_IQueryableLeak.md
+++ b/docs/LC004_IQueryableLeak.md
@@ -1,21 +1,21 @@
 # Spec: LC004 - IQueryable to IEnumerable Leak
 
 ## Goal
-Detect when an `IQueryable` is passed to a method parameter of type `IEnumerable`, causing implicit materialization and preventing further query composition.
+Detect when an `IQueryable` is passed to a method parameter of type `IEnumerable` and the callee is proven to force in-memory execution.
 
 ## The Problem
-`IQueryable` represents a database query that hasn't run yet. `IEnumerable` usually represents an in-memory collection. If you pass an `IQueryable` to an `IEnumerable` parameter, the query provider might lose the ability to add more filters (like `Where` or `Take`) to the SQL, forcing them to run in your app instead.
+`IQueryable` represents a database query that hasn't run yet. `IEnumerable` usually represents an in-memory collection. Passing an `IQueryable` into an `IEnumerable` parameter erases provider semantics. If the callee then iterates, counts, or materializes that parameter, the remaining work happens in your app instead of in the database.
 
 ### Example Violation
 ```csharp
 public void ProcessUsers(IEnumerable<User> users) { ... }
 
-// Leak: Query is materialized implicitly when ProcessUsers iterates
+// Leak: ProcessUsers is proven to enumerate the sequence in memory.
 ProcessUsers(db.Users); 
 ```
 
 ### The Fix
-Change the method parameter to `IQueryable` if you want to allow further filtering, or explicitly call `.ToList()` if you intend to fetch the data.
+Change the method parameter to `IQueryable` if you want to allow further filtering, or explicitly call `.ToList()` at the call site if you intend to fetch the data.
 
 ```csharp
 // Correct: Allows composing the query inside the method
@@ -23,6 +23,16 @@ public void ProcessUsers(IQueryable<User> users) { ... }
 ```
 
 ## Analyzer Logic
+- Reports only when the target method is inspectable in the current compilation.
+- Treats a parameter as hazardous only when the method body proves one of these:
+  - `foreach` or manual enumerator consumption.
+  - terminal or materializing `Enumerable` calls such as `Any`, `Count`, `ToList`, or `ToArray`.
+  - forwarding into another same-compilation parameter already proven hazardous.
+- Does not report for framework methods, delegate invocations, parameters already typed as `IQueryable`, or callees without source bodies.
+
+## Fixer Behavior
+- Offers one safe fix when the source query is generic: materialize explicitly with `.ToList()`.
+- Does not offer signature-changing fixes.
 
 ### ID: `LC004`
 ### Category: `Performance`

--- a/src/LinqContraband/Analyzers/LC004_IQueryableLeak/IQueryableLeakAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LC004_IQueryableLeak/IQueryableLeakAnalysis.cs
@@ -1,0 +1,579 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC004_IQueryableLeak;
+
+internal static class IQueryableLeakDiagnosticProperties
+{
+    public const string FixerEligible = "LC004.FixerEligible";
+}
+
+internal sealed class IQueryableLeakCompilationState
+{
+    private static readonly ImmutableHashSet<string> HazardousEnumerableMethods = ImmutableHashSet.Create(
+        "Aggregate",
+        "All",
+        "Any",
+        "Average",
+        "Contains",
+        "Count",
+        "ElementAt",
+        "ElementAtOrDefault",
+        "First",
+        "FirstOrDefault",
+        "Last",
+        "LastOrDefault",
+        "LongCount",
+        "Max",
+        "MaxBy",
+        "Min",
+        "MinBy",
+        "SequenceEqual",
+        "Single",
+        "SingleOrDefault",
+        "Sum",
+        "ToArray",
+        "ToDictionary",
+        "ToHashSet",
+        "ToList",
+        "ToLookup");
+
+    private readonly Compilation _compilation;
+    private readonly INamedTypeSymbol _enumerableType;
+    private readonly INamedTypeSymbol _enumerableGenericType;
+    private readonly INamedTypeSymbol? _queryableType;
+    private readonly INamedTypeSymbol? _queryableGenericType;
+    private readonly INamedTypeSymbol? _linqEnumerableType;
+    private readonly INamedTypeSymbol? _linqQueryableType;
+    private readonly ConcurrentDictionary<ISymbol, HazardousParameterSummary> _methodSummaries = new(SymbolEqualityComparer.Default);
+
+    public IQueryableLeakCompilationState(Compilation compilation)
+    {
+        _compilation = compilation;
+        _enumerableType = compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable);
+        _enumerableGenericType = compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T);
+        _queryableType = compilation.GetTypeByMetadataName("System.Linq.IQueryable");
+        _queryableGenericType = compilation.GetTypeByMetadataName("System.Linq.IQueryable`1");
+        _linqEnumerableType = compilation.GetTypeByMetadataName("System.Linq.Enumerable");
+        _linqQueryableType = compilation.GetTypeByMetadataName("System.Linq.Queryable");
+    }
+
+    public bool CanAnalyze =>
+        _enumerableType.SpecialType == SpecialType.System_Collections_IEnumerable &&
+        _enumerableGenericType.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T &&
+        _linqEnumerableType != null;
+
+    public void AnalyzeInvocation(OperationAnalysisContext context)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var targetMethod = GetOriginalTargetMethod(invocation.TargetMethod);
+
+        if (targetMethod.MethodKind == MethodKind.DelegateInvoke || targetMethod.IsFrameworkMethod())
+            return;
+
+        var summary = GetMethodSummary(targetMethod, new HashSet<ISymbol>(SymbolEqualityComparer.Default));
+        if (!summary.IsInspectable || summary.HazardousParameterOrdinals.Count == 0)
+            return;
+
+        foreach (var input in EnumerateInvocationInputs(invocation))
+        {
+            if (!summary.HazardousParameterOrdinals.Contains(input.Parameter.Ordinal))
+                continue;
+
+            if (!IsIEnumerableParameterType(input.Parameter.Type) || IsIQueryableType(input.Parameter.Type))
+                continue;
+
+            if (!TryGetQuerySourceType(input.Value, out var querySourceType))
+                continue;
+
+            var properties = ImmutableDictionary<string, string?>.Empty.Add(
+                IQueryableLeakDiagnosticProperties.FixerEligible,
+                CanOfferToListFix(querySourceType) ? "true" : "false");
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    IQueryableLeakAnalyzer.Rule,
+                    input.Value.Syntax.GetLocation(),
+                    properties,
+                    input.Parameter.Name,
+                    input.Parameter.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+        }
+    }
+
+    private HazardousParameterSummary GetMethodSummary(IMethodSymbol method, HashSet<ISymbol> visiting)
+    {
+        if (_methodSummaries.TryGetValue(method, out var cachedSummary))
+            return cachedSummary;
+
+        if (!visiting.Add(method))
+            return HazardousParameterSummary.EmptyInspectable;
+
+        try
+        {
+            var summary = AnalyzeMethod(method, visiting);
+            _methodSummaries.TryAdd(method, summary);
+            return summary;
+        }
+        finally
+        {
+            visiting.Remove(method);
+        }
+    }
+
+    private HazardousParameterSummary AnalyzeMethod(IMethodSymbol method, HashSet<ISymbol> visiting)
+    {
+        if (!TryGetExecutableRoot(method, out var executableRoot))
+            return HazardousParameterSummary.NotInspectable;
+
+        var candidateOrdinals = ImmutableHashSet.CreateBuilder<int>();
+        foreach (var parameter in method.Parameters)
+        {
+            if (IsIEnumerableParameterType(parameter.Type) && !IsIQueryableType(parameter.Type))
+                candidateOrdinals.Add(parameter.Ordinal);
+        }
+
+        if (candidateOrdinals.Count == 0)
+            return HazardousParameterSummary.EmptyInspectable;
+
+        var hazardousOrdinals = ImmutableHashSet.CreateBuilder<int>();
+
+        foreach (var operation in EnumerateOperations(executableRoot))
+        {
+            switch (operation)
+            {
+                case IForEachLoopOperation forEachLoop:
+                    MarkHazardIfParameterSource(
+                        forEachLoop.Collection,
+                        forEachLoop.Syntax.SpanStart,
+                        executableRoot,
+                        candidateOrdinals,
+                        hazardousOrdinals);
+                    break;
+
+                case IInvocationOperation invocation:
+                    if (IsDirectConsumption(invocation))
+                    {
+                        MarkHazardIfParameterSource(
+                            invocation.GetInvocationReceiver(),
+                            invocation.Syntax.SpanStart,
+                            executableRoot,
+                            candidateOrdinals,
+                            hazardousOrdinals);
+                    }
+
+                    MarkForwardedHazards(invocation, executableRoot, candidateOrdinals, hazardousOrdinals, visiting);
+                    break;
+            }
+        }
+
+        return new HazardousParameterSummary(true, hazardousOrdinals.ToImmutable());
+    }
+
+    private void MarkForwardedHazards(
+        IInvocationOperation invocation,
+        IOperation executableRoot,
+        ImmutableHashSet<int>.Builder candidateOrdinals,
+        ImmutableHashSet<int>.Builder hazardousOrdinals,
+        HashSet<ISymbol> visiting)
+    {
+        var targetMethod = GetOriginalTargetMethod(invocation.TargetMethod);
+        if (targetMethod.MethodKind == MethodKind.DelegateInvoke || targetMethod.IsFrameworkMethod())
+            return;
+
+        var calleeSummary = GetMethodSummary(targetMethod, visiting);
+        if (!calleeSummary.IsInspectable || calleeSummary.HazardousParameterOrdinals.Count == 0)
+            return;
+
+        foreach (var input in EnumerateInvocationInputs(invocation))
+        {
+            if (!calleeSummary.HazardousParameterOrdinals.Contains(input.Parameter.Ordinal))
+                continue;
+
+            if (!TryResolveParameterSource(
+                    input.Value,
+                    invocation.Syntax.SpanStart,
+                    executableRoot,
+                    new HashSet<ISymbol>(SymbolEqualityComparer.Default),
+                    out var parameter))
+            {
+                continue;
+            }
+
+            if (candidateOrdinals.Contains(parameter.Ordinal))
+                hazardousOrdinals.Add(parameter.Ordinal);
+        }
+    }
+
+    private bool IsDirectConsumption(IInvocationOperation invocation)
+    {
+        if (IsGetEnumeratorInvocation(invocation))
+            return true;
+
+        var targetMethod = GetOriginalTargetMethod(invocation.TargetMethod);
+        return IsEnumerableMethod(targetMethod) &&
+               HazardousEnumerableMethods.Contains(targetMethod.Name);
+    }
+
+    private bool IsGetEnumeratorInvocation(IInvocationOperation invocation)
+    {
+        return invocation.Arguments.Length == 0 &&
+               string.Equals(invocation.TargetMethod.Name, "GetEnumerator", StringComparison.Ordinal) &&
+               IsIEnumerableLike(invocation.GetInvocationReceiver()?.Type);
+    }
+
+    private void MarkHazardIfParameterSource(
+        IOperation? operation,
+        int position,
+        IOperation executableRoot,
+        ImmutableHashSet<int>.Builder candidateOrdinals,
+        ImmutableHashSet<int>.Builder hazardousOrdinals)
+    {
+        if (!TryResolveParameterSource(
+                operation,
+                position,
+                executableRoot,
+                new HashSet<ISymbol>(SymbolEqualityComparer.Default),
+                out var parameter))
+        {
+            return;
+        }
+
+        if (candidateOrdinals.Contains(parameter.Ordinal))
+            hazardousOrdinals.Add(parameter.Ordinal);
+    }
+
+    private bool TryResolveParameterSource(
+        IOperation? operation,
+        int position,
+        IOperation executableRoot,
+        HashSet<ISymbol> visitedLocals,
+        out IParameterSymbol parameter)
+    {
+        parameter = null!;
+        if (operation == null)
+            return false;
+
+        var current = operation.UnwrapConversions();
+
+        if (current is IParameterReferenceOperation parameterReference)
+        {
+            parameter = parameterReference.Parameter;
+            return true;
+        }
+
+        if (current is ILocalReferenceOperation localReference)
+        {
+            if (!visitedLocals.Add(localReference.Local))
+                return false;
+
+            if (!TryResolveSingleAssignedValue(executableRoot, localReference.Local, position, out var assignedValue))
+                return false;
+
+            return TryResolveParameterSource(assignedValue, position, executableRoot, visitedLocals, out parameter);
+        }
+
+        if (current is IInvocationOperation invocation &&
+            IsSequencePreservingInvocation(invocation))
+        {
+            return TryResolveParameterSource(
+                invocation.GetInvocationReceiver(),
+                position,
+                executableRoot,
+                visitedLocals,
+                out parameter);
+        }
+
+        return false;
+    }
+
+    private bool TryResolveSingleAssignedValue(
+        IOperation executableRoot,
+        ILocalSymbol local,
+        int position,
+        out IOperation value)
+    {
+        value = null!;
+        IOperation? latestValue = null;
+        var latestPosition = -1;
+        var assignmentCount = 0;
+
+        foreach (var operation in EnumerateOperations(executableRoot))
+        {
+            if (operation.Syntax.SpanStart >= position)
+                continue;
+
+            switch (operation)
+            {
+                case IVariableDeclaratorOperation declarator
+                    when SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) &&
+                         declarator.Initializer != null &&
+                         declarator.Syntax.SpanStart > latestPosition:
+                    latestValue = declarator.Initializer.Value;
+                    latestPosition = declarator.Syntax.SpanStart;
+                    assignmentCount++;
+                    break;
+
+                case ISimpleAssignmentOperation assignment
+                    when assignment.Target is ILocalReferenceOperation targetLocal &&
+                         SymbolEqualityComparer.Default.Equals(targetLocal.Local, local) &&
+                         assignment.Syntax.SpanStart > latestPosition:
+                    latestValue = assignment.Value;
+                    latestPosition = assignment.Syntax.SpanStart;
+                    assignmentCount++;
+                    break;
+            }
+        }
+
+        if (latestValue == null || assignmentCount != 1)
+            return false;
+
+        value = latestValue.UnwrapConversions();
+        return true;
+    }
+
+    private IEnumerable<InvocationInput> EnumerateInvocationInputs(IInvocationOperation invocation)
+    {
+        var targetMethod = invocation.TargetMethod;
+        var originalTargetMethod = GetOriginalTargetMethod(targetMethod);
+
+        if (targetMethod.ReducedFrom != null && invocation.Instance != null && originalTargetMethod.Parameters.Length > 0)
+        {
+            yield return new InvocationInput(invocation.Instance, originalTargetMethod.Parameters[0]);
+        }
+
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter == null)
+                continue;
+
+            var parameter = argument.Parameter;
+            if (targetMethod.ReducedFrom != null)
+            {
+                var originalOrdinal = parameter.Ordinal + 1;
+                if (originalOrdinal >= originalTargetMethod.Parameters.Length)
+                    continue;
+
+                parameter = originalTargetMethod.Parameters[originalOrdinal];
+            }
+
+            yield return new InvocationInput(argument.Value, parameter);
+        }
+    }
+
+    private bool TryGetQuerySourceType(IOperation operation, out ITypeSymbol sourceType)
+    {
+        sourceType = null!;
+        var current = operation.UnwrapConversions();
+        if (current.Type == null || !IsIQueryableType(current.Type))
+            return false;
+
+        sourceType = current.Type;
+        return true;
+    }
+
+    private bool CanOfferToListFix(ITypeSymbol sourceType)
+    {
+        return TryGetConstructedInterface(sourceType, _queryableGenericType, out _);
+    }
+
+    private bool IsSequencePreservingInvocation(IInvocationOperation invocation)
+    {
+        var targetMethod = GetOriginalTargetMethod(invocation.TargetMethod);
+        if (!IsEnumerableMethod(targetMethod) && !IsQueryableMethod(targetMethod))
+            return false;
+
+        if (!IsIEnumerableLike(targetMethod.ReturnType) && !IsIQueryableType(targetMethod.ReturnType))
+            return false;
+
+        return invocation.GetInvocationReceiver() != null;
+    }
+
+    private bool IsEnumerableMethod(IMethodSymbol method)
+    {
+        return _linqEnumerableType != null &&
+               SymbolEqualityComparer.Default.Equals(method.ContainingType, _linqEnumerableType);
+    }
+
+    private bool IsQueryableMethod(IMethodSymbol method)
+    {
+        return _linqQueryableType != null &&
+               SymbolEqualityComparer.Default.Equals(method.ContainingType, _linqQueryableType);
+    }
+
+    private bool IsIEnumerableParameterType(ITypeSymbol type)
+    {
+        return SymbolEqualityComparer.Default.Equals(type, _enumerableType) ||
+               TryGetConstructedInterface(type, _enumerableGenericType, out var enumerableInterface) &&
+               SymbolEqualityComparer.Default.Equals(type, enumerableInterface);
+    }
+
+    private bool IsIQueryableType(ITypeSymbol? type)
+    {
+        if (type == null)
+            return false;
+
+        return SymbolEqualityComparer.Default.Equals(type, _queryableType) ||
+               TryGetConstructedInterface(type, _queryableGenericType, out _) ||
+               type.AllInterfaces.Any(i =>
+                   SymbolEqualityComparer.Default.Equals(i, _queryableType));
+    }
+
+    private bool IsIEnumerableLike(ITypeSymbol? type)
+    {
+        if (type == null)
+            return false;
+
+        if (SymbolEqualityComparer.Default.Equals(type, _enumerableType))
+            return true;
+
+        return TryGetConstructedInterface(type, _enumerableGenericType, out _) ||
+               type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, _enumerableType));
+    }
+
+    private bool TryGetConstructedInterface(ITypeSymbol? type, INamedTypeSymbol? interfaceType, out INamedTypeSymbol match)
+    {
+        match = null!;
+        if (type == null || interfaceType == null)
+            return false;
+
+        if (type is INamedTypeSymbol namedType &&
+            SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, interfaceType))
+        {
+            match = namedType;
+            return true;
+        }
+
+        foreach (var currentInterface in type.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(currentInterface.OriginalDefinition, interfaceType))
+            {
+                match = currentInterface;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryGetExecutableRoot(IMethodSymbol method, out IOperation executableRoot)
+    {
+        foreach (var syntaxReference in method.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxReference.GetSyntax();
+            var semanticModel = _compilation.GetSemanticModel(syntax.SyntaxTree);
+
+            switch (syntax)
+            {
+                case MethodDeclarationSyntax methodDeclaration when methodDeclaration.Body != null:
+                    var methodBody = semanticModel.GetOperation(methodDeclaration.Body);
+                    if (methodBody != null)
+                    {
+                        executableRoot = methodBody;
+                        return true;
+                    }
+
+                    break;
+
+                case MethodDeclarationSyntax methodDeclaration when methodDeclaration.ExpressionBody != null:
+                    var methodExpressionBody = semanticModel.GetOperation(methodDeclaration.ExpressionBody.Expression);
+                    if (methodExpressionBody != null)
+                    {
+                        executableRoot = methodExpressionBody;
+                        return true;
+                    }
+
+                    break;
+
+                case LocalFunctionStatementSyntax localFunction when localFunction.Body != null:
+                    var localFunctionBody = semanticModel.GetOperation(localFunction.Body);
+                    if (localFunctionBody != null)
+                    {
+                        executableRoot = localFunctionBody;
+                        return true;
+                    }
+
+                    break;
+
+                case LocalFunctionStatementSyntax localFunction when localFunction.ExpressionBody != null:
+                    var localFunctionExpressionBody = semanticModel.GetOperation(localFunction.ExpressionBody.Expression);
+                    if (localFunctionExpressionBody != null)
+                    {
+                        executableRoot = localFunctionExpressionBody;
+                        return true;
+                    }
+
+                    break;
+            }
+        }
+
+        executableRoot = null!;
+        return false;
+    }
+
+    private IEnumerable<IOperation> EnumerateOperations(IOperation executableRoot)
+    {
+        yield return executableRoot;
+
+        foreach (var operation in executableRoot.Descendants())
+        {
+            if (IsInsideNestedExecutable(operation, executableRoot))
+                continue;
+
+            yield return operation;
+        }
+    }
+
+    private static bool IsInsideNestedExecutable(IOperation operation, IOperation executableRoot)
+    {
+        var current = operation.Parent;
+        while (current != null && !ReferenceEquals(current, executableRoot))
+        {
+            if (current is ILocalFunctionOperation or IAnonymousFunctionOperation)
+                return true;
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private static IMethodSymbol GetOriginalTargetMethod(IMethodSymbol method)
+    {
+        return method.ReducedFrom ?? method;
+    }
+
+    private readonly struct InvocationInput
+    {
+        public InvocationInput(IOperation value, IParameterSymbol parameter)
+        {
+            Value = value;
+            Parameter = parameter;
+        }
+
+        public IOperation Value { get; }
+        public IParameterSymbol Parameter { get; }
+    }
+
+    private sealed class HazardousParameterSummary
+    {
+        public HazardousParameterSummary(bool isInspectable, ImmutableHashSet<int> hazardousParameterOrdinals)
+        {
+            IsInspectable = isInspectable;
+            HazardousParameterOrdinals = hazardousParameterOrdinals;
+        }
+
+        public bool IsInspectable { get; }
+        public ImmutableHashSet<int> HazardousParameterOrdinals { get; }
+
+        public static readonly HazardousParameterSummary NotInspectable = new(false, ImmutableHashSet<int>.Empty);
+        public static readonly HazardousParameterSummary EmptyInspectable = new(true, ImmutableHashSet<int>.Empty);
+    }
+}

--- a/src/LinqContraband/Analyzers/LC004_IQueryableLeak/IQueryableLeakAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC004_IQueryableLeak/IQueryableLeakAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -10,25 +9,24 @@ namespace LinqContraband.Analyzers.LC004_IQueryableLeak;
 /// Analyzes IQueryable instances being passed to methods that only accept IEnumerable, causing implicit materialization. Diagnostic ID: LC004
 /// </summary>
 /// <remarks>
-/// <para><b>Why this matters:</b> When an IQueryable is implicitly converted to IEnumerable (due to covariance), the query
-/// is executed immediately if the receiving method iterates it. This prevents further query composition and optimization,
-/// often causing all data to be loaded into memory unnecessarily. Methods should either accept IQueryable to preserve deferred
-/// execution, or callers should explicitly materialize (ToList/ToArray) to make the performance impact visible and intentional.</para>
+/// <para><b>Why this matters:</b> Passing an IQueryable to an IEnumerable parameter erases query-provider semantics. If the receiving method
+/// is proven to enumerate that parameter, the remaining work happens in memory instead of being composed into the provider query. Callers should
+/// materialize explicitly to make that cost obvious, or the callee should keep the parameter queryable.</para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class IQueryableLeakAnalyzer : DiagnosticAnalyzer
+public sealed class IQueryableLeakAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC004";
     private const string Category = "Performance";
     private static readonly LocalizableString Title = "Deferred Execution Leak: IQueryable passed as IEnumerable";
 
     private static readonly LocalizableString MessageFormat =
-        "Passing IQueryable '{0}' to parameter of type '{1}' causes implicit materialization. Change parameter to IQueryable or materialize explicitly.";
+        "Passing IQueryable to parameter '{0}' of type '{1}' forces in-memory execution. Change the parameter to IQueryable or materialize explicitly.";
 
     private static readonly LocalizableString Description =
-        "Passing an IQueryable to a method that only accepts IEnumerable causes the query to be implicitly materialized (executed) if the method iterates it. This prevents further query composition.";
+        "Warns only when the target method is inspectable in the current compilation and is proven to enumerate the IEnumerable parameter or forward it into another proven sink.";
 
-    private static readonly DiagnosticDescriptor Rule = new(
+    internal static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
         Title,
         MessageFormat,
@@ -43,75 +41,15 @@ public class IQueryableLeakAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(InitializeCompilation);
     }
 
-    private void AnalyzeInvocation(OperationAnalysisContext context)
+    private static void InitializeCompilation(CompilationStartAnalysisContext context)
     {
-        var invocation = (IInvocationOperation)context.Operation;
-        var method = invocation.TargetMethod;
+        var state = new IQueryableLeakCompilationState(context.Compilation);
+        if (!state.CanAnalyze)
+            return;
 
-        // Skip framework methods (e.g. System.Linq.Enumerable.ToList, String.Join, etc.)
-        // These are "sinks" and it's safe/intended to pass IQueryable to them.
-        if (method.IsFrameworkMethod()) return;
-
-        // Iterate over arguments to find matching parameters
-        foreach (var argument in invocation.Arguments)
-        {
-            // Check if argument corresponds to a parameter
-            if (argument.Parameter == null) continue;
-
-            var paramType = argument.Parameter.Type;
-            var argValue = argument.Value;
-
-            // Check if parameter is IEnumerable<T> but NOT IQueryable<T>
-            if (!IsIEnumerable(paramType) || IsIQueryable(paramType)) continue;
-
-            // We need to check if the underlying object being passed is IQueryable.
-            // This requires peeling back conversions.
-            if (IsSourceIQueryable(argValue))
-                context.ReportDiagnostic(
-                    Diagnostic.Create(Rule, argument.Syntax.GetLocation(),
-                        argument.Parameter.Name,
-                        paramType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
-        }
-    }
-
-    private bool IsIEnumerable(ITypeSymbol type)
-    {
-        if (type.SpecialType == SpecialType.System_Collections_IEnumerable) return true;
-        if (type.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T) return true;
-
-        // Check by name for robustness (especially in tests/mocks)
-        if (type.Name == "IEnumerable" &&
-            type.ContainingNamespace?.ToString() == "System.Collections.Generic") return true;
-        if (type.Name == "IEnumerable" && type.ContainingNamespace?.ToString() == "System.Collections") return true;
-
-        foreach (var i in type.AllInterfaces)
-        {
-            if (i.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T ||
-                i.SpecialType == SpecialType.System_Collections_IEnumerable) return true;
-
-            if (i.Name == "IEnumerable" && i.ContainingNamespace?.ToString() == "System.Collections.Generic")
-                return true;
-        }
-
-        return false;
-    }
-
-    private bool IsIQueryable(ITypeSymbol type)
-    {
-        return type.IsIQueryable();
-    }
-
-    private bool IsSourceIQueryable(IOperation operation)
-    {
-        var current = operation;
-
-        // Walk back conversions to find the real source
-        while (current is IConversionOperation conv) current = conv.Operand;
-
-        // Check if the source type is IQueryable
-        return current.Type != null && IsIQueryable(current.Type);
+        context.RegisterOperationAction(operationContext => state.AnalyzeInvocation(operationContext), OperationKind.Invocation);
     }
 }

--- a/src/LinqContraband/Analyzers/LC004_IQueryableLeak/IQueryableLeakFixer.cs
+++ b/src/LinqContraband/Analyzers/LC004_IQueryableLeak/IQueryableLeakFixer.cs
@@ -1,0 +1,94 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace LinqContraband.Analyzers.LC004_IQueryableLeak;
+
+/// <summary>
+/// Provides code fixes for LC004. Materializes the offending query explicitly with ToList().
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(IQueryableLeakFixer))]
+[Shared]
+public sealed class IQueryableLeakFixer : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(IQueryableLeakAnalyzer.DiagnosticId);
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var diagnostic = context.Diagnostics.First();
+        if (!diagnostic.Properties.TryGetValue(IQueryableLeakDiagnosticProperties.FixerEligible, out var fixerEligible) ||
+            fixerEligible != "true")
+        {
+            return;
+        }
+
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+        var expression = node as ExpressionSyntax ?? node.AncestorsAndSelf().OfType<ExpressionSyntax>().FirstOrDefault();
+        if (expression == null)
+            return;
+
+        var replacementTarget = expression.Parent is ParenthesizedExpressionSyntax parenthesizedExpression
+            ? parenthesizedExpression
+            : expression;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Materialize with ToList()",
+                cancellationToken => ApplyFixAsync(context.Document, replacementTarget, cancellationToken),
+                nameof(IQueryableLeakFixer)),
+            diagnostic);
+    }
+
+    private static async Task<Document> ApplyFixAsync(
+        Document document,
+        ExpressionSyntax expression,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        var receiver = ParenthesizeIfNeeded(expression.WithoutTrivia());
+        var fixedExpression = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    receiver,
+                    SyntaxFactory.IdentifierName("ToList")))
+            .WithTriviaFrom(expression);
+
+        editor.ReplaceNode(expression, fixedExpression);
+        editor.EnsureUsing("System.Linq");
+
+        return editor.GetChangedDocument();
+    }
+
+    private static ExpressionSyntax ParenthesizeIfNeeded(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            IdentifierNameSyntax => expression,
+            GenericNameSyntax => expression,
+            MemberAccessExpressionSyntax => expression,
+            InvocationExpressionSyntax => expression,
+            ElementAccessExpressionSyntax => expression,
+            ThisExpressionSyntax => expression,
+            BaseExpressionSyntax => expression,
+            ParenthesizedExpressionSyntax => expression,
+            _ => SyntaxFactory.ParenthesizedExpression(expression)
+        };
+    }
+}

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>4.4.0</Version>
+        <Version>4.5.0</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC004_IQueryableLeak/IQueryableLeakFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC004_IQueryableLeak/IQueryableLeakFixerTests.cs
@@ -1,0 +1,269 @@
+using VerifyFix = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+    LinqContraband.Analyzers.LC004_IQueryableLeak.IQueryableLeakAnalyzer,
+    LinqContraband.Analyzers.LC004_IQueryableLeak.IQueryableLeakFixer>;
+
+namespace LinqContraband.Tests.Analyzers.LC004_IQueryableLeak;
+
+public class IQueryableLeakFixerTests
+{
+    private const string Usings = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using TestNamespace;
+";
+
+    private const string MockNamespace = @"
+namespace TestNamespace
+{
+    public class User
+    {
+        public int Id { get; set; }
+    }
+
+    public class DbContext : IDisposable
+    {
+        public void Dispose() { }
+    }
+
+    public class DbSet<T> : IQueryable<T>
+    {
+        public Type ElementType => typeof(T);
+        public System.Linq.Expressions.Expression Expression => System.Linq.Expressions.Expression.Constant(this);
+        public IQueryProvider Provider => null;
+        public IEnumerator<T> GetEnumerator() => null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null;
+    }
+}
+";
+
+    [Fact]
+    public async Task Fixer_ShouldMaterializePlainArgument()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public void Main()
+        {
+            using var db = new AppDbContext();
+            var query = db.Users.Where(u => u.Id > 10);
+
+            ProcessUsers({|#0:query|});
+        }
+
+        private static void ProcessUsers(IEnumerable<User> users)
+        {
+            foreach (var user in users)
+            {
+                Console.WriteLine(user.Id);
+            }
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public void Main()
+        {
+            using var db = new AppDbContext();
+            var query = db.Users.Where(u => u.Id > 10);
+
+            ProcessUsers(query.ToList());
+        }
+
+        private static void ProcessUsers(IEnumerable<User> users)
+        {
+            foreach (var user in users)
+            {
+                Console.WriteLine(user.Id);
+            }
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyFix.Diagnostic("LC004").WithLocation(0).WithArguments("users", "IEnumerable<User>");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldMaterializeNamedArgument()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public void Main()
+        {
+            using var db = new AppDbContext();
+            var query = db.Users.Where(u => u.Id > 10);
+
+            ProcessUsers(users: {|#0:query|});
+        }
+
+        private static void ProcessUsers(IEnumerable<User> users)
+        {
+            foreach (var user in users)
+            {
+                Console.WriteLine(user.Id);
+            }
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public void Main()
+        {
+            using var db = new AppDbContext();
+            var query = db.Users.Where(u => u.Id > 10);
+
+            ProcessUsers(users: query.ToList());
+        }
+
+        private static void ProcessUsers(IEnumerable<User> users)
+        {
+            foreach (var user in users)
+            {
+                Console.WriteLine(user.Id);
+            }
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyFix.Diagnostic("LC004").WithLocation(0).WithArguments("users", "IEnumerable<User>");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldPreserveParenthesizedQueryExpression()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public void Main()
+        {
+            using var db = new AppDbContext();
+
+            ProcessUsers(({|#0:db.Users.Where(u => u.Id > 10)|}));
+        }
+
+        private static void ProcessUsers(IEnumerable<User> users)
+        {
+            foreach (var user in users)
+            {
+                Console.WriteLine(user.Id);
+            }
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public void Main()
+        {
+            using var db = new AppDbContext();
+
+            ProcessUsers((db.Users.Where(u => u.Id > 10)).ToList());
+        }
+
+        private static void ProcessUsers(IEnumerable<User> users)
+        {
+            foreach (var user in users)
+            {
+                Console.WriteLine(user.Id);
+            }
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyFix.Diagnostic("LC004").WithLocation(0).WithArguments("users", "IEnumerable<User>");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldNotRegister_ForNonGenericQuerySource()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public void Main()
+        {
+            using var db = new AppDbContext();
+            IQueryable query = db.Users.Where(u => u.Id > 10);
+
+            ProcessUsers({|#0:query|});
+        }
+
+        private static void ProcessUsers(IEnumerable users)
+        {
+            foreach (var user in users)
+            {
+                Console.WriteLine(user);
+            }
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyFix.Diagnostic("LC004").WithLocation(0).WithArguments("users", "IEnumerable");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, test);
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC004_IQueryableLeak/IQueryableLeakTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC004_IQueryableLeak/IQueryableLeakTests.cs
@@ -16,14 +16,16 @@ using TestNamespace;
     private const string MockNamespace = @"
 namespace TestNamespace
 {
-    public class User { public int Id { get; set; } }
-    
-    // Mock EF Core classes
-    public class DbContext : IDisposable 
-    { 
-        public void Dispose() {}
+    public class User
+    {
+        public int Id { get; set; }
     }
-    
+
+    public class DbContext : IDisposable
+    {
+        public void Dispose() { }
+    }
+
     public class DbSet<T> : IQueryable<T>
     {
         public Type ElementType => typeof(T);
@@ -32,69 +34,174 @@ namespace TestNamespace
         public IEnumerator<T> GetEnumerator() => null;
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null;
     }
-
-    namespace Microsoft.EntityFrameworkCore
-    {
-        // Just to allow 'using Microsoft.EntityFrameworkCore' if needed, 
-        // but we are using TestNamespace.DbContext
-    }
 }
 ";
 
     [Fact]
-    public async Task Leak_WhenPassingIQueryableToIEnumerableMethod_ShouldTrigger()
+    public async Task Leak_WhenForeachConsumesParameter_ShouldTrigger()
     {
         var test = Usings + @"
-namespace TestApp 
+namespace TestApp
 {
-    public class AppDbContext : DbContext { public DbSet<User> Users { get; set; } }
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
 
-    public class Program
+    public sealed class Program
     {
         public void Main()
         {
             using var db = new AppDbContext();
             var query = db.Users.Where(u => u.Id > 10);
-            
-            // Trigger: passing IQueryable to IEnumerable parameter
+
             ProcessUsers({|LC004:query|});
         }
 
-        public void ProcessUsers(IEnumerable<User> users)
+        private static void ProcessUsers(IEnumerable<User> users)
         {
-            // This forces iteration or cannot be composed
-            foreach(var u in users) { }
+            foreach (var user in users)
+            {
+                Console.WriteLine(user.Id);
+            }
         }
     }
-}" + MockNamespace;
+}
+" + MockNamespace;
 
         await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
-    public async Task NoLeak_WhenPassingToList_ShouldNotTrigger()
+    public async Task Leak_WhenEnumerableTerminalConsumesParameter_ShouldTrigger()
     {
         var test = Usings + @"
-namespace TestApp 
+namespace TestApp
 {
-    public class AppDbContext : DbContext { public DbSet<User> Users { get; set; } }
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
 
-    public class Program
+    public sealed class Program
+    {
+        public bool Main()
+        {
+            using var db = new AppDbContext();
+            var query = db.Users.Where(u => u.Id > 10);
+
+            return HasUsers({|LC004:query|});
+        }
+
+        private static bool HasUsers(IEnumerable<User> users)
+        {
+            return users.Where(u => u.Id > 50).Any();
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Leak_WhenExpressionBodiedMethodConsumesParameter_ShouldTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public bool Main()
+        {
+            using var db = new AppDbContext();
+            var query = db.Users.Where(u => u.Id > 10);
+
+            return HasUsers({|LC004:query|});
+        }
+
+        private static bool HasUsers(IEnumerable<User> users) => users.Any();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Leak_WhenWrapperForwardsToHazardousMethod_ShouldTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
     {
         public void Main()
         {
             using var db = new AppDbContext();
-            
-            // Safe: Explicit materialization
-            ProcessUsers(db.Users.Where(u => u.Id > 10).ToList());
+            var query = db.Users.Where(u => u.Id > 10);
+
+            Wrapper({|LC004:query|});
         }
 
-        public void ProcessUsers(IEnumerable<User> users)
+        private static void Wrapper(IEnumerable<User> users)
         {
-            foreach(var u in users) { }
+            Consume(users);
+        }
+
+        private static void Consume(IEnumerable<User> users)
+        {
+            foreach (var user in users)
+            {
+                Console.WriteLine(user.Id);
+            }
         }
     }
-}" + MockNamespace;
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NoLeak_WhenMethodDoesNotConsumeParameter_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public IEnumerable<User> Main()
+        {
+            using var db = new AppDbContext();
+            var query = db.Users.Where(u => u.Id > 10);
+
+            return Tap(query);
+        }
+
+        private static IEnumerable<User> Tap(IEnumerable<User> users)
+        {
+            Console.WriteLine(nameof(users));
+            return users;
+        }
+    }
+}
+" + MockNamespace;
 
         await VerifyCS.VerifyAnalyzerAsync(test);
     }
@@ -103,27 +210,156 @@ namespace TestApp
     public async Task NoLeak_WhenPassingToIQueryableMethod_ShouldNotTrigger()
     {
         var test = Usings + @"
-namespace TestApp 
+namespace TestApp
 {
-    public class AppDbContext : DbContext { public DbSet<User> Users { get; set; } }
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
 
-    public class Program
+    public sealed class Program
+    {
+        public IQueryable<User> Main()
+        {
+            using var db = new AppDbContext();
+            var query = db.Users.Where(u => u.Id > 10);
+
+            return ProcessUsersQuery(query);
+        }
+
+        private static IQueryable<User> ProcessUsersQuery(IQueryable<User> users)
+        {
+            return users.Where(u => u.Id > 20);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NoLeak_WhenPassingToFrameworkMethod_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public string Main()
+        {
+            using var db = new AppDbContext();
+
+            return string.Join("","", db.Users.Where(u => u.Id > 10).Select(u => u.Id));
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NoLeak_WhenMethodHasNoSourceBody_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public interface IUserProcessor
+    {
+        void Process(IEnumerable<User> users);
+    }
+
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public void Main(IUserProcessor processor)
+        {
+            using var db = new AppDbContext();
+            var query = db.Users.Where(u => u.Id > 10);
+
+            processor.Process(query);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NoLeak_WhenCallingDelegateInvoke_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
     {
         public void Main()
         {
             using var db = new AppDbContext();
             var query = db.Users.Where(u => u.Id > 10);
-            
-            // Safe: Target accepts IQueryable
-            ProcessUsersQuery(query);
-        }
+            Action<IEnumerable<User>> sink = users =>
+            {
+                foreach (var user in users)
+                {
+                    Console.WriteLine(user.Id);
+                }
+            };
 
-        public void ProcessUsersQuery(IQueryable<User> users)
-        {
-            var list = users.ToList();
+            sink(query);
         }
     }
-}" + MockNamespace;
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NoLeak_WhenArgumentIsAlreadyMaterialized_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public sealed class AppDbContext : DbContext
+    {
+        public DbSet<User> Users { get; set; }
+    }
+
+    public sealed class Program
+    {
+        public void Main()
+        {
+            using var db = new AppDbContext();
+
+            ProcessUsers(db.Users.Where(u => u.Id > 10).ToList());
+        }
+
+        private static void ProcessUsers(IEnumerable<User> users)
+        {
+            foreach (var user in users)
+            {
+                Console.WriteLine(user.Id);
+            }
+        }
+    }
+}
+" + MockNamespace;
 
         await VerifyCS.VerifyAnalyzerAsync(test);
     }


### PR DESCRIPTION
## Summary
- move LC004 to proof-based same-compilation analysis with cached hazardous-parameter summaries
- add a guarded caller-side ToList fixer and expand LC004 analyzer/fixer coverage
- bump package metadata to 4.5.0 and document the shipped LC004 contract in the changelog/docs

## Verification
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --filter IQueryableLeak -f net9.0
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --filter IQueryableLeak -f net10.0
- dotnet test LinqContraband.sln -f net9.0
- dotnet test LinqContraband.sln -f net10.0
- dotnet pack src/LinqContraband/LinqContraband.csproj -c Release