### PR TITLE
refactor(LC040): split mixed-tracking analysis helpers

### DIFF
--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingAnalyzer.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Operations;
 namespace LinqContraband.Analyzers.LC040_MixedTrackingAndNoTracking;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class MixedTrackingAndNoTrackingAnalyzer : DiagnosticAnalyzer
+public sealed partial class MixedTrackingAndNoTrackingAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC040";
     private const string Category = "Reliability";
@@ -74,7 +74,7 @@ public sealed class MixedTrackingAndNoTrackingAnalyzer : DiagnosticAnalyzer
         context.RegisterCompilationEndAction(state.ReportDiagnostics);
     }
 
-    private sealed class AnalysisState
+    private sealed partial class AnalysisState
     {
         private readonly ConcurrentBag<MaterializationRecord> _records = new();
 
@@ -134,157 +134,6 @@ public sealed class MixedTrackingAndNoTrackingAnalyzer : DiagnosticAnalyzer
                     }
                 }
             }
-        }
-
-        private static bool TryGetTrackingMode(IInvocationOperation invocation, IOperation root, out TrackingMode mode)
-        {
-            mode = TrackingMode.Tracked;
-
-            IOperation? current = invocation.GetInvocationReceiver();
-            while (current != null)
-            {
-                current = current.UnwrapConversions();
-
-                switch (current)
-                {
-                    case IInvocationOperation nestedInvocation:
-                        if (nestedInvocation.TargetMethod.Name is "AsTracking")
-                        {
-                            mode = TrackingMode.Tracked;
-                            return true;
-                        }
-
-                        if (nestedInvocation.TargetMethod.Name is "AsNoTracking" or "AsNoTrackingWithIdentityResolution")
-                        {
-                            mode = TrackingMode.NoTracking;
-                            return true;
-                        }
-
-                        if (nestedInvocation.TargetMethod.Name == "Select")
-                            return false;
-
-                        current = nestedInvocation.GetInvocationReceiver();
-                        continue;
-
-                    case ILocalReferenceOperation localReference:
-                        if (!TryResolveAssignedValue(localReference.Local, root, out var assignedValue))
-                            return false;
-
-                        current = assignedValue;
-                        continue;
-
-                    case IPropertyReferenceOperation propertyReference:
-                    case IFieldReferenceOperation fieldReference:
-                        return true;
-
-                    case IParameterReferenceOperation:
-                        return false;
-
-                    default:
-                        return true;
-                }
-            }
-
-            return true;
-        }
-
-        private static bool TryGetContextSymbol(IInvocationOperation invocation, IOperation root, out ISymbol? contextSymbol)
-        {
-            contextSymbol = null;
-
-            var current = invocation.GetInvocationReceiver();
-            while (current != null)
-            {
-                current = current.UnwrapConversions();
-
-                if (current is IInvocationOperation nestedInvocation)
-                {
-                    if (nestedInvocation.TargetMethod.Name == "Select")
-                        return false;
-
-                    if (nestedInvocation.TargetMethod.Name == "Set" &&
-                        nestedInvocation.TargetMethod.ContainingType.IsDbContext())
-                        return TryGetSymbol(nestedInvocation.Instance, out contextSymbol);
-
-                    current = nestedInvocation.GetInvocationReceiver();
-                    continue;
-                }
-
-                switch (current)
-                {
-                    case IPropertyReferenceOperation propertyReference when propertyReference.Type.IsDbSet():
-                        return TryGetSymbol(propertyReference.Instance, out contextSymbol);
-
-                    case IFieldReferenceOperation fieldReference when fieldReference.Type.IsDbSet():
-                        return TryGetSymbol(fieldReference.Instance, out contextSymbol);
-
-                    case ILocalReferenceOperation localReference:
-                        if (!TryResolveAssignedValue(localReference.Local, root, out var assignedValue))
-                            return false;
-
-                        current = assignedValue;
-                        continue;
-
-                    case IParameterReferenceOperation:
-                        return false;
-
-                    default:
-                        return false;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool TryGetSymbol(IOperation? operation, out ISymbol? symbol)
-        {
-            switch (operation?.UnwrapConversions())
-            {
-                case ILocalReferenceOperation localReference:
-                    symbol = localReference.Local;
-                    return true;
-                case IParameterReferenceOperation parameterReference:
-                    symbol = parameterReference.Parameter;
-                    return true;
-                case IFieldReferenceOperation fieldReference:
-                    symbol = fieldReference.Field;
-                    return true;
-                case IPropertyReferenceOperation propertyReference:
-                    symbol = propertyReference.Property;
-                    return true;
-                default:
-                    symbol = null;
-                    return false;
-            }
-        }
-
-        private static bool TryResolveAssignedValue(ILocalSymbol local, IOperation root, out IOperation? assignedValue)
-        {
-            assignedValue = null;
-            var matches = 0;
-
-            foreach (var descendant in root.Descendants())
-            {
-                if (descendant is ISimpleAssignmentOperation assignment &&
-                    assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal &&
-                    SymbolEqualityComparer.Default.Equals(targetLocal.Local, local))
-                {
-                    matches++;
-                    assignedValue = assignment.Value;
-                }
-                else if (descendant is IVariableDeclaratorOperation declarator &&
-                         SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) &&
-                         declarator.Initializer != null)
-                {
-                    matches++;
-                    assignedValue = declarator.Initializer.Value;
-                }
-
-                if (matches > 1)
-                    return false;
-            }
-
-            return matches == 1 && assignedValue != null;
         }
     }
 

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingAssignedValueAnalysis.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingAssignedValueAnalysis.cs
@@ -1,0 +1,40 @@
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC040_MixedTrackingAndNoTracking;
+
+public sealed partial class MixedTrackingAndNoTrackingAnalyzer
+{
+    private sealed partial class AnalysisState
+    {
+        private static bool TryResolveAssignedValue(ILocalSymbol local, IOperation root, out IOperation? assignedValue)
+        {
+            assignedValue = null;
+            var matches = 0;
+
+            foreach (var descendant in root.Descendants())
+            {
+                if (descendant is ISimpleAssignmentOperation assignment &&
+                    assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal &&
+                    SymbolEqualityComparer.Default.Equals(targetLocal.Local, local))
+                {
+                    matches++;
+                    assignedValue = assignment.Value;
+                }
+                else if (descendant is IVariableDeclaratorOperation declarator &&
+                         SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) &&
+                         declarator.Initializer != null)
+                {
+                    matches++;
+                    assignedValue = declarator.Initializer.Value;
+                }
+
+                if (matches > 1)
+                    return false;
+            }
+
+            return matches == 1 && assignedValue != null;
+        }
+    }
+}

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingContextResolution.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingContextResolution.cs
@@ -1,0 +1,81 @@
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC040_MixedTrackingAndNoTracking;
+
+public sealed partial class MixedTrackingAndNoTrackingAnalyzer
+{
+    private sealed partial class AnalysisState
+    {
+        private static bool TryGetContextSymbol(IInvocationOperation invocation, IOperation root, out ISymbol? contextSymbol)
+        {
+            contextSymbol = null;
+
+            var current = invocation.GetInvocationReceiver();
+            while (current != null)
+            {
+                current = current.UnwrapConversions();
+
+                if (current is IInvocationOperation nestedInvocation)
+                {
+                    if (nestedInvocation.TargetMethod.Name == "Select")
+                        return false;
+
+                    if (nestedInvocation.TargetMethod.Name == "Set" &&
+                        nestedInvocation.TargetMethod.ContainingType.IsDbContext())
+                        return TryGetSymbol(nestedInvocation.Instance, out contextSymbol);
+
+                    current = nestedInvocation.GetInvocationReceiver();
+                    continue;
+                }
+
+                switch (current)
+                {
+                    case IPropertyReferenceOperation propertyReference when propertyReference.Type.IsDbSet():
+                        return TryGetSymbol(propertyReference.Instance, out contextSymbol);
+
+                    case IFieldReferenceOperation fieldReference when fieldReference.Type.IsDbSet():
+                        return TryGetSymbol(fieldReference.Instance, out contextSymbol);
+
+                    case ILocalReferenceOperation localReference:
+                        if (!TryResolveAssignedValue(localReference.Local, root, out var assignedValue))
+                            return false;
+
+                        current = assignedValue;
+                        continue;
+
+                    case IParameterReferenceOperation:
+                        return false;
+
+                    default:
+                        return false;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryGetSymbol(IOperation? operation, out ISymbol? symbol)
+        {
+            switch (operation?.UnwrapConversions())
+            {
+                case ILocalReferenceOperation localReference:
+                    symbol = localReference.Local;
+                    return true;
+                case IParameterReferenceOperation parameterReference:
+                    symbol = parameterReference.Parameter;
+                    return true;
+                case IFieldReferenceOperation fieldReference:
+                    symbol = fieldReference.Field;
+                    return true;
+                case IPropertyReferenceOperation propertyReference:
+                    symbol = propertyReference.Property;
+                    return true;
+                default:
+                    symbol = null;
+                    return false;
+            }
+        }
+    }
+}

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingTrackingAnalysis.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingTrackingAnalysis.cs
@@ -1,0 +1,63 @@
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC040_MixedTrackingAndNoTracking;
+
+public sealed partial class MixedTrackingAndNoTrackingAnalyzer
+{
+    private sealed partial class AnalysisState
+    {
+        private static bool TryGetTrackingMode(IInvocationOperation invocation, IOperation root, out TrackingMode mode)
+        {
+            mode = TrackingMode.Tracked;
+
+            IOperation? current = invocation.GetInvocationReceiver();
+            while (current != null)
+            {
+                current = current.UnwrapConversions();
+
+                switch (current)
+                {
+                    case IInvocationOperation nestedInvocation:
+                        if (nestedInvocation.TargetMethod.Name is "AsTracking")
+                        {
+                            mode = TrackingMode.Tracked;
+                            return true;
+                        }
+
+                        if (nestedInvocation.TargetMethod.Name is "AsNoTracking" or "AsNoTrackingWithIdentityResolution")
+                        {
+                            mode = TrackingMode.NoTracking;
+                            return true;
+                        }
+
+                        if (nestedInvocation.TargetMethod.Name == "Select")
+                            return false;
+
+                        current = nestedInvocation.GetInvocationReceiver();
+                        continue;
+
+                    case ILocalReferenceOperation localReference:
+                        if (!TryResolveAssignedValue(localReference.Local, root, out var assignedValue))
+                            return false;
+
+                        current = assignedValue;
+                        continue;
+
+                    case IPropertyReferenceOperation:
+                    case IFieldReferenceOperation:
+                        return true;
+
+                    case IParameterReferenceOperation:
+                        return false;
+
+                    default:
+                        return true;
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- split `LC040`'s analyzer into smaller helper files
- separate tracking-mode analysis, context resolution, and assigned-value analysis
- keep analyzer behavior unchanged while reducing local complexity

Closes #52

## Validation
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0 --filter FullyQualifiedName~LC040_MixedTrackingAndNoTracking`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0`
- `dotnet build LinqContraband.sln -p:ContinuousIntegrationBuild=true`
