### PR TITLE
refactor(LC026): split cancellation-token analysis helpers

### DIFF
--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC026_MissingCancellationToken/MissingCancellationTokenAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC026_MissingCancellationToken/MissingCancellationTokenAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -11,7 +10,7 @@ namespace LinqContraband.Analyzers.LC026_MissingCancellationToken;
 /// Analyzes EF Core async calls to ensure CancellationToken is passed when available. Diagnostic ID: LC026
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class MissingCancellationTokenAnalyzer : DiagnosticAnalyzer
+public sealed partial class MissingCancellationTokenAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC026";
     private const string Category = "Reliability";
@@ -40,83 +39,16 @@ public sealed class MissingCancellationTokenAnalyzer : DiagnosticAnalyzer
         var invocation = (IInvocationOperation)context.Operation;
         var method = invocation.TargetMethod;
 
-        if (!method.Name.EndsWith("Async")) return;
-
-        // Verify it's an EF Core method (or related library)
-        if (!IsEfCoreMethod(method)) return;
-
-        // Check if the method accepts a CancellationToken
-        var ctParameter = method.Parameters.FirstOrDefault(p =>
-            p.Type.Name == "CancellationToken" &&
-            p.Type.ContainingNamespace?.ToString() == "System.Threading");
-
-        if (ctParameter == null) return;
-
-        // Find if an argument is passed for this parameter
-        var ctArgument = invocation.Arguments.FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.Parameter, ctParameter));
-
-        var semanticModel = context.Operation.SemanticModel;
-        if (semanticModel == null)
+        if (!IsCandidateAsyncEfMethod(method, out var ctParameter))
             return;
 
-        if (FindCancellationTokenInScope(semanticModel, invocation.Syntax.SpanStart) == null)
+        if (!HasUsableCancellationTokenInScope(context.Operation.SemanticModel, invocation.Syntax.SpanStart))
             return;
 
+        var ctArgument = FindCancellationTokenArgument(invocation, ctParameter!);
         if (ctArgument == null || ctArgument.IsImplicit || IsUsingDefault(ctArgument.Value))
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), method.Name));
         }
-    }
-
-    internal static string? FindCancellationTokenInScope(SemanticModel semanticModel, int position)
-    {
-        ISymbol? fallback = null;
-        ISymbol? shortName = null;
-
-        foreach (var symbol in semanticModel.LookupSymbols(position))
-        {
-            if (symbol is not ILocalSymbol and not IParameterSymbol)
-                continue;
-
-            var type = symbol switch
-            {
-                ILocalSymbol local => local.Type,
-                IParameterSymbol parameter => parameter.Type,
-                _ => null
-            };
-
-            if (type == null || !IsCancellationTokenType(type))
-                continue;
-
-            if (symbol.Name == "cancellationToken")
-                return symbol.Name;
-
-            if (symbol.Name == "ct" && shortName == null)
-                shortName = symbol;
-
-            fallback ??= symbol;
-        }
-
-        return shortName?.Name ?? fallback?.Name;
-    }
-
-    private bool IsEfCoreMethod(IMethodSymbol method)
-    {
-        var ns = method.ContainingNamespace?.ToString();
-        return ns != null && (ns.StartsWith("Microsoft.EntityFrameworkCore", System.StringComparison.Ordinal) ||
-                             ns.StartsWith("System.Data.Entity", System.StringComparison.Ordinal));
-    }
-
-    private static bool IsCancellationTokenType(ITypeSymbol type)
-    {
-        return type.Name == "CancellationToken" &&
-               type.ContainingNamespace?.ToString() == "System.Threading";
-    }
-
-    private bool IsUsingDefault(IOperation operation)
-    {
-        var unwrapped = operation.UnwrapConversions();
-        return unwrapped.Kind == OperationKind.DefaultValue ||
-               (unwrapped is IPropertyReferenceOperation propRef && propRef.Property.Name == "None" && propRef.Property.ContainingType.Name == "CancellationToken");
     }
 }

