### PR TITLE
Prepare 4.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.7.0] - 2026-03-18
+
+### Added
+- Added `LC033`, an advisory analyzer and fixer that upgrades provably read-only `private static readonly HashSet<T>` membership caches to `FrozenSet<T>` and `ToFrozenSet(...)` on supported target frameworks
+
+### Changed
+- `LC033` reports only when the cache initializer is fixer-safe and every source reference in the compilation is a direct `Contains(...)` use outside expression-tree contexts
+- Updated the README, rule documentation, and sample project to publish the new analyzer/fixer surface and raise the documented rule count from 32 to 33
+
+### Fixed
+- Hardened the `LC033` fixer to preserve semantic type binding under aliases and colliding imports by generating rewritten type syntax from Roslyn symbols instead of minimally qualified text
+- Hardened `LC033` initializer classification to reject static `Enumerable.ToHashSet(...)`-style receivers semantically rather than relying on syntax-string comparison
+- Expanded `LC033` regression coverage with should-report, should-not-report, fix, no-fix, Fix All, alias, and colliding-type-name scenarios
+
 ## [4.6.0] - 2026-03-18
 
 ### Added

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>4.6.0</Version>
+        <Version>4.7.0</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- bump the package version from 4.6.0 to 4.7.0
- add the 4.7.0 changelog entry for LC033 and the follow-up hardening work

## Verification
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net10.0 --filter LC033
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0 --filter LC033
- dotnet build samples/LinqContraband.Sample/LinqContraband.Sample.csproj -f net9.0

## Notes
- the first release-branch attempt to run net9 and net10 in parallel reproduced the known deps.json lock issue in this repo, so net9 was rerun serially
- the sample build still emits the existing NU1903 advisory on Microsoft.Extensions.Caching.Memory 8.0.0