### PR TITLE
Fix LC001 translation marker exemptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.7.1] - 2026-03-18
+
+### Changed
+- `LC001` now trusts methods explicitly marked with `Microsoft.EntityFrameworkCore.DbFunctionAttribute` or `EntityFrameworkCore.Projectables.ProjectableAttribute`, so known translatable helpers no longer trigger client-evaluation warnings
+- Updated the LC001 README and rule documentation to document the explicit translation-marker exemptions and their intended scope
+
+### Fixed
+- `LC001` no longer flags `DbFunction`-mapped methods or `Projectable` methods, including reduced extension-method calls that should translate through EF Core or Projectables
+- Expanded LC001 regression coverage with should-not-report tests for official translation markers and should-report guards for unannotated helpers and lookalike third-party `ProjectableAttribute` types
+
 ## [4.7.0] - 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ var minDob = DateTime.Now.AddYears(-18);
 var query = db.Users.Where(u => u.Dob <= minDob);
 ```
 
+Methods explicitly mapped for translation are exempt. LC001 will not report methods marked with
+`[DbFunction]` or `EntityFrameworkCore.Projectables`' `[Projectable]` attribute.
+
 ---
 
 ### LC002: Premature Materialization

--- a/docs/LC001_LocalMethod.md
+++ b/docs/LC001_LocalMethod.md
@@ -6,6 +6,9 @@ Detect usage of local C# methods within LINQ to Entities queries that cannot be 
 ## The Problem
 Entity Framework Core attempts to translate LINQ expressions into SQL. When it encounters a method it does not recognize (like a custom local method), it often has to resort to "Client-Side Evaluation." This means it fetches ALL the data from the table into your application's memory and then filters it using C#. For large tables, this is a massive performance and memory leak.
 
+Methods explicitly marked as translatable are exempt. LC001 does not report methods annotated with
+`[Microsoft.EntityFrameworkCore.DbFunction]` or `[EntityFrameworkCore.Projectables.Projectable]`.
+
 ### Example Violation
 ```csharp
 // CalculateAge is a local method. EF Core cannot translate it to SQL.
@@ -30,4 +33,6 @@ var users = db.Users.Where(u => u.DateOfBirth <= minDob).ToList();
 ### Algorithm
 1.  **Target**: Invocations within a lambda expression.
 2.  **Context**: Ensure the lambda is an argument to an `IQueryable` method.
-3.  **Check**: If the method invoked is not a known framework method or a trusted database function (e.g., `EF.Functions`), flag it.
+3.  **Check**: Skip known framework methods, trusted provider methods, and methods explicitly marked with
+    `[DbFunction]` or `[Projectable]`.
+4.  **Report**: If none of those exemptions apply, flag the invocation.

--- a/src/LinqContraband/Analyzers/LC001_LocalMethod/LocalMethodAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LC001_LocalMethod/LocalMethodAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Collections.Generic;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -20,6 +21,8 @@ public sealed class LocalMethodAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC001";
     private const string Category = "Performance";
+    private const string DbFunctionAttributeMetadataName = "Microsoft.EntityFrameworkCore.DbFunctionAttribute";
+    private const string ProjectableAttributeMetadataName = "EntityFrameworkCore.Projectables.ProjectableAttribute";
     private static readonly LocalizableString Title = "Client-side evaluation risk: Local method usage in IQueryable";
 
     private static readonly LocalizableString MessageFormat =
@@ -57,7 +60,7 @@ public sealed class LocalMethodAnalyzer : DiagnosticAnalyzer
             return;
 
         // Trust methods from specific namespaces known to be translatable
-        if (IsTrustedTranslatableMethod(methodSymbol))
+        if (IsTrustedTranslatableMethod(context.Compilation, methodSymbol))
             return;
 
         // Constraint 1: Inside a Lambda
