### PR TITLE
Add LC033 FrozenSet membership cache analyzer and fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The analyzer will immediately start scanning your code for contraband.
 
 ## 👮‍♂️ The Rules
 
-> **32 rules** covering performance, correctness, and design pitfalls in Entity Framework Core queries.
+> **33 rules** covering performance, correctness, and design pitfalls in Entity Framework Core queries.
 
 ### LC001: The Local Method Smuggler
 
@@ -1086,6 +1086,41 @@ not offer an automatic fixer.
 
 ---
 
+### LC033: FrozenSet Membership Cache
+
+If a `private static readonly HashSet<T>` is initialized once and then used only for `Contains(...)`, you are paying
+for mutability you never use. On .NET 8+, `FrozenSet<T>` is a better fit for these membership caches.
+
+**👶 Explain it like I'm a ten year old:** Imagine you made a VIP guest list and then laminated it forever. You do not
+need an editable whiteboard anymore. A laminated list is faster to check and nobody can accidentally scribble on it.
+
+**❌ The Crime:**
+
+```csharp
+private static readonly HashSet<string> ElevatedRoles = new(StringComparer.OrdinalIgnoreCase)
+{
+    "admin",
+    "ops"
+};
+
+var elevated = roles.Where(role => ElevatedRoles.Contains(role)).ToList();
+```
+
+**✅ The Fix:**
+Convert the cache to `FrozenSet<T>` when the set is built once and only used for membership checks.
+
+```csharp
+private static readonly FrozenSet<string> ElevatedRoles = new string[] { "admin", "ops" }
+    .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+```
+
+**🛡️ Reliability Notes:**
+- LC033 only reports `private static readonly HashSet<T>` fields with inline initializers that can be rewritten safely.
+- It requires every source reference in the compilation to be a direct `Contains(...)` use and skips aliases, enumeration, mutation, and expression-tree usage.
+- The fixer is intentionally narrow and bails out if the field declaration no longer matches the analyzer-proven shape.
+
+---
+
 ## ⚙️ Configuration
 
 You can configure the severity of these rules in your `.editorconfig` file:
