### PR TITLE
refactor(LC038): split eager-loading analysis helpers

### DIFF
--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingAnalyzer.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Operations;
 namespace LinqContraband.Analyzers.LC038_ExcessiveEagerLoading;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class ExcessiveEagerLoadingAnalyzer : DiagnosticAnalyzer
+public sealed partial class ExcessiveEagerLoadingAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC038";
     internal const string ThresholdOptionKey = "dotnet_code_quality.LC038.include_threshold";
@@ -72,105 +72,5 @@ public sealed class ExcessiveEagerLoadingAnalyzer : DiagnosticAnalyzer
 
         context.ReportDiagnostic(
             Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), includeCount, threshold));
-    }
-
-    private static bool TryCountIncludeChain(IInvocationOperation outermostInvocation, out int includeCount)
-    {
-        includeCount = 0;
-
-        IOperation? current = outermostInvocation;
-        while (current is IInvocationOperation invocation && IsIncludeLike(invocation.TargetMethod))
-        {
-            includeCount++;
-            current = invocation.GetInvocationReceiver();
-        }
-
-        if (current == null)
-            return false;
-
-        return IsProvableEfRoot(current);
-    }
-
-    private static bool IsProvableEfRoot(IOperation operation)
-    {
-        operation = operation.UnwrapConversions();
-
-        return operation switch
-        {
-            IPropertyReferenceOperation propertyReference => propertyReference.Type.IsDbSet(),
-            IFieldReferenceOperation fieldReference => fieldReference.Type.IsDbSet(),
-            IInvocationOperation invocation => IsDbContextSetInvocation(invocation),
-            _ => false
-        };
-    }
-
-    private static bool IsDbContextSetInvocation(IInvocationOperation invocation)
-    {
-        return invocation.TargetMethod.Name == "Set" &&
-               invocation.TargetMethod.ContainingType.IsDbContext();
-    }
-
-    private static bool IsIncludeLike(IMethodSymbol method)
-    {
-        return IncludeLikeMethods.Contains(method.Name) &&
-               method.ContainingNamespace?.ToString()?.StartsWith("Microsoft.EntityFrameworkCore", StringComparison.Ordinal) == true;
-    }
-
-    private static bool HasIncludeAncestor(IInvocationOperation invocation)
-    {
-        for (var current = invocation.Parent; current != null; current = current.Parent)
-        {
-            if (current is not IInvocationOperation parentInvocation)
-                continue;
-
-            if (!IsIncludeLike(parentInvocation.TargetMethod))
-                continue;
-
-            if (InvocationUsesReceiverChain(parentInvocation.GetInvocationReceiver(), invocation))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static bool InvocationUsesReceiverChain(IOperation? current, IInvocationOperation target)
-    {
-        current = current?.UnwrapConversions();
-
-        while (current != null)
-        {
-            if (ReferenceEquals(current, target))
-                return true;
-
-            if (current is IInvocationOperation invocation)
-            {
-                current = invocation.GetInvocationReceiver();
-                continue;
-            }
-
-            break;
-        }
-
-        return false;
-    }
-
-    private static int GetThreshold(OperationAnalysisContext context, ConditionalWeakTable<SyntaxTree, StrongBox<int>> thresholdCache)
-    {
-        var syntaxTree = context.Operation.Syntax.SyntaxTree;
-        if (thresholdCache.TryGetValue(syntaxTree, out var cached))
-            return cached.Value;
-
-        var options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
-        var threshold = DefaultThreshold;
-
-        if (options.TryGetValue(ThresholdOptionKey, out var value) &&
-            int.TryParse(value, out var configuredThreshold) &&
-            configuredThreshold > 0)
-        {
-            threshold = configuredThreshold;
-        }
-
-        thresholdCache.Add(syntaxTree, new StrongBox<int>(threshold));
-        return threshold;
     }
 }

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingAncestorAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingAncestorAnalysis.cs
@@ -1,0 +1,46 @@
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC038_ExcessiveEagerLoading;
+
+public sealed partial class ExcessiveEagerLoadingAnalyzer
+{
+    private static bool HasIncludeAncestor(IInvocationOperation invocation)
+    {
+        for (var current = invocation.Parent; current != null; current = current.Parent)
+        {
+            if (current is not IInvocationOperation parentInvocation)
+                continue;
+
+            if (!IsIncludeLike(parentInvocation.TargetMethod))
+                continue;
+
+            if (InvocationUsesReceiverChain(parentInvocation.GetInvocationReceiver(), invocation))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool InvocationUsesReceiverChain(IOperation? current, IInvocationOperation target)
+    {
+        current = current?.UnwrapConversions();
+
+        while (current != null)
+        {
+            if (ReferenceEquals(current, target))
+                return true;
+
+            if (current is IInvocationOperation invocation)
+            {
+                current = invocation.GetInvocationReceiver();
+                continue;
+            }
+
+            break;
+        }
+
+        return false;
+    }
+}

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingChainAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingChainAnalysis.cs
@@ -1,0 +1,51 @@
+using System;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC038_ExcessiveEagerLoading;
+
+public sealed partial class ExcessiveEagerLoadingAnalyzer
+{
+    private static bool TryCountIncludeChain(IInvocationOperation outermostInvocation, out int includeCount)
+    {
+        includeCount = 0;
+
+        IOperation? current = outermostInvocation;
+        while (current is IInvocationOperation invocation && IsIncludeLike(invocation.TargetMethod))
+        {
+            includeCount++;
+            current = invocation.GetInvocationReceiver();
+        }
+
+        if (current == null)
+            return false;
+
+        return IsProvableEfRoot(current);
+    }
+
+    private static bool IsProvableEfRoot(IOperation operation)
+    {
+        operation = operation.UnwrapConversions();
+
+        return operation switch
+        {
+            IPropertyReferenceOperation propertyReference => propertyReference.Type.IsDbSet(),
+            IFieldReferenceOperation fieldReference => fieldReference.Type.IsDbSet(),
+            IInvocationOperation invocation => IsDbContextSetInvocation(invocation),
+            _ => false
+        };
+    }
+
+    private static bool IsDbContextSetInvocation(IInvocationOperation invocation)
+    {
+        return invocation.TargetMethod.Name == "Set" &&
+               invocation.TargetMethod.ContainingType.IsDbContext();
+    }
+
+    private static bool IsIncludeLike(IMethodSymbol method)
+    {
+        return IncludeLikeMethods.Contains(method.Name) &&
+               method.ContainingNamespace?.ToString()?.StartsWith("Microsoft.EntityFrameworkCore", StringComparison.Ordinal) == true;
+    }
+}

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingThresholds.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingThresholds.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace LinqContraband.Analyzers.LC038_ExcessiveEagerLoading;
+
+public sealed partial class ExcessiveEagerLoadingAnalyzer
+{
+    private static int GetThreshold(OperationAnalysisContext context, ConditionalWeakTable<SyntaxTree, StrongBox<int>> thresholdCache)
+    {
+        var syntaxTree = context.Operation.Syntax.SyntaxTree;
+        if (thresholdCache.TryGetValue(syntaxTree, out var cached))
+            return cached.Value;
+
+        var options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
+        var threshold = DefaultThreshold;
+
+        if (options.TryGetValue(ThresholdOptionKey, out var value) &&
+            int.TryParse(value, out var configuredThreshold) &&
+            configuredThreshold > 0)
+        {
+            threshold = configuredThreshold;
+        }
+
+        thresholdCache.Add(syntaxTree, new StrongBox<int>(threshold));
+        return threshold;
+    }
+}


### PR DESCRIPTION
## Summary
- split `LC038`'s analyzer into smaller helper files
- separate chain counting, ancestor detection, and threshold resolution
- keep analyzer behavior unchanged while reducing local complexity

Closes #55

## Validation
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0 --filter FullyQualifiedName~LC038_ExcessiveEagerLoading`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0`
- `dotnet build LinqContraband.sln -p:ContinuousIntegrationBuild=true`