@@ -100,10 +103,11 @@ public sealed class LocalMethodAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private bool IsTrustedTranslatableMethod(IMethodSymbol method)
+    private static bool IsTrustedTranslatableMethod(Compilation compilation, IMethodSymbol method)
     {
         // System and Microsoft (Linq, EF Core base) are generally translatable
         if (method.IsFrameworkMethod()) return true;
+        if (HasExplicitTranslationMarker(compilation, method)) return true;
 
         var ns = method.ContainingNamespace?.ToString();
         if (ns == null) return false;
@@ -117,5 +121,57 @@ public sealed class LocalMethodAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static bool HasExplicitTranslationMarker(Compilation compilation, IMethodSymbol method)
+    {
+        var dbFunctionAttribute = compilation.GetTypeByMetadataName(DbFunctionAttributeMetadataName);
+        var projectableAttribute = compilation.GetTypeByMetadataName(ProjectableAttributeMetadataName);
+        if (dbFunctionAttribute == null && projectableAttribute == null) return false;
+
+        foreach (var candidate in EnumerateMethodVariants(method))
+        {
+            foreach (var attribute in candidate.GetAttributes())
+            {
+                var attributeClass = attribute.AttributeClass;
+                if (attributeClass == null)
+                    continue;
+
+                if ((dbFunctionAttribute != null &&
+                     SymbolEqualityComparer.Default.Equals(attributeClass, dbFunctionAttribute)) ||
+                    (projectableAttribute != null &&
+                     SymbolEqualityComparer.Default.Equals(attributeClass, projectableAttribute)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<IMethodSymbol> EnumerateMethodVariants(IMethodSymbol method)
+    {
+        var pending = new Stack<IMethodSymbol>();
+        var seen = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
+        pending.Push(method);
+
+        while (pending.Count > 0)
+        {
+            var current = pending.Pop();
+            if (!seen.Add(current))
+                continue;
+
+            yield return current;
+
+            if (current.ReducedFrom != null)
+                pending.Push(current.ReducedFrom);
+
+            if (!SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, current))
+                pending.Push(current.OriginalDefinition);
+
+            if (current.OverriddenMethod != null)
+                pending.Push(current.OverriddenMethod);
+        }
     }
 }

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>4.7.0</Version>
+        <Version>4.7.1</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC001_LocalMethod/LocalMethodSmugglerEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC001_LocalMethod/LocalMethodSmugglerEdgeCasesTests.cs
@@ -29,6 +29,33 @@ namespace TestNamespace
     }
 }";
 
+    private const string DbFunctionAttributeMock = @"
+namespace Microsoft.EntityFrameworkCore
+{
+    [System.AttributeUsage(System.AttributeTargets.Method)]
+    public class DbFunctionAttribute : System.Attribute
+    {
+    }
+}";
+
+    private const string ProjectableAttributeMock = @"
+namespace EntityFrameworkCore.Projectables
+{
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Constructor, Inherited = true, AllowMultiple = false)]
+    public sealed class ProjectableAttribute : System.Attribute
+    {
+    }
+}";
+
+    private const string FakeProjectableAttributeMock = @"
+namespace Fake.Projectables
+{
+    [System.AttributeUsage(System.AttributeTargets.Method)]
+    public sealed class ProjectableAttribute : System.Attribute
+    {
+    }
+}";
+
     [Fact]
     public async Task TestCrime_NestedLambda_LocalMethodInInnerLambda_ShouldTriggerLC001()
     {
@@ -174,6 +201,122 @@ class Program
         var expected = VerifyCS.Diagnostic("LC001")
             .WithSpan(13, 42, 13, 60)
             .WithArguments("FormatName");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestInnocent_DbFunctionMethodInWhere_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Where(u => DatabaseFunctions.IsAdult(u.Age));
+    }
+}
+
+static class DatabaseFunctions
+{
+    [Microsoft.EntityFrameworkCore.DbFunction]
+    public static bool IsAdult(int age) => age >= 18;
+}
+" + DbFunctionAttributeMock + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ProjectableInstanceMethodInWhere_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Where(u => IsAdult(u.Age));
+    }
+
+    [EntityFrameworkCore.Projectables.Projectable]
+    bool IsAdult(int age) => age >= 18;
+}
+" + ProjectableAttributeMock + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ProjectableExtensionMethodInWhere_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Where(u => u.HasAdultAge());
+    }
+}
+
+static class UserProjectables
+{
+    [EntityFrameworkCore.Projectables.Projectable]
+    public static bool HasAdultAge(this User user) => user.Age >= 18;
+}
+" + ProjectableAttributeMock + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_StaticHelperMethodInWhereWithoutAttribute_ShouldTriggerLC001()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Where(u => DatabaseFunctions.IsAdult(u.Age));
+    }
+}
+
+static class DatabaseFunctions
+{
+    public static bool IsAdult(int age) => age >= 18;
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC001")
+            .WithSpan(13, 41, 13, 73)
+            .WithArguments("IsAdult");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_LookalikeProjectableAttribute_ShouldTriggerLC001()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Where(u => IsAdult(u.Age));
+    }
+
+    [Fake.Projectables.Projectable]
+    bool IsAdult(int age) => age >= 18;
+}
+" + FakeProjectableAttributeMock + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC001")
+            .WithSpan(13, 41, 13, 55)
+            .WithArguments("IsAdult");
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }


### PR DESCRIPTION
## Summary
- exempt LC001 for methods marked with exact `DbFunctionAttribute` or `ProjectableAttribute` symbols
- add regression coverage for DbFunction, Projectable, extension-method, and lookalike-attribute cases
- prepare the 4.7.1 release metadata and notes

## Testing
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net9.0 --filter "FullyQualifiedName~LinqContraband.Tests.Analyzers.LC001_LocalMethod"`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~LinqContraband.Tests.Analyzers.LC001_LocalMethod"`
- `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release`

## Release Notes
- LC001 now trusts methods explicitly marked with `Microsoft.EntityFrameworkCore.DbFunctionAttribute` or `EntityFrameworkCore.Projectables.ProjectableAttribute`, so known translatable helpers no longer trigger false-positive client-evaluation warnings.
- Added LC001 regression coverage for official translation markers and guard cases for unannotated helpers and lookalike third-party `ProjectableAttribute` types.
- Updated the LC001 README and rule documentation to describe the explicit translation-marker exemptions.

Fixes #16