@@ -1097,8 +1132,8 @@ dotnet_diagnostic.LC002.severity = error
 dotnet_diagnostic.LC003.severity = warning
 ```
 
-Advisory rules such as `LC009`, `LC017`, `LC023`, `LC026`, `LC027`, `LC029`, `LC030`, `LC031`, and `LC032` default to
-`Info` so they surface as hints without drowning out higher-confidence warnings.
+Advisory rules such as `LC009`, `LC017`, `LC023`, `LC026`, `LC027`, `LC029`, `LC030`, `LC031`, `LC032`, and `LC033`
+default to `Info` so they surface as hints without drowning out higher-confidence warnings.
 
 ## 🤝 Contributing
 

--- a/docs/LC033_UseFrozenSetForStaticMembershipCaches.md
+++ b/docs/LC033_UseFrozenSetForStaticMembershipCaches.md
@@ -1,0 +1,48 @@
+# Spec: LC033 - Use FrozenSet for Provably Read-Only Static Membership Caches
+
+## Goal
+Detect `private static readonly HashSet<T>` membership caches that can be safely converted to `FrozenSet<T>` on .NET 8+.
+
+## The Problem
+`HashSet<T>` is mutable and optimized for general-purpose set operations. When a cache is initialized once, never mutated, and only used for `Contains(...)`, `FrozenSet<T>` is a better fit: it trades construction cost for faster steady-state lookups and lower ongoing overhead.
+
+### Example Violation
+```csharp
+private static readonly HashSet<string> ElevatedRoles = new(StringComparer.OrdinalIgnoreCase)
+{
+    "admin",
+    "ops"
+};
+
+static bool IsElevated(string role) => ElevatedRoles.Contains(role);
+```
+
+### The Fix
+Convert the cache to `FrozenSet<T>` and build it once with `ToFrozenSet(...)`.
+
+```csharp
+private static readonly FrozenSet<string> ElevatedRoles = new string[]
+{
+    "admin",
+    "ops"
+}.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+```
+
+## Analyzer Logic
+
+### ID: `LC033`
+### Category: `Performance`
+### Severity: `Info`
+
+### Algorithm
+1. Require a source-declared `private static readonly HashSet<T>` field with a single declarator and an inline initializer.
+2. Require `System.Collections.Frozen.FrozenSet<T>` and `ToFrozenSet(...)` to be available in the compilation.
+3. Accept only fixer-safe initializer shapes:
+   - collection initializer forms (`new HashSet<T>() { ... }`, optionally with a comparer),
+   - `new HashSet<T>(source[, comparer])`,
+   - `source.ToHashSet([comparer])`.
+4. Track every source reference to the field across the compilation and require every usage to be a direct `Contains(...)` call.
+5. Skip any field used in `IQueryable` / expression-tree contexts, passed around through aliases, mutated, enumerated, or touched through any non-`Contains` member.
+
+## Notes
+This rule is intentionally narrow. If there is any ambiguity about initialization, mutability, or usage shape, it stays silent instead of suggesting a speculative rewrite.

--- a/samples/LinqContraband.Sample/Program.cs
+++ b/samples/LinqContraband.Sample/Program.cs
@@ -22,6 +22,7 @@ using LinqContraband.Sample.Samples.LC026_MissingCancellationToken;
 using LinqContraband.Sample.Samples.LC029_RedundantIdentitySelect;
 using LinqContraband.Sample.Samples.LC030_DbContextInSingleton;
 using LinqContraband.Sample.Samples.LC032_ExecuteUpdateForBulkUpdates;
+using LinqContraband.Sample.Samples.LC033_UseFrozenSetForStaticMembershipCaches;
 
 namespace LinqContraband.Sample;
 
@@ -61,10 +62,11 @@ internal class Program
         FindInsteadOfFirstOrDefaultSample.Run(db);
         AsNoTrackingWithUpdateSample.Run(db);
 
-        // LC026 - LC032
+        // LC026 - LC033
         await MissingCancellationTokenSample.RunAsync(db, CancellationToken.None);
         RedundantIdentitySelectSample.Run(users);
         new DbContextInSingletonSample(db).Run();
         ExecuteUpdateForBulkUpdatesSample.Run();
+        UseFrozenSetForStaticMembershipCachesSample.Run();
     }
 }

--- a/samples/LinqContraband.Sample/Samples/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesSample.cs
+++ b/samples/LinqContraband.Sample/Samples/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesSample.cs
@@ -1,0 +1,21 @@
+namespace LinqContraband.Sample.Samples.LC033_UseFrozenSetForStaticMembershipCaches;
+
+public static class UseFrozenSetForStaticMembershipCachesSample
+{
+    private static readonly HashSet<string> ElevatedRoles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "admin",
+        "ops"
+    };
+
+    public static void Run()
+    {
+        Console.WriteLine("Testing LC033...");
+
+        var roles = new List<string> { "admin", "guest" };
+
+        // ADVISORY: This cache is read-only and used only for membership checks.
+        var elevatedRoles = roles.Where(role => ElevatedRoles.Contains(role)).ToList();
+        Console.WriteLine(elevatedRoles.Count);
+    }
+}

--- a/src/LinqContraband/Analyzers/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesAnalysis.cs
@@ -1,0 +1,251 @@
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches;
+
+internal static class UseFrozenSetForStaticMembershipCachesDiagnosticProperties
+{
+    public const string FixerEligible = "LC033.FixerEligible";
+}
+
+internal enum FrozenSetInitializerKind
+{
+    CollectionInitializer,
+    SourceConstructor,
+    ToHashSetInvocation
+}
+
+internal readonly struct FrozenSetSupport
+{
+    public FrozenSetSupport(
+        INamedTypeSymbol hashSetType,
+        INamedTypeSymbol frozenSetType,
+        INamedTypeSymbol expressionType,
+        ImmutableArray<IMethodSymbol> toFrozenSetMethods)
+    {
+        HashSetType = hashSetType;
+        FrozenSetType = frozenSetType;
+        ExpressionType = expressionType;
+        ToFrozenSetMethods = toFrozenSetMethods;
+    }
+
+    public INamedTypeSymbol HashSetType { get; }
+    public INamedTypeSymbol FrozenSetType { get; }
+    public INamedTypeSymbol ExpressionType { get; }
+    public ImmutableArray<IMethodSymbol> ToFrozenSetMethods { get; }
+}
+
+internal static class UseFrozenSetForStaticMembershipCachesAnalysis
+{
+    public static bool TryGetFrozenSetSupport(Compilation compilation, out FrozenSetSupport support)
+    {
+        support = default;
+
+        var hashSetType = compilation.GetTypeByMetadataName("System.Collections.Generic.HashSet`1");
+        var frozenSetType = compilation.GetTypeByMetadataName("System.Collections.Frozen.FrozenSet`1");
+        var expressionType = compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
+
+        if (hashSetType is null || frozenSetType is null || expressionType is null)
+            return false;
+
+        var toFrozenSetMethods = compilation
+            .GetSymbolsWithName(static name => name == "ToFrozenSet", SymbolFilter.Member)
+            .OfType<IMethodSymbol>()
+            .Where(static method => method.IsExtensionMethod)
+            .Where(method => method.ContainingNamespace?.ToDisplayString() == "System.Collections.Frozen")
+            .Where(method => method.ReturnType is INamedTypeSymbol returnType &&
+                             SymbolEqualityComparer.Default.Equals(returnType.OriginalDefinition, frozenSetType))
+            .ToImmutableArray();
+
+        if (toFrozenSetMethods.IsDefaultOrEmpty)
+            return false;
+
+        support = new FrozenSetSupport(hashSetType, frozenSetType, expressionType, toFrozenSetMethods);
+        return true;
+    }
+
+    public static bool IsHashSetType(ITypeSymbol? type, INamedTypeSymbol hashSetType)
+    {
+        return type is INamedTypeSymbol namedType &&
+               SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, hashSetType);
+    }
+
+    public static bool IsExpressionType(ITypeSymbol? type, INamedTypeSymbol expressionType)
+    {
+        return type is INamedTypeSymbol namedType &&
+               SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, expressionType);
+    }
+
+    public static bool TryClassifyInitializer(
+        ExpressionSyntax initializerSyntax,
+        SemanticModel semanticModel,
+        FrozenSetSupport support,
+        CancellationToken cancellationToken,
+        out FrozenSetInitializerKind kind)
+    {
+        kind = default;
+
+        if (semanticModel.GetOperation(initializerSyntax, cancellationToken)?.UnwrapConversions() is not IOperation operation)
+            return false;
+
+        switch (operation)
+        {
+            case IObjectCreationOperation creation when IsHashSetType(creation.Type, support.HashSetType):
+                if (IsSupportedCollectionInitializer(creation, support))
+                {
+                    kind = FrozenSetInitializerKind.CollectionInitializer;
+                    return true;
+                }
+
+                if (IsSupportedSourceConstructor(creation, support))
+                {
+                    kind = FrozenSetInitializerKind.SourceConstructor;
+                    return true;
+                }
+
+                return false;
+
+            case IInvocationOperation invocation when IsSupportedToHashSetInvocation(invocation, semanticModel, support, cancellationToken):
+                kind = FrozenSetInitializerKind.ToHashSetInvocation;
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool IsSupportedCollectionInitializer(IObjectCreationOperation creation, FrozenSetSupport support)
+    {
+        if (creation.Initializer is null)
+            return false;
+
+        if (creation.Arguments.Length == 0)
+            return AllInitializersAreAddCalls(creation.Initializer);
+
+        if (creation.Arguments.Length == 1 &&
+            creation.Type is INamedTypeSymbol hashSetType &&
+            IsEqualityComparerType(creation.Constructor?.Parameters[0].Type, hashSetType.TypeArguments[0]))
+        {
+            return AllInitializersAreAddCalls(creation.Initializer);
+        }
+
+        return false;
+    }
+
+    private static bool IsSupportedSourceConstructor(IObjectCreationOperation creation, FrozenSetSupport support)
+    {
+        if (creation.Initializer is not null || creation.Constructor is null)
+            return false;
+
+        var parameters = creation.Constructor.Parameters;
+        if (creation.Type is not INamedTypeSymbol hashSetType)
+            return false;
+
+        if (parameters.Length == 1)
+            return IsEnumerableType(parameters[0].Type, hashSetType.TypeArguments[0]);
+
+        return parameters.Length == 2 &&
+               IsEnumerableType(parameters[0].Type, hashSetType.TypeArguments[0]) &&
+               IsEqualityComparerType(parameters[1].Type, hashSetType.TypeArguments[0]);
+    }
+
+    private static bool IsSupportedToHashSetInvocation(
+        IInvocationOperation invocation,
+        SemanticModel semanticModel,
+        FrozenSetSupport support,
+        CancellationToken cancellationToken)
+    {
+        if (invocation.TargetMethod.Name != "ToHashSet" ||
+            !invocation.TargetMethod.IsExtensionMethod ||
+            !invocation.TargetMethod.IsFrameworkMethod() ||
+            !IsHashSetType(invocation.Type, support.HashSetType))
+        {
+            return false;
+        }
+
+        if (invocation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
+            invocationSyntax.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return false;
+        }
+
+        if (invocation.Arguments.Length is not (1 or 2))
+            return false;
+
+        if (IsStaticTypeOrNamespaceAccess(memberAccess.Expression, semanticModel, cancellationToken))
+            return false;
+
+        var parameters = invocation.TargetMethod.Parameters;
+        if (parameters.Length == 1)
+            return IsEnumerableType(parameters[0].Type, invocation.Type is INamedTypeSymbol named ? named.TypeArguments[0] : null);
+
+        return parameters.Length == 2 &&
+               IsEnumerableType(parameters[0].Type, invocation.Type is INamedTypeSymbol type ? type.TypeArguments[0] : null) &&
+               IsEqualityComparerType(parameters[1].Type, invocation.Type is INamedTypeSymbol comparerType ? comparerType.TypeArguments[0] : null);
+    }
+
+    private static bool IsStaticTypeOrNamespaceAccess(
+        ExpressionSyntax receiverExpression,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var symbolInfo = semanticModel.GetSymbolInfo(receiverExpression, cancellationToken);
+        if (IsTypeOrNamespaceSymbol(symbolInfo.Symbol))
+            return true;
+
+        return symbolInfo.CandidateSymbols.Any(IsTypeOrNamespaceSymbol);
+    }
+
+    private static bool IsTypeOrNamespaceSymbol(ISymbol? symbol)
+    {
+        return symbol switch
+        {
+            ITypeSymbol => true,
+            INamespaceSymbol => true,
+            IAliasSymbol { Target: ITypeSymbol or INamespaceSymbol } => true,
+            _ => false
+        };
+    }
+
+    private static bool AllInitializersAreAddCalls(IObjectOrCollectionInitializerOperation initializer)
+    {
+        return initializer.Initializers.All(operation =>
+            operation is IInvocationOperation invocation &&
+            invocation.TargetMethod.Name == "Add" &&
+            invocation.Arguments.Length == 1);
+    }
+
+    private static bool IsEnumerableType(ITypeSymbol? type, ITypeSymbol? elementType)
+    {
+        if (type is not INamedTypeSymbol namedType || elementType is null)
+            return false;
+
+        if (IsEnumerableInterface(namedType, elementType))
+            return true;
+
+        return namedType.AllInterfaces.OfType<INamedTypeSymbol>().Any(interfaceType => IsEnumerableInterface(interfaceType, elementType));
+    }
+
+    private static bool IsEnumerableInterface(INamedTypeSymbol type, ITypeSymbol elementType)
+    {
+        return type.Name == "IEnumerable" &&
+               type.ContainingNamespace?.ToDisplayString() == "System.Collections.Generic" &&
+               type.TypeArguments.Length == 1 &&
+               SymbolEqualityComparer.Default.Equals(type.TypeArguments[0], elementType);
+    }
+
+    private static bool IsEqualityComparerType(ITypeSymbol? type, ITypeSymbol? elementType)
+    {
+        return type is INamedTypeSymbol namedType &&
+               elementType is not null &&
+               namedType.Name == "IEqualityComparer" &&
+               namedType.ContainingNamespace?.ToDisplayString() == "System.Collections.Generic" &&
+               namedType.TypeArguments.Length == 1 &&
+               SymbolEqualityComparer.Default.Equals(namedType.TypeArguments[0], elementType);
+    }
+}

--- a/src/LinqContraband/Analyzers/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesAnalyzer.cs
@@ -1,0 +1,226 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Linq;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseFrozenSetForStaticMembershipCachesAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "LC033";
+    private const string Category = "Performance";
+    private static readonly LocalizableString Title = "Use FrozenSet for provably read-only membership caches";
+
+    private static readonly LocalizableString MessageFormat =
+        "Field '{0}' is a provably read-only membership cache. Consider FrozenSet<T> for faster steady-state Contains lookups on .NET 8+.";
+
+    private static readonly LocalizableString Description =
+        "Reports only when a private static readonly HashSet<T> has a fixer-safe initializer and every source reference is a direct Contains call outside IQueryable or expression-tree contexts.";
+
+    internal static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        Category,
+        DiagnosticSeverity.Info,
+        true,
+        Description,
+        helpLinkUri: "https://github.com/georgewall/LinqContraband/blob/main/docs/LC033_UseFrozenSetForStaticMembershipCaches.md",
+        customTags: new[] { WellKnownDiagnosticTags.CompilationEnd });
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterCompilationStartAction(InitializeCompilation);
+    }
+
+    private static void InitializeCompilation(CompilationStartAnalysisContext context)
+    {
+        if (!UseFrozenSetForStaticMembershipCachesAnalysis.TryGetFrozenSetSupport(context.Compilation, out var support))
+            return;
+
+        var state = new AnalysisState(context.Compilation, support);
+        context.RegisterSymbolAction(state.AnalyzeField, SymbolKind.Field);
+        context.RegisterOperationAction(state.AnalyzeFieldReference, OperationKind.FieldReference);
+        context.RegisterCompilationEndAction(state.ReportDiagnostics);
+    }
+
+    private sealed class AnalysisState
+    {
+        private readonly Compilation _compilation;
+        private readonly FrozenSetSupport _support;
+        private readonly ConcurrentDictionary<IFieldSymbol, CandidateField> _candidates =
+            new(SymbolEqualityComparer.Default);
+        private readonly ConcurrentDictionary<IFieldSymbol, int> _allowedUsageCounts =
+            new(SymbolEqualityComparer.Default);
+        private readonly ConcurrentDictionary<IFieldSymbol, byte> _disallowedUsages =
+            new(SymbolEqualityComparer.Default);
+
+        public AnalysisState(Compilation compilation, FrozenSetSupport support)
+        {
+            _compilation = compilation;
+            _support = support;
+        }
+
+        public void AnalyzeField(SymbolAnalysisContext context)
+        {
+            var field = (IFieldSymbol)context.Symbol;
+            if (!IsPotentialCandidate(field))
+                return;
+
+            if (!TryGetSingleFieldDeclaration(field, context.CancellationToken, out var fieldDeclaration))
+                return;
+
+            var declarator = fieldDeclaration.Declaration.Variables[0];
+            if (declarator.Initializer?.Value is not ExpressionSyntax initializerSyntax)
+                return;
+
+            var semanticModel = _compilation.GetSemanticModel(initializerSyntax.SyntaxTree);
+            if (!UseFrozenSetForStaticMembershipCachesAnalysis.TryClassifyInitializer(
+                    initializerSyntax,
+                    semanticModel,
+                    _support,
+                    context.CancellationToken,
+                    out _))
+            {
+                return;
+            }
+
+            _candidates.TryAdd(field, new CandidateField(field, fieldDeclaration.GetLocation()));
+        }
+
+        public void AnalyzeFieldReference(OperationAnalysisContext context)
+        {
+            var fieldReference = (IFieldReferenceOperation)context.Operation;
+            var field = fieldReference.Field;
+
+            if (!IsPotentialCandidate(field))
+                return;
+
+            if (IsAllowedContainsUsage(fieldReference))
+            {
+                _allowedUsageCounts.AddOrUpdate(field, 1, static (_, count) => count + 1);
+                return;
+            }
+
+            _disallowedUsages.TryAdd(field, 0);
+        }
+
+        public void ReportDiagnostics(CompilationAnalysisContext context)
+        {
+            var properties = ImmutableDictionary<string, string?>.Empty.Add(
+                UseFrozenSetForStaticMembershipCachesDiagnosticProperties.FixerEligible,
+                "true");
+
+            foreach (var pair in _candidates)
+            {
+                var field = pair.Key;
+                var candidate = pair.Value;
+
+                if (_disallowedUsages.ContainsKey(field))
+                    continue;
+
+                if (!_allowedUsageCounts.TryGetValue(field, out var allowedCount) || allowedCount == 0)
+                    continue;
+
+                context.ReportDiagnostic(Diagnostic.Create(Rule, candidate.Location, properties, field.Name));
+            }
+        }
+
+        private bool IsPotentialCandidate(IFieldSymbol field)
+        {
+            return field.Locations.Any(static location => location.IsInSource) &&
+                   field.DeclaredAccessibility == Accessibility.Private &&
+                   field.IsStatic &&
+                   field.IsReadOnly &&
+                   UseFrozenSetForStaticMembershipCachesAnalysis.IsHashSetType(field.Type, _support.HashSetType);
+        }
+
+        private bool TryGetSingleFieldDeclaration(
+            IFieldSymbol field,
+            System.Threading.CancellationToken cancellationToken,
+            out FieldDeclarationSyntax fieldDeclaration)
+        {
+            fieldDeclaration = null!;
+
+            if (field.DeclaringSyntaxReferences.Length != 1 ||
+                field.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken) is not VariableDeclaratorSyntax declarator ||
+                declarator.Parent?.Parent is not FieldDeclarationSyntax declaration)
+            {
+                return false;
+            }
+
+            if (declaration.Declaration.Variables.Count != 1)
+                return false;
+
+            fieldDeclaration = declaration;
+            return true;
+        }
+
+        private bool IsAllowedContainsUsage(IFieldReferenceOperation fieldReference)
+        {
+            if (fieldReference.Parent is not IInvocationOperation invocation)
+                return false;
+
+            if (invocation.TargetMethod.Name != "Contains" ||
+                invocation.TargetMethod.IsExtensionMethod ||
+                invocation.Arguments.Length != 1 ||
+                invocation.Type?.SpecialType != SpecialType.System_Boolean)
+            {
+                return false;
+            }
+
+            if (invocation.Instance?.UnwrapConversions() is not IFieldReferenceOperation receiver ||
+                !SymbolEqualityComparer.Default.Equals(receiver.Field, fieldReference.Field))
+            {
+                return false;
+            }
+
+            return !IsInExpressionTree(invocation);
+        }
+
+        private bool IsInExpressionTree(IOperation operation)
+        {
+            for (var current = operation; current != null; current = current.Parent)
+            {
+                if (current is not IAnonymousFunctionOperation anonymousFunction)
+                    continue;
+
+                var parent = anonymousFunction.Parent;
+                while (parent is IConversionOperation or IDelegateCreationOperation or IParenthesizedOperation)
+                {
+                    if (UseFrozenSetForStaticMembershipCachesAnalysis.IsExpressionType(parent.Type, _support.ExpressionType))
+                        return true;
+
+                    parent = parent.Parent;
+                }
+
+                if (UseFrozenSetForStaticMembershipCachesAnalysis.IsExpressionType(parent?.Type, _support.ExpressionType))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    private sealed class CandidateField
+    {
+        public CandidateField(IFieldSymbol field, Location location)
+        {
+            Field = field;
+            Location = location;
+        }
+
+        public IFieldSymbol Field { get; }
+        public Location Location { get; }
+    }
+}

--- a/src/LinqContraband/Analyzers/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesFixer.cs
+++ b/src/LinqContraband/Analyzers/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesFixer.cs
@@ -1,0 +1,296 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Simplification;
+
+namespace LinqContraband.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseFrozenSetForStaticMembershipCachesFixer))]
+[Shared]
+public sealed class UseFrozenSetForStaticMembershipCachesFixer : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(UseFrozenSetForStaticMembershipCachesAnalyzer.DiagnosticId);
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var diagnostic = context.Diagnostics.First();
+        if (!diagnostic.Properties.TryGetValue(UseFrozenSetForStaticMembershipCachesDiagnosticProperties.FixerEligible, out var fixerEligible) ||
+            fixerEligible != "true")
+        {
+            return;
+        }
+
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+        var fieldDeclaration = node as FieldDeclarationSyntax ??
+                               node.AncestorsAndSelf().OfType<FieldDeclarationSyntax>().FirstOrDefault();
+        if (fieldDeclaration?.Declaration.Variables.Count != 1)
+            return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Convert to FrozenSet",
+                cancellationToken => ApplyFixAsync(context.Document, fieldDeclaration, cancellationToken),
+                nameof(UseFrozenSetForStaticMembershipCachesFixer)),
+            diagnostic);
+    }
+
+    private static async Task<Document> ApplyFixAsync(
+        Document document,
+        FieldDeclarationSyntax fieldDeclaration,
+        CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null ||
+            !UseFrozenSetForStaticMembershipCachesAnalysis.TryGetFrozenSetSupport(semanticModel.Compilation, out var support))
+        {
+            return document;
+        }
+
+        var variable = fieldDeclaration.Declaration.Variables[0];
+        if (semanticModel.GetDeclaredSymbol(variable, cancellationToken) is not IFieldSymbol fieldSymbol ||
+            fieldSymbol.Type is not INamedTypeSymbol fieldType ||
+            fieldType.TypeArguments.Length != 1)
+        {
+            return document;
+        }
+
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var elementType = fieldType.TypeArguments[0];
+        var elementTypeSyntax = CreateTypeSyntax(editor.Generator, elementType);
+
+        if (variable.Initializer?.Value is not ExpressionSyntax initializerSyntax ||
+            !UseFrozenSetForStaticMembershipCachesAnalysis.TryClassifyInitializer(
+                initializerSyntax,
+                semanticModel,
+                support,
+                cancellationToken,
+                out var initializerKind) ||
+            !TryRewriteInitializer(initializerSyntax, initializerKind, elementTypeSyntax, semanticModel, support, cancellationToken, out var rewrittenInitializer))
+        {
+            return document;
+        }
+
+        var rewrittenVariable = variable.WithInitializer(variable.Initializer.WithValue(rewrittenInitializer));
+        var rewrittenType = CreateTypeSyntax(editor.Generator, support.FrozenSetType.Construct(elementType))
+            .WithTriviaFrom(fieldDeclaration.Declaration.Type);
+        var rewrittenFieldDeclaration = fieldDeclaration.WithDeclaration(
+            fieldDeclaration.Declaration
+                .WithType(rewrittenType)
+                .WithVariables(SyntaxFactory.SingletonSeparatedList(rewrittenVariable)))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        editor.ReplaceNode(fieldDeclaration, rewrittenFieldDeclaration);
+        editor.EnsureUsing("System.Collections.Frozen");
+
+        var changedDocument = editor.GetChangedDocument();
+        var simplifiedDocument = await Simplifier.ReduceAsync(
+            changedDocument,
+            Simplifier.Annotation,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return await Formatter.FormatAsync(
+            simplifiedDocument,
+            Formatter.Annotation,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool TryRewriteInitializer(
+        ExpressionSyntax initializerSyntax,
+        FrozenSetInitializerKind initializerKind,
+        TypeSyntax elementTypeSyntax,
+        SemanticModel semanticModel,
+        FrozenSetSupport support,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax rewrittenInitializer)
+    {
+        rewrittenInitializer = null!;
+
+        switch (initializerKind)
+        {
+            case FrozenSetInitializerKind.CollectionInitializer:
+                return TryRewriteCollectionInitializer(initializerSyntax, elementTypeSyntax, semanticModel, support, cancellationToken, out rewrittenInitializer);
+
+            case FrozenSetInitializerKind.SourceConstructor:
+                return TryRewriteSourceConstructor(initializerSyntax, semanticModel, support, cancellationToken, out rewrittenInitializer);
+
+            case FrozenSetInitializerKind.ToHashSetInvocation:
+                return TryRewriteToHashSetInvocation(initializerSyntax, semanticModel, support, cancellationToken, out rewrittenInitializer);
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryRewriteCollectionInitializer(
+        ExpressionSyntax initializerSyntax,
+        TypeSyntax elementTypeSyntax,
+        SemanticModel semanticModel,
+        FrozenSetSupport support,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax rewrittenInitializer)
+    {
+        rewrittenInitializer = null!;
+
+        if (semanticModel.GetOperation(initializerSyntax, cancellationToken)?.UnwrapConversions() is not IObjectCreationOperation creation ||
+            creation.Initializer is null ||
+            !UseFrozenSetForStaticMembershipCachesAnalysis.TryClassifyInitializer(
+                initializerSyntax,
+                semanticModel,
+                support,
+                cancellationToken,
+                out var initializerKind) ||
+            initializerKind != FrozenSetInitializerKind.CollectionInitializer)
+        {
+            return false;
+        }
+
+        var syntaxInitializer = creation.Syntax switch
+        {
+            ObjectCreationExpressionSyntax objectCreation => objectCreation.Initializer,
+            ImplicitObjectCreationExpressionSyntax implicitObjectCreation => implicitObjectCreation.Initializer,
+            _ => null
+        };
+
+        if (syntaxInitializer is null)
+            return false;
+
+        var arrayInitializer = SyntaxFactory.InitializerExpression(
+            SyntaxKind.ArrayInitializerExpression,
+            syntaxInitializer.Expressions);
+
+        var arrayType = SyntaxFactory.ArrayType(
+            elementTypeSyntax.WithoutTrivia(),
+            SyntaxFactory.SingletonList(
+                SyntaxFactory.ArrayRankSpecifier(
+                    SyntaxFactory.SingletonSeparatedList<ExpressionSyntax>(SyntaxFactory.OmittedArraySizeExpression()))));
+
+        var arrayCreation = SyntaxFactory.ArrayCreationExpression(arrayType, arrayInitializer);
+        var comparerArgument = creation.Arguments.Length == 1
+            ? creation.Arguments[0].Value.Syntax as ExpressionSyntax
+            : null;
+
+        rewrittenInitializer = CreateToFrozenSetInvocation(arrayCreation, comparerArgument).WithTriviaFrom(initializerSyntax);
+        return true;
+    }
+
+    private static bool TryRewriteSourceConstructor(
+        ExpressionSyntax initializerSyntax,
+        SemanticModel semanticModel,
+        FrozenSetSupport support,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax rewrittenInitializer)
+    {
+        rewrittenInitializer = null!;
+
+        if (semanticModel.GetOperation(initializerSyntax, cancellationToken)?.UnwrapConversions() is not IObjectCreationOperation creation ||
+            !UseFrozenSetForStaticMembershipCachesAnalysis.TryClassifyInitializer(
+                initializerSyntax,
+                semanticModel,
+                support,
+                cancellationToken,
+                out var initializerKind) ||
+            initializerKind != FrozenSetInitializerKind.SourceConstructor ||
+            creation.Arguments.Length is < 1 or > 2 ||
+            creation.Arguments[0].Value.Syntax is not ExpressionSyntax sourceExpression)
+        {
+            return false;
+        }
+
+        var comparerArgument = creation.Arguments.Length == 2
+            ? creation.Arguments[1].Value.Syntax as ExpressionSyntax
+            : null;
+
+        rewrittenInitializer = CreateToFrozenSetInvocation(sourceExpression, comparerArgument).WithTriviaFrom(initializerSyntax);
+        return true;
+    }
+
+    private static bool TryRewriteToHashSetInvocation(
+        ExpressionSyntax initializerSyntax,
+        SemanticModel semanticModel,
+        FrozenSetSupport support,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax rewrittenInitializer)
+    {
+        rewrittenInitializer = null!;
+
+        if (semanticModel.GetOperation(initializerSyntax, cancellationToken)?.UnwrapConversions() is not IInvocationOperation invocation ||
+            !UseFrozenSetForStaticMembershipCachesAnalysis.TryClassifyInitializer(
+                initializerSyntax,
+                semanticModel,
+                support,
+                cancellationToken,
+                out var initializerKind) ||
+            initializerKind != FrozenSetInitializerKind.ToHashSetInvocation ||
+            initializerSyntax is not InvocationExpressionSyntax invocationSyntax ||
+            invocationSyntax.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return false;
+        }
+
+        rewrittenInitializer = invocationSyntax
+            .WithExpression(memberAccess.WithName(SyntaxFactory.IdentifierName("ToFrozenSet")))
+            .WithTriviaFrom(initializerSyntax);
+        return true;
+    }
+
+    private static ExpressionSyntax CreateToFrozenSetInvocation(ExpressionSyntax sourceExpression, ExpressionSyntax? comparerArgument)
+    {
+        var receiver = ParenthesizeIfNeeded(sourceExpression.WithoutTrivia());
+        var memberAccess = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            receiver,
+            SyntaxFactory.IdentifierName("ToFrozenSet"));
+
+        if (comparerArgument is null)
+            return SyntaxFactory.InvocationExpression(memberAccess);
+
+        return SyntaxFactory.InvocationExpression(
+            memberAccess,
+            SyntaxFactory.ArgumentList(
+                SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(comparerArgument.WithoutTrivia()))));
+    }
+
+    private static TypeSyntax CreateTypeSyntax(SyntaxGenerator generator, ITypeSymbol typeSymbol)
+    {
+        return ((TypeSyntax)generator.TypeExpression(typeSymbol))
+            .WithAdditionalAnnotations(Simplifier.Annotation);
+    }
+
+    private static ExpressionSyntax ParenthesizeIfNeeded(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            IdentifierNameSyntax => expression,
+            GenericNameSyntax => expression,
+            MemberAccessExpressionSyntax => expression,
+            InvocationExpressionSyntax => expression,
+            ElementAccessExpressionSyntax => expression,
+            ThisExpressionSyntax => expression,
+            BaseExpressionSyntax => expression,
+            ParenthesizedExpressionSyntax => expression,
+            ArrayCreationExpressionSyntax => expression,
+            ImplicitArrayCreationExpressionSyntax => expression,
+            ImplicitObjectCreationExpressionSyntax => expression,
+            ObjectCreationExpressionSyntax => expression,
+            _ => SyntaxFactory.ParenthesizedExpression(expression)
+        };
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesFixerTests.cs
@@ -1,0 +1,454 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Testing;
+using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
+    LinqContraband.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches.UseFrozenSetForStaticMembershipCachesAnalyzer,
+    LinqContraband.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches.UseFrozenSetForStaticMembershipCachesFixer,
+    Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+using VerifyFix = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+    LinqContraband.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches.UseFrozenSetForStaticMembershipCachesAnalyzer,
+    LinqContraband.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches.UseFrozenSetForStaticMembershipCachesFixer>;
+
+namespace LinqContraband.Tests.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches;
+
+public class UseFrozenSetForStaticMembershipCachesFixerTests
+{
+    private const string Usings = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+";
+
+    private const string FrozenSupport = @"
+namespace System.Collections.Frozen
+{
+    using System.Collections.Generic;
+
+    public abstract class FrozenSet<T> : IEnumerable<T>
+    {
+        public abstract bool Contains(T item);
+        public abstract IEnumerator<T> GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static class FrozenSetExtensions
+    {
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source) => null;
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer) => null;
+    }
+}
+";
+
+    [Fact]
+    public async Task CollectionInitializer_WithComparer_RewritesToFrozenSet()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    {|#0:private static readonly HashSet<string> ElevatedRoles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ""admin"",
+        ""ops""
+    };|}
+
+    static bool IsElevated(string role) => ElevatedRoles.Contains(role);
+}";
+
+        var fixedCode = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Collections.Frozen;
+
+namespace System.Collections.Frozen
+{
+    using System.Collections.Generic;
+
+    public abstract class FrozenSet<T> : IEnumerable<T>
+    {
+        public abstract bool Contains(T item);
+        public abstract IEnumerator<T> GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static class FrozenSetExtensions
+    {
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source) => null;
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer) => null;
+    }
+}
+
+class Program
+{
+    private static readonly FrozenSet<string> ElevatedRoles = new string[] {
+        ""admin"",
+        ""ops""
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    static bool IsElevated(string role) => ElevatedRoles.Contains(role);
+}";
+
+        var expected = VerifyFix.Diagnostic("LC033").WithLocation(0).WithArguments("ElevatedRoles");
+        await VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task SourceConstructor_RewritesToFrozenSet()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    private static readonly int[] SeedValues = { 1, 2, 3 };
+    {|#0:private static readonly HashSet<int> ReservedIds = new HashSet<int>(SeedValues);|}
+
+    static bool IsReserved(int value) => ReservedIds.Contains(value);
+}";
+
+        var fixedCode = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Collections.Frozen;
+
+namespace System.Collections.Frozen
+{
+    using System.Collections.Generic;
+
+    public abstract class FrozenSet<T> : IEnumerable<T>
+    {
+        public abstract bool Contains(T item);
+        public abstract IEnumerator<T> GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static class FrozenSetExtensions
+    {
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source) => null;
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer) => null;
+    }
+}
+
+class Program
+{
+    private static readonly int[] SeedValues = { 1, 2, 3 };
+    private static readonly FrozenSet<int> ReservedIds = SeedValues.ToFrozenSet();
+
+    static bool IsReserved(int value) => ReservedIds.Contains(value);
+}";
+
+        var expected = VerifyFix.Diagnostic("LC033").WithLocation(0).WithArguments("ReservedIds");
+        await VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task ToHashSetInitializer_RewritesToFrozenSetWithoutDuplicateUsing()
+    {
+        var test = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Collections.Frozen;
+" + FrozenSupport + @"
+class Program
+{
+    private static readonly string[] SeedValues = { ""admin"", ""ops"" };
+    {|#0:private static readonly HashSet<string> ElevatedRoles = SeedValues.ToHashSet(StringComparer.OrdinalIgnoreCase);|}
+
+    static bool IsElevated(string role) => ElevatedRoles.Contains(role);
+}";
+
+        var fixedCode = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Collections.Frozen;
+
+namespace System.Collections.Frozen
+{
+    using System.Collections.Generic;
+
+    public abstract class FrozenSet<T> : IEnumerable<T>
+    {
+        public abstract bool Contains(T item);
+        public abstract IEnumerator<T> GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static class FrozenSetExtensions
+    {
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source) => null;
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer) => null;
+    }
+}
+
+class Program
+{
+    private static readonly string[] SeedValues = { ""admin"", ""ops"" };
+    private static readonly FrozenSet<string> ElevatedRoles = SeedValues.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    static bool IsElevated(string role) => ElevatedRoles.Contains(role);
+}";
+
+        var expected = VerifyFix.Diagnostic("LC033").WithLocation(0).WithArguments("ElevatedRoles");
+        await VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task FixAll_RewritesMultipleEligibleFields()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    private static readonly int[] SeedValues = { 1, 2, 3 };
+    {|#0:private static readonly HashSet<int> ReservedIds = new HashSet<int>(SeedValues);|}
+    {|#1:private static readonly HashSet<string> ElevatedRoles = new(StringComparer.OrdinalIgnoreCase) { ""admin"", ""ops"" };|}
+
+    static bool Matches(int value, string role) => ReservedIds.Contains(value) && ElevatedRoles.Contains(role);
+}";
+
+        var fixedCode = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Collections.Frozen;
+
+namespace System.Collections.Frozen
+{
+    using System.Collections.Generic;
+
+    public abstract class FrozenSet<T> : IEnumerable<T>
+    {
+        public abstract bool Contains(T item);
+        public abstract IEnumerator<T> GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static class FrozenSetExtensions
+    {
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source) => null;
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer) => null;
+    }
+}
+
+class Program
+{
+    private static readonly int[] SeedValues = { 1, 2, 3 };
+    private static readonly FrozenSet<int> ReservedIds = SeedValues.ToFrozenSet();
+    private static readonly FrozenSet<string> ElevatedRoles = new string[] { ""admin"", ""ops"" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    static bool Matches(int value, string role) => ReservedIds.Contains(value) && ElevatedRoles.Contains(role);
+}";
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            BatchFixedCode = fixedCode,
+            NumberOfIncrementalIterations = 2,
+            CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
+            CompilerDiagnostics = CompilerDiagnostics.None
+        };
+
+        testObj.ExpectedDiagnostics.Add(VerifyFix.Diagnostic("LC033").WithLocation(0).WithArguments("ReservedIds"));
+        testObj.ExpectedDiagnostics.Add(VerifyFix.Diagnostic("LC033").WithLocation(1).WithArguments("ElevatedRoles"));
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task AliasTypeSyntax_RewritesUsingSemanticElementType()
+    {
+        var test = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using IntSet = System.Collections.Generic.HashSet<int>;
+" + FrozenSupport + @"
+class Program
+{
+    {|#0:private static readonly IntSet ReservedIds = new() { 1, 2, 3 };|}
+
+    static bool IsReserved(int value) => ReservedIds.Contains(value);
+}";
+
+        var fixedCode = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using IntSet = System.Collections.Generic.HashSet<int>;
+using System.Collections.Frozen;
+
+namespace System.Collections.Frozen
+{
+    using System.Collections.Generic;
+
+    public abstract class FrozenSet<T> : IEnumerable<T>
+    {
+        public abstract bool Contains(T item);
+        public abstract IEnumerator<T> GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static class FrozenSetExtensions
+    {
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source) => null;
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer) => null;
+    }
+}
+
+class Program
+{
+    private static readonly FrozenSet<int> ReservedIds = new int[] { 1, 2, 3 }.ToFrozenSet();
+
+    static bool IsReserved(int value) => ReservedIds.Contains(value);
+}";
+
+        await VerifyCodeFixAsync(
+            test,
+            VerifyFix.Diagnostic("LC033").WithLocation(0).WithArguments("ReservedIds"),
+            fixedCode);
+    }
+
+    [Fact]
+    public async Task CollidingTypeNames_RewritesToTheOriginalElementTypeSymbol()
+    {
+        var test = @"
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+" + FrozenSupport + @"
+namespace Demo.Models
+{
+    public sealed class Task
+    {
+    }
+}
+
+class Program
+{
+    {|#0:private static readonly HashSet<Demo.Models.Task> ReservedTasks = new()
+    {
+        new Demo.Models.Task()
+    };|}
+
+    static bool ContainsTask(Demo.Models.Task value) => ReservedTasks.Contains(value);
+}";
+
+        var fixedCode = @"
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Frozen;
+
+namespace System.Collections.Frozen
+{
+    using System.Collections.Generic;
+
+    public abstract class FrozenSet<T> : IEnumerable<T>
+    {
+        public abstract bool Contains(T item);
+        public abstract IEnumerator<T> GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static class FrozenSetExtensions
+    {
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source) => null;
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer) => null;
+    }
+}
+
+namespace Demo.Models
+{
+    public sealed class Task
+    {
+    }
+}
+
+class Program
+{
+    private static readonly FrozenSet<Demo.Models.Task> ReservedTasks = new Demo.Models.Task[] {
+        new Demo.Models.Task()
+    }.ToFrozenSet();
+
+    static bool ContainsTask(Demo.Models.Task value) => ReservedTasks.Contains(value);
+}";
+
+        await VerifyCodeFixAsync(
+            test,
+            VerifyFix.Diagnostic("LC033").WithLocation(0).WithArguments("ReservedTasks"),
+            fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_DoesNotRegister_WhenDiagnosticIsNotFixerEligible()
+    {
+        const string source = """
+            using System.Collections.Generic;
+
+            class Program
+            {
+                private static readonly HashSet<int> ReservedIds = new() { 1, 2, 3 };
+            }
+            """;
+
+        using var workspace = new AdhocWorkspace();
+        var project = workspace.CurrentSolution
+            .AddProject("TestProject", "TestProject", LanguageNames.CSharp)
+            .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithParseOptions(new CSharpParseOptions(LanguageVersion.Preview))
+            .AddMetadataReference(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
+            .AddMetadataReference(MetadataReference.CreateFromFile(typeof(HashSet<int>).Assembly.Location));
+
+        var document = project.AddDocument("Test.cs", source);
+        var root = await document.GetSyntaxRootAsync();
+        var fieldDeclaration = root!.DescendantNodes().OfType<FieldDeclarationSyntax>().Single();
+
+        var diagnostic = Diagnostic.Create(
+            new DiagnosticDescriptor("LC033", "title", "message", "Performance", DiagnosticSeverity.Info, true),
+            fieldDeclaration.GetLocation(),
+            ImmutableDictionary<string, string?>.Empty);
+
+        var fixer = new LinqContraband.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches.UseFrozenSetForStaticMembershipCachesFixer();
+        var actions = new List<CodeAction>();
+
+        var context = new CodeFixContext(
+            document,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            default);
+
+        await fixer.RegisterCodeFixesAsync(context);
+
+        Assert.Empty(actions);
+    }
+
+    private static async Task VerifyCodeFixAsync(string test, DiagnosticResult expected, string fixedCode)
+    {
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
+            CompilerDiagnostics = CompilerDiagnostics.None
+        };
+
+        testObj.ExpectedDiagnostics.Add(expected);
+        await testObj.RunAsync();
+    }
+
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesTests.cs
@@ -1,0 +1,222 @@
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    LinqContraband.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches.UseFrozenSetForStaticMembershipCachesAnalyzer>;
+
+namespace LinqContraband.Tests.Analyzers.LC033_UseFrozenSetForStaticMembershipCaches;
+
+public class UseFrozenSetForStaticMembershipCachesTests
+{
+    private const string Usings = @"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+";
+
+    private const string FrozenSupport = @"
+namespace System.Collections.Frozen
+{
+    using System.Collections.Generic;
+
+    public abstract class FrozenSet<T> : IEnumerable<T>
+    {
+        public abstract bool Contains(T item);
+        public abstract IEnumerator<T> GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static class FrozenSetExtensions
+    {
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source) => null;
+        public static FrozenSet<T> ToFrozenSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer) => null;
+    }
+}
+";
+
+    [Fact]
+    public async Task PrivateStaticReadonlyHashSet_WithDirectContains_Triggers()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    {|LC033:private static readonly HashSet<string> ElevatedRoles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ""admin"",
+        ""ops""
+    };|}
+
+    static bool IsElevated(string role) => ElevatedRoles.Contains(role);
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task PrivateStaticReadonlyHashSet_UsedInEnumerableLambda_Triggers()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    {|LC033:private static readonly HashSet<int> ReservedIds = new() { 1, 2, 3 };|}
+
+    static List<int> Filter(IEnumerable<int> values)
+    {
+        return values.Where(value => ReservedIds.Contains(value)).ToList();
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task SourceToHashSetInitializer_Triggers()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    private static readonly int[] SeedValues = { 1, 2, 3 };
+    {|LC033:private static readonly HashSet<int> ReservedIds = SeedValues.ToHashSet();|}
+
+    static bool IsReserved(int value) => ReservedIds.Contains(value);
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task StaticEnumerableToHashSetInitializer_DoesNotTrigger()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    private static readonly int[] SeedValues = { 1, 2, 3 };
+    private static readonly HashSet<int> ReservedIds = Enumerable.ToHashSet(SeedValues);
+
+    static bool IsReserved(int value) => ReservedIds.Contains(value);
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NonPrivateField_DoesNotTrigger()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    internal static readonly HashSet<int> ReservedIds = new() { 1, 2, 3 };
+
+    static bool IsReserved(int value) => ReservedIds.Contains(value);
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task StaticConstructorInitialization_DoesNotTrigger()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    private static readonly HashSet<int> ReservedIds;
+
+    static Program()
+    {
+        ReservedIds = new HashSet<int> { 1, 2, 3 };
+    }
+
+    static bool IsReserved(int value) => ReservedIds.Contains(value);
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task MutationAfterInitialization_DoesNotTrigger()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    private static readonly HashSet<int> ReservedIds = new() { 1, 2, 3 };
+
+    static void AddValue(int value)
+    {
+        ReservedIds.Add(value);
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task EnumerationUsage_DoesNotTrigger()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    private static readonly HashSet<int> ReservedIds = new() { 1, 2, 3 };
+
+    static int Sum()
+    {
+        var total = 0;
+        foreach (var value in ReservedIds)
+        {
+            total += value;
+        }
+
+        return total;
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AliasedUsage_DoesNotTrigger()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    private static readonly HashSet<int> ReservedIds = new() { 1, 2, 3 };
+
+    static bool IsReserved(int value)
+    {
+        var cache = ReservedIds;
+        return cache.Contains(value);
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task QueryableExpressionTreeUsage_DoesNotTrigger()
+    {
+        var test = Usings + FrozenSupport + @"
+class Program
+{
+    private static readonly HashSet<int> ReservedIds = new() { 1, 2, 3 };
+
+    static List<int> Filter(IQueryable<int> values)
+    {
+        return values.Where(value => ReservedIds.Contains(value)).ToList();
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task MissingFrozenSetSupport_DoesNotTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    private static readonly HashSet<int> ReservedIds = new() { 1, 2, 3 };
+
+    static bool IsReserved(int value) => ReservedIds.Contains(value);
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}


### PR DESCRIPTION
## Summary
- add LC033 to flag provably read-only private static readonly HashSet<T> membership caches
- add the metadata-gated fixer that rewrites supported initializers to FrozenSet<T> / ToFrozenSet(...)
- sync README, docs, sample coverage, and targeted analyzer/fixer tests
- harden the review follow-up paths by using semantic ToHashSet receiver checks and collision-safe rewritten type syntax

## Verification
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net10.0 --filter LC033
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0 --filter LC033
- dotnet build samples/LinqContraband.Sample/LinqContraband.Sample.csproj -f net9.0

## Notes
- the first attempt at running net9/net10 in parallel hit the known nupkg file-lock issue in this repo, so the final verification was rerun serially
- the sample build still emits the existing NU1903 advisory on Microsoft.Extensions.Caching.Memory 8.0.0