### PR TITLE
chore: prepare 5.0.4 release

### DIFF
--- a/.complexity-log.md
+++ b/.complexity-log.md
@@ -34,125 +34,125 @@
 
 - [AvoidDateTimeNowSample.cs](./samples/LinqContraband.Sample/Samples/LC016_AvoidDateTimeNow/AvoidDateTimeNowSample.cs#L21) - Max nesting depth is 6 (threshold: 4)
 
-## [LocalMethodAnalyzer.cs](src/LinqContraband/Analyzers/LC001_LocalMethod/LocalMethodAnalyzer.cs)
+## [LocalMethodAnalyzer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodAnalyzer.cs)
 
-- [LocalMethodAnalyzer.cs](./src/LinqContraband/Analyzers/LC001_LocalMethod/LocalMethodAnalyzer.cs#L93) - Max nesting depth is 12 (threshold: 4)
+- [LocalMethodAnalyzer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodAnalyzer.cs#L93) - Max nesting depth is 12 (threshold: 4)
 
-## [LocalMethodFixer.cs](src/LinqContraband/Analyzers/LC001_LocalMethod/LocalMethodFixer.cs)
+## [LocalMethodFixer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodFixer.cs)
 
-- [LocalMethodFixer.cs](./src/LinqContraband/Analyzers/LC001_LocalMethod/LocalMethodFixer.cs#L43) - Max nesting depth is 8 (threshold: 4)
+- [LocalMethodFixer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodFixer.cs#L43) - Max nesting depth is 8 (threshold: 4)
 
-## [PrematureMaterializationAnalyzer.cs](src/LinqContraband/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs)
+## [PrematureMaterializationAnalyzer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs)
 
-- [PrematureMaterializationAnalyzer.cs](./src/LinqContraband/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs#L74) - Max nesting depth is 15 (threshold: 4)
+- [PrematureMaterializationAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs#L74) - Max nesting depth is 15 (threshold: 4)
 
-## [PrematureMaterializationFixer.cs](src/LinqContraband/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationFixer.cs)
+## [PrematureMaterializationFixer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationFixer.cs)
 
-- [PrematureMaterializationFixer.cs](./src/LinqContraband/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationFixer.cs#L91) - Max nesting depth is 12 (threshold: 4)
+- [PrematureMaterializationFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationFixer.cs#L91) - Max nesting depth is 12 (threshold: 4)
 
-## [AnyOverCountAnalyzer.cs](src/LinqContraband/Analyzers/LC003_AnyOverCount/AnyOverCountAnalyzer.cs)
+## [AnyOverCountAnalyzer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC003_AnyOverCount/AnyOverCountAnalyzer.cs)
 
-- [AnyOverCountAnalyzer.cs](./src/LinqContraband/Analyzers/LC003_AnyOverCount/AnyOverCountAnalyzer.cs#L132) - Max nesting depth is 10 (threshold: 4)
+- [AnyOverCountAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC003_AnyOverCount/AnyOverCountAnalyzer.cs#L132) - Max nesting depth is 10 (threshold: 4)
 
-## [AnyOverCountFixer.cs](src/LinqContraband/Analyzers/LC003_AnyOverCount/AnyOverCountFixer.cs)
+## [AnyOverCountFixer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC003_AnyOverCount/AnyOverCountFixer.cs)
 
-- [AnyOverCountFixer.cs](./src/LinqContraband/Analyzers/LC003_AnyOverCount/AnyOverCountFixer.cs#L49) - Max nesting depth is 8 (threshold: 4)
+- [AnyOverCountFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC003_AnyOverCount/AnyOverCountFixer.cs#L49) - Max nesting depth is 8 (threshold: 4)
 
-## [IQueryableLeakAnalyzer.cs](src/LinqContraband/Analyzers/LC004_IQueryableLeak/IQueryableLeakAnalyzer.cs)
+## [IQueryableLeakAnalyzer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC004_IQueryableLeak/IQueryableLeakAnalyzer.cs)
 
-- [IQueryableLeakAnalyzer.cs](./src/LinqContraband/Analyzers/LC004_IQueryableLeak/IQueryableLeakAnalyzer.cs#L75) - Max nesting depth is 12 (threshold: 4)
+- [IQueryableLeakAnalyzer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC004_IQueryableLeak/IQueryableLeakAnalyzer.cs#L75) - Max nesting depth is 12 (threshold: 4)
 
-## [MultipleOrderByAnalyzer.cs](src/LinqContraband/Analyzers/LC005_MultipleOrderBy/MultipleOrderByAnalyzer.cs)
+## [MultipleOrderByAnalyzer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC005_MultipleOrderBy/MultipleOrderByAnalyzer.cs)
 
-- [MultipleOrderByAnalyzer.cs](./src/LinqContraband/Analyzers/LC005_MultipleOrderBy/MultipleOrderByAnalyzer.cs#L57) - Max nesting depth is 11 (threshold: 4)
+- [MultipleOrderByAnalyzer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC005_MultipleOrderBy/MultipleOrderByAnalyzer.cs#L57) - Max nesting depth is 11 (threshold: 4)
 
-## [MultipleOrderByFixer.cs](src/LinqContraband/Analyzers/LC005_MultipleOrderBy/MultipleOrderByFixer.cs)
+## [MultipleOrderByFixer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC005_MultipleOrderBy/MultipleOrderByFixer.cs)
 
-- [MultipleOrderByFixer.cs](./src/LinqContraband/Analyzers/LC005_MultipleOrderBy/MultipleOrderByFixer.cs#L41) - Max nesting depth is 10 (threshold: 4)
+- [MultipleOrderByFixer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC005_MultipleOrderBy/MultipleOrderByFixer.cs#L41) - Max nesting depth is 10 (threshold: 4)
 
-## [CartesianExplosionAnalyzer.cs](src/LinqContraband/Analyzers/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs)
+## [CartesianExplosionAnalyzer.cs](src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs)
 
-- [CartesianExplosionAnalyzer.cs](./src/LinqContraband/Analyzers/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs#L108) - Max nesting depth is 13 (threshold: 4)
+- [CartesianExplosionAnalyzer.cs](./src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs#L108) - Max nesting depth is 13 (threshold: 4)
 
-## [CartesianExplosionFixer.cs](src/LinqContraband/Analyzers/LC006_CartesianExplosion/CartesianExplosionFixer.cs)
+## [CartesianExplosionFixer.cs](src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionFixer.cs)
 
-- [CartesianExplosionFixer.cs](./src/LinqContraband/Analyzers/LC006_CartesianExplosion/CartesianExplosionFixer.cs#L41) - Max nesting depth is 8 (threshold: 4)
+- [CartesianExplosionFixer.cs](./src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionFixer.cs#L41) - Max nesting depth is 8 (threshold: 4)
 
-## [NPlusOneLooperAnalyzer.cs](src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs)
+## [NPlusOneLooperAnalyzer.cs](src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs)
 
-- [NPlusOneLooperAnalyzer.cs](./src/LinqContraband/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs#L61) - Max nesting depth is 8 (threshold: 4)
+- [NPlusOneLooperAnalyzer.cs](./src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs#L61) - Max nesting depth is 8 (threshold: 4)
 
-## [SyncBlockerAnalyzer.cs](src/LinqContraband/Analyzers/LC008_SyncBlocker/SyncBlockerAnalyzer.cs)
+## [SyncBlockerAnalyzer.cs](src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerAnalyzer.cs)
 
-- [SyncBlockerAnalyzer.cs](./src/LinqContraband/Analyzers/LC008_SyncBlocker/SyncBlockerAnalyzer.cs#L118) - Max nesting depth is 8 (threshold: 4)
+- [SyncBlockerAnalyzer.cs](./src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerAnalyzer.cs#L118) - Max nesting depth is 8 (threshold: 4)
 
-## [SyncBlockerFixer.cs](src/LinqContraband/Analyzers/LC008_SyncBlocker/SyncBlockerFixer.cs)
+## [SyncBlockerFixer.cs](src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerFixer.cs)
 
-- [SyncBlockerFixer.cs](./src/LinqContraband/Analyzers/LC008_SyncBlocker/SyncBlockerFixer.cs#L48) - Max nesting depth is 12 (threshold: 4)
+- [SyncBlockerFixer.cs](./src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerFixer.cs#L48) - Max nesting depth is 12 (threshold: 4)
 
-## [MissingAsNoTrackingAnalyzer.cs](src/LinqContraband/Analyzers/LC009_MissingAsNoTracking/MissingAsNoTrackingAnalyzer.cs)
+## [MissingAsNoTrackingAnalyzer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingAnalyzer.cs)
 
-- [MissingAsNoTrackingAnalyzer.cs](./src/LinqContraband/Analyzers/LC009_MissingAsNoTracking/MissingAsNoTrackingAnalyzer.cs#L105) - Max nesting depth is 13 (threshold: 4)
+- [MissingAsNoTrackingAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingAnalyzer.cs#L105) - Max nesting depth is 13 (threshold: 4)
 
-## [MissingAsNoTrackingFixer.cs](src/LinqContraband/Analyzers/LC009_MissingAsNoTracking/MissingAsNoTrackingFixer.cs)
+## [MissingAsNoTrackingFixer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingFixer.cs)
 
-- [MissingAsNoTrackingFixer.cs](./src/LinqContraband/Analyzers/LC009_MissingAsNoTracking/MissingAsNoTrackingFixer.cs#L42) - Max nesting depth is 8 (threshold: 4)
+- [MissingAsNoTrackingFixer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingFixer.cs#L42) - Max nesting depth is 8 (threshold: 4)
 
-## [SaveChangesInLoopAnalyzer.cs](src/LinqContraband/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopAnalyzer.cs)
+## [SaveChangesInLoopAnalyzer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC010_SaveChangesInLoop/SaveChangesInLoopAnalyzer.cs)
 
-- [SaveChangesInLoopAnalyzer.cs](./src/LinqContraband/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopAnalyzer.cs#L64) - Max nesting depth is 8 (threshold: 4)
+- [SaveChangesInLoopAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC010_SaveChangesInLoop/SaveChangesInLoopAnalyzer.cs#L64) - Max nesting depth is 8 (threshold: 4)
 
-## [EntityMissingPrimaryKeyAnalyzer.cs](src/LinqContraband/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs)
+## [EntityMissingPrimaryKeyAnalyzer.cs](src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs)
 
-- [EntityMissingPrimaryKeyAnalyzer.cs](./src/LinqContraband/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs#L1) - File has 501 lines (threshold: 500)
-- [EntityMissingPrimaryKeyAnalyzer.cs](./src/LinqContraband/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs#L145) - Max nesting depth is 14 (threshold: 4)
+- [EntityMissingPrimaryKeyAnalyzer.cs](./src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs#L1) - File has 501 lines (threshold: 500)
+- [EntityMissingPrimaryKeyAnalyzer.cs](./src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs#L145) - Max nesting depth is 14 (threshold: 4)
 
-## [OptimizeRemoveRangeAnalyzer.cs](src/LinqContraband/Analyzers/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzer.cs)
+## [OptimizeRemoveRangeAnalyzer.cs](src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzer.cs)
 
-- [OptimizeRemoveRangeAnalyzer.cs](./src/LinqContraband/Analyzers/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzer.cs#L62) - Max nesting depth is 6 (threshold: 4)
+- [OptimizeRemoveRangeAnalyzer.cs](./src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzer.cs#L62) - Max nesting depth is 6 (threshold: 4)
 
-## [DisposedContextQueryAnalyzer.cs](src/LinqContraband/Analyzers/LC013_DisposedContextQuery/DisposedContextQueryAnalyzer.cs)
+## [DisposedContextQueryAnalyzer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC013_DisposedContextQuery/DisposedContextQueryAnalyzer.cs)
 
-- [DisposedContextQueryAnalyzer.cs](./src/LinqContraband/Analyzers/LC013_DisposedContextQuery/DisposedContextQueryAnalyzer.cs#L186) - Max nesting depth is 12 (threshold: 4)
+- [DisposedContextQueryAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC013_DisposedContextQuery/DisposedContextQueryAnalyzer.cs#L186) - Max nesting depth is 12 (threshold: 4)
 
-## [AvoidStringCaseConversionAnalyzer.cs](src/LinqContraband/Analyzers/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionAnalyzer.cs)
+## [AvoidStringCaseConversionAnalyzer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionAnalyzer.cs)
 
-- [AvoidStringCaseConversionAnalyzer.cs](./src/LinqContraband/Analyzers/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionAnalyzer.cs#L109) - Max nesting depth is 12 (threshold: 4)
+- [AvoidStringCaseConversionAnalyzer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionAnalyzer.cs#L109) - Max nesting depth is 12 (threshold: 4)
 
-## [AvoidStringCaseConversionFixer.cs](src/LinqContraband/Analyzers/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionFixer.cs)
+## [AvoidStringCaseConversionFixer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionFixer.cs)
 
-- [AvoidStringCaseConversionFixer.cs](./src/LinqContraband/Analyzers/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionFixer.cs#L44) - Max nesting depth is 10 (threshold: 4)
+- [AvoidStringCaseConversionFixer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionFixer.cs#L44) - Max nesting depth is 10 (threshold: 4)
 
-## [MissingOrderByAnalyzer.cs](src/LinqContraband/Analyzers/LC015_MissingOrderBy/MissingOrderByAnalyzer.cs)
+## [MissingOrderByAnalyzer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC015_MissingOrderBy/MissingOrderByAnalyzer.cs)
 
-- [MissingOrderByAnalyzer.cs](./src/LinqContraband/Analyzers/LC015_MissingOrderBy/MissingOrderByAnalyzer.cs#L104) - Max nesting depth is 10 (threshold: 4)
+- [MissingOrderByAnalyzer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC015_MissingOrderBy/MissingOrderByAnalyzer.cs#L104) - Max nesting depth is 10 (threshold: 4)
 
-## [MissingOrderByFixer.cs](src/LinqContraband/Analyzers/LC015_MissingOrderBy/MissingOrderByFixer.cs)
+## [MissingOrderByFixer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC015_MissingOrderBy/MissingOrderByFixer.cs)
 
-- [MissingOrderByFixer.cs](./src/LinqContraband/Analyzers/LC015_MissingOrderBy/MissingOrderByFixer.cs#L61) - Max nesting depth is 8 (threshold: 4)
+- [MissingOrderByFixer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC015_MissingOrderBy/MissingOrderByFixer.cs#L61) - Max nesting depth is 8 (threshold: 4)
 
-## [AvoidDateTimeNowAnalyzer.cs](src/LinqContraband/Analyzers/LC016_AvoidDateTimeNow/AvoidDateTimeNowAnalyzer.cs)
+## [AvoidDateTimeNowAnalyzer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowAnalyzer.cs)
 
-- [AvoidDateTimeNowAnalyzer.cs](./src/LinqContraband/Analyzers/LC016_AvoidDateTimeNow/AvoidDateTimeNowAnalyzer.cs#L76) - Max nesting depth is 15 (threshold: 4)
+- [AvoidDateTimeNowAnalyzer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowAnalyzer.cs#L76) - Max nesting depth is 15 (threshold: 4)
 
-## [AvoidDateTimeNowFixer.cs](src/LinqContraband/Analyzers/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixer.cs)
+## [AvoidDateTimeNowFixer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixer.cs)
 
-- [AvoidDateTimeNowFixer.cs](./src/LinqContraband/Analyzers/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixer.cs#L100) - Max nesting depth is 18 (threshold: 4)
+- [AvoidDateTimeNowFixer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixer.cs#L100) - Max nesting depth is 18 (threshold: 4)
 
-## [WholeEntityProjectionAnalyzer.cs](src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs)
+## [WholeEntityProjectionAnalyzer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs)
 
-- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L276) - Max nesting depth is 6 (threshold: 4)
-- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L55) - Function 'AnalyzeInvocation' has complexity 12 (threshold: 10)
-- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L109) - Function 'AnalyzeQueryChain' has complexity 19 (threshold: 10)
-- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L284) - Function 'CountPropertyAccesses' has complexity 12 (threshold: 10)
+- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L276) - Max nesting depth is 6 (threshold: 4)
+- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L55) - Function 'AnalyzeInvocation' has complexity 12 (threshold: 10)
+- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L109) - Function 'AnalyzeQueryChain' has complexity 19 (threshold: 10)
+- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L284) - Function 'CountPropertyAccesses' has complexity 12 (threshold: 10)
 
-## [WholeEntityProjectionFixer.cs](src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs)
+## [WholeEntityProjectionFixer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs)
 
-- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L184) - Max nesting depth is 8 (threshold: 4)
-- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L84) - Function 'GetEntityType' has complexity 19 (threshold: 10)
-- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L84) - Function 'GetEntityType' has 54 lines (threshold: 50)
-- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L140) - Function 'FindAccessedProperties' has complexity 11 (threshold: 10)
-- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L215) - Function 'AddSelectProjectionAsync' has 54 lines (threshold: 50)
+- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L184) - Max nesting depth is 8 (threshold: 4)
+- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L84) - Function 'GetEntityType' has complexity 19 (threshold: 10)
+- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L84) - Function 'GetEntityType' has 54 lines (threshold: 50)
+- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L140) - Function 'FindAccessedProperties' has complexity 11 (threshold: 10)
+- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L215) - Function 'AddSelectProjectionAsync' has 54 lines (threshold: 50)
 
 ## [AnalysisExtensions.cs](src/LinqContraband/Extensions/AnalysisExtensions.cs)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.4] - 2026-04-01
+
+### Added
+- Added `docs/analyzer-layout-decision.md` to record the trade-offs, migration strategy, and long-term contract for the analyzer source layout
+
+### Changed
+- Grouped analyzer source folders by domain under `src/LinqContraband/Analyzers/` while preserving analyzer ids, namespaces, tests, samples, and docs layout
+- Extended `RuleCatalog` metadata with analyzer source paths so architecture tests validate the grouped source layout through the catalog
+- Refreshed contributor guidance to explain the grouped source layout and catalog-driven placement rules for future analyzers
+- Refreshed `.complexity-log.md` path references to match the new grouped analyzer source folders
+
 ## [5.0.3] - 2026-04-01
 
 ### Added

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.0.3</Version>
+        <Version>5.0.4</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- bump the package version to `5.0.4`
- add grouped-layout release notes to `CHANGELOG.md`
- refresh `.complexity-log.md` source paths after the domain-based analyzer move

## Validation
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0`
- `dotnet build LinqContraband.sln -p:ContinuousIntegrationBuild=true`
- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check`

## Release notes draft
### Added
- added the analyzer layout decision document describing the new domain-based source structure

### Changed
- grouped analyzer source folders by domain while preserving ids, namespaces, tests, samples, and docs layout
- extended `RuleCatalog` with analyzer source paths for governance validation
- refreshed `.complexity-log.md` path references to match the grouped layout