--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC026_MissingCancellationToken/MissingCancellationTokenMethodAnalysis.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC026_MissingCancellationToken/MissingCancellationTokenMethodAnalysis.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC026_MissingCancellationToken;
+
+public sealed partial class MissingCancellationTokenAnalyzer
+{
+    private bool IsCandidateAsyncEfMethod(IMethodSymbol method, out IParameterSymbol? cancellationTokenParameter)
+    {
+        cancellationTokenParameter = null;
+
+        if (!method.Name.EndsWith("Async", System.StringComparison.Ordinal))
+            return false;
+
+        if (!IsEfCoreMethod(method))
+            return false;
+
+        cancellationTokenParameter = method.Parameters.FirstOrDefault(IsCancellationTokenParameter);
+        return cancellationTokenParameter != null;
+    }
+
+    private static bool IsCancellationTokenParameter(IParameterSymbol parameter)
+    {
+        return IsCancellationTokenType(parameter.Type);
+    }
+
+    private static IArgumentOperation? FindCancellationTokenArgument(
+        IInvocationOperation invocation,
+        IParameterSymbol cancellationTokenParameter)
+    {
+        return invocation.Arguments.FirstOrDefault(argument =>
+            SymbolEqualityComparer.Default.Equals(argument.Parameter, cancellationTokenParameter));
+    }
+
+    private bool IsEfCoreMethod(IMethodSymbol method)
+    {
+        var ns = method.ContainingNamespace?.ToString();
+        return ns != null &&
+               (ns.StartsWith("Microsoft.EntityFrameworkCore", System.StringComparison.Ordinal) ||
+                ns.StartsWith("System.Data.Entity", System.StringComparison.Ordinal));
+    }
+
+    private static bool IsCancellationTokenType(ITypeSymbol type)
+    {
+        return type.Name == "CancellationToken" &&
+               type.ContainingNamespace?.ToString() == "System.Threading";
+    }
+
+    private bool IsUsingDefault(IOperation operation)
+    {
+        var unwrapped = operation.UnwrapConversions();
+        return unwrapped.Kind == OperationKind.DefaultValue ||
+               (unwrapped is IPropertyReferenceOperation propRef &&
+                propRef.Property.Name == "None" &&
+                propRef.Property.ContainingType.Name == "CancellationToken");
+    }
+}

--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC026_MissingCancellationToken/MissingCancellationTokenScopeAnalysis.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC026_MissingCancellationToken/MissingCancellationTokenScopeAnalysis.cs
@@ -1,0 +1,46 @@
+using Microsoft.CodeAnalysis;
+
+namespace LinqContraband.Analyzers.LC026_MissingCancellationToken;
+
+public sealed partial class MissingCancellationTokenAnalyzer
+{
+    internal static string? FindCancellationTokenInScope(SemanticModel semanticModel, int position)
+    {
+        ISymbol? fallback = null;
+        ISymbol? shortName = null;
+
+        foreach (var symbol in semanticModel.LookupSymbols(position))
+        {
+            if (symbol is not ILocalSymbol and not IParameterSymbol)
+                continue;
+
+            var type = symbol switch
+            {
+                ILocalSymbol local => local.Type,
+                IParameterSymbol parameter => parameter.Type,
+                _ => null
+            };
+
+            if (type == null || !IsCancellationTokenType(type))
+                continue;
+
+            if (symbol.Name == "cancellationToken")
+                return symbol.Name;
+
+            if (symbol.Name == "ct" && shortName == null)
+                shortName = symbol;
+
+            fallback ??= symbol;
+        }
+
+        return shortName?.Name ?? fallback?.Name;
+    }
+
+    private static bool HasUsableCancellationTokenInScope(SemanticModel? semanticModel, int position)
+    {
+        if (semanticModel == null)
+            return false;
+
+        return FindCancellationTokenInScope(semanticModel, position) != null;
+    }
+}


### PR DESCRIPTION
## Summary
- split `LC026`'s analyzer into smaller helper files
- separate method eligibility and scope/token lookup analysis
- keep analyzer behavior unchanged while reducing local complexity

## Validation
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0 --filter FullyQualifiedName~LC026_MissingCancellationToken`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0`
- `dotnet build LinqContraband.sln -p:ContinuousIntegrationBuild=true`

## Follow-up
- Created an issue for the next likely hotspot after LC026.
