### PR TITLE
build: generate rule catalog docs from metadata

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
+      - name: Verify generated rule catalog docs
+        run: dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check
+
       - name: Build
         run: dotnet build --no-restore
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,10 @@ src/LinqContraband/
         OperationTraversalExtensions.cs
         SymbolAnalysisExtensions.cs
 
+tools/
+    RuleCatalogDocGenerator/
+        Program.cs
+
 tests/LinqContraband.Tests/
     Analyzers/
         LC001_LocalMethod/
@@ -70,6 +74,12 @@ Every rule is now governed by the central catalog in `src/LinqContraband/Catalog
 - docs page at `docs/LCxxx_Name.md`
 
 If a rule intentionally has no fixer, record the rationale in the catalog. `tests/LinqContraband.Tests/Architecture/RuleCatalogIntegrityTests.cs` enforces this contract in CI.
+
+`docs/rule-catalog.md` is generated from `RuleCatalog`. Regenerate it locally with:
+```bash
+dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --write
+```
+CI runs the same tool with `--check` and fails if the checked-in file is stale.
 
 ### Quick Summary
 

--- a/LinqContraband.sln
+++ b/LinqContraband.sln
@@ -51,6 +51,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{04BE0F95-3
 		docs\adding_new_analyzer.md = docs\adding_new_analyzer.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{07C2787E-EAC7-C090-1BA3-A61EC2A24D84}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RuleCatalogDocGenerator", "tools\RuleCatalogDocGenerator\RuleCatalogDocGenerator.csproj", "{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +101,18 @@ Global
 		{BE8C692E-90BD-4F68-A353-530F3DD4E036}.Release|x64.Build.0 = Release|Any CPU
 		{BE8C692E-90BD-4F68-A353-530F3DD4E036}.Release|x86.ActiveCfg = Release|Any CPU
 		{BE8C692E-90BD-4F68-A353-530F3DD4E036}.Release|x86.Build.0 = Release|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Debug|x64.Build.0 = Debug|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Debug|x86.Build.0 = Debug|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Release|x64.ActiveCfg = Release|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Release|x64.Build.0 = Release|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Release|x86.ActiveCfg = Release|Any CPU
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -105,5 +121,6 @@ Global
 		{587BFFC2-D0E5-4606-8EC3-359613878759} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{FF55B03C-3890-46CA-8554-E2AC7ED686E1} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{BE8C692E-90BD-4F68-A353-530F3DD4E036} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
+		{E3F3AEA7-226F-4570-96BB-BD1C5DAFEF81} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 	EndGlobalSection
 EndGlobal

--- a/docs/adding_new_analyzer.md
+++ b/docs/adding_new_analyzer.md
@@ -33,6 +33,11 @@ Every rule now has to update the central catalog and keep all four mirrored surf
 If a rule intentionally has no code fix, add an explicit rationale in `RuleCatalog.cs`.
 The architecture tests in `tests/LinqContraband.Tests/Architecture/RuleCatalogIntegrityTests.cs` enforce this contract in CI.
 
+`docs/rule-catalog.md` is generated from `RuleCatalog`. After updating rule metadata, regenerate it with:
+```bash
+dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --write
+```
+
 ## 2. TDD Workflow
 
 We use TDD to ensure our analyzers and fixers work as expected. The general workflow is:

--- a/docs/rule-catalog.md
+++ b/docs/rule-catalog.md
@@ -1,7 +1,7 @@
 # Rule Catalog
 
 The source of truth for rule metadata lives in `src/LinqContraband/Catalog/RuleCatalog.cs`.
-This page mirrors that catalog in a navigable matrix grouped by domain.
+This page is generated from that catalog and grouped by domain.
 
 ## Bulk Operations & Set-Based Writes
 

--- a/tools/RuleCatalogDocGenerator/Program.cs
+++ b/tools/RuleCatalogDocGenerator/Program.cs
@@ -1,0 +1,90 @@
+using System.Text;
+using LinqContraband.Catalog;
+
+var repoRoot = FindRepoRoot();
+var outputPath = Path.Combine(repoRoot, "docs", "rule-catalog.md");
+
+var checkOnly = args.Contains("--check", StringComparer.Ordinal);
+var writeOnly = args.Contains("--write", StringComparer.Ordinal);
+
+if (checkOnly && writeOnly)
+{
+    Console.Error.WriteLine("Use either --check or --write, not both.");
+    return 1;
+}
+
+var generated = GenerateMarkdown();
+
+if (checkOnly)
+{
+    var current = File.Exists(outputPath) ? File.ReadAllText(outputPath) : string.Empty;
+    if (!string.Equals(current, generated, StringComparison.Ordinal))
+    {
+        Console.Error.WriteLine($"{outputPath} is out of date. Run: dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --write");
+        return 1;
+    }
+
+    Console.WriteLine("docs/rule-catalog.md is up to date.");
+    return 0;
+}
+
+File.WriteAllText(outputPath, generated, new UTF8Encoding(false));
+Console.WriteLine($"Wrote {outputPath}");
+return 0;
+
+static string FindRepoRoot()
+{
+    var current = new DirectoryInfo(Environment.CurrentDirectory);
+    while (current is not null)
+    {
+        if (File.Exists(Path.Combine(current.FullName, "LinqContraband.sln")))
+            return current.FullName;
+
+        current = current.Parent;
+    }
+
+    throw new InvalidOperationException("Could not locate LinqContraband.sln from the current working directory.");
+}
+
+static string GenerateMarkdown()
+{
+    var builder = new StringBuilder();
+    builder.AppendLine("# Rule Catalog");
+    builder.AppendLine();
+    builder.AppendLine("The source of truth for rule metadata lives in `src/LinqContraband/Catalog/RuleCatalog.cs`.");
+    builder.AppendLine("This page is generated from that catalog and grouped by domain.");
+    builder.AppendLine();
+
+    var groups = RuleCatalog.All
+        .OrderBy(rule => rule.Domain, StringComparer.Ordinal)
+        .ThenBy(rule => rule.Id, StringComparer.Ordinal)
+        .GroupBy(rule => rule.Domain, StringComparer.Ordinal);
+
+    foreach (var group in groups)
+    {
+        builder.AppendLine($"## {group.Key}");
+        builder.AppendLine();
+        builder.AppendLine("| Rule | Severity | Legacy Category | Fix | Docs | Sample |\n| --- | --- | --- | --- | --- | --- |");
+
+        foreach (var rule in group)
+        {
+            var fixText = rule.HasCodeFix ? "Code fix" : "Manual only";
+            var docsLink = $"[`{rule.Slug}`](./{Path.GetFileName(rule.DocumentationPath)})";
+            var sampleDirectory = Path.GetDirectoryName(rule.SamplePath)?.Replace('\\', '/');
+            var shortSampleDirectory = sampleDirectory is null
+                ? rule.SamplePath.Replace('\\', '/')
+                : sampleDirectory.Replace("samples/LinqContraband.Sample/", string.Empty, StringComparison.Ordinal);
+
+            builder.AppendLine($"| `{rule.Id}` {EscapePipes(rule.Title)} | `{rule.Severity}` | `{rule.Category}` | {fixText} | {docsLink} | `{shortSampleDirectory}/` |");
+        }
+
+        builder.AppendLine();
+    }
+
+    return builder.ToString();
+}
+
+static string EscapePipes(string value)
+{
+    return value.Replace("|", "\\|", StringComparison.Ordinal);
+}

--- a/tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj
+++ b/tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\LinqContraband\LinqContraband.csproj" />
+        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.0" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add a `RuleCatalogDocGenerator` tool that generates `docs/rule-catalog.md` directly from `RuleCatalog`
- add a CI `--check` step so stale generated docs fail the build
- document the regeneration command in contributor docs

Closes #39

## Validation
- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0`
- `dotnet build LinqContraband.sln -p:ContinuousIntegrationBuild=true`
