### PR TITLE
refactor(LC011): split primary-key analysis helpers

### DIFF
--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace LinqContraband.Analyzers.LC011_EntityMissingPrimaryKey;
@@ -21,7 +20,7 @@ namespace LinqContraband.Analyzers.LC011_EntityMissingPrimaryKey;
 /// or IEntityTypeConfiguration implementations.</para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class EntityMissingPrimaryKeyAnalyzer : DiagnosticAnalyzer
+public sealed partial class EntityMissingPrimaryKeyAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC011";
     private const string Category = "Design";
@@ -55,424 +54,61 @@ public sealed class EntityMissingPrimaryKeyAnalyzer : DiagnosticAnalyzer
     {
         var namedType = (INamedTypeSymbol)context.Symbol;
 
-        // Must be a DbContext subclass (not the base class itself)
-        if (!namedType.IsDbContext()) return;
+        if (!namedType.IsDbContext())
+            return;
         if (namedType.Name == "DbContext" &&
             namedType.ContainingNamespace?.ToString() == "Microsoft.EntityFrameworkCore")
             return;
 
-        // Gather keyless and owned entities from OnModelCreating
         var keylessEntities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
         var ownedEntities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
         ScanOnModelCreating(namedType, keylessEntities, ownedEntities, context.Compilation);
 
-        // Gather configured entities from IEntityTypeConfiguration<T>
         var configuredEntities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
         ScanEntityTypeConfigurations(context.Compilation, configuredEntities, keylessEntities);
 
-        // Find all DbSet<T> members (properties AND explicit fields, not backing fields)
         foreach (var member in namedType.GetMembers())
         {
-            ITypeSymbol? dbSetType = null;
-            Location? location = null;
+            if (!TryGetDbSetMember(member, out var entityType, out var location))
+                continue;
 
-            if (member is IPropertySymbol property)
+            if (IsMissingPrimaryKey(entityType!, namedType, configuredEntities, keylessEntities, ownedEntities, context.Compilation))
             {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(Rule, location!, entityType!.Name));
+            }
+        }
+    }
+
+    private static bool TryGetDbSetMember(ISymbol member, out INamedTypeSymbol? entityType, out Location? location)
+    {
+        entityType = null;
+        location = null;
+
+        ITypeSymbol? dbSetType = null;
+        switch (member)
+        {
+            case IPropertySymbol property:
                 dbSetType = property.Type;
                 location = property.Locations.FirstOrDefault();
-            }
-            else if (member is IFieldSymbol field)
-            {
-                // Skip compiler-generated backing fields (they start with <)
+                break;
+
+            case IFieldSymbol field:
                 if (field.IsImplicitlyDeclared || field.Name.StartsWith("<", StringComparison.Ordinal))
-                    continue;
+                    return false;
 
                 dbSetType = field.Type;
                 location = field.Locations.FirstOrDefault();
-            }
-
-            if (dbSetType is not INamedTypeSymbol propType || !propType.IsDbSet())
-                continue;
-
-            var entityType = propType.TypeArguments.Length > 0
-                ? propType.TypeArguments[0] as INamedTypeSymbol
-                : null;
-
-            if (entityType == null || location == null) continue;
-
-            // Check if entity is missing a primary key
-            if (IsMissingPrimaryKey(entityType, namedType, configuredEntities, keylessEntities, ownedEntities, context.Compilation))
-            {
-                context.ReportDiagnostic(
-                    Diagnostic.Create(Rule, location, entityType.Name));
-            }
-        }
-    }
-
-    /// <summary>
-    /// Scans OnModelCreating for HasNoKey() and OwnsOne/OwnsMany configurations.
-    /// </summary>
-    private static void ScanOnModelCreating(
-        INamedTypeSymbol dbContextType,
-        HashSet<INamedTypeSymbol> keylessEntities,
-        HashSet<INamedTypeSymbol> ownedEntities,
-        Compilation compilation)
-    {
-        var methods = dbContextType.GetMembers("OnModelCreating");
-        if (methods.IsEmpty) return;
-
-        if (methods[0] is not IMethodSymbol onModelCreating) return;
-
-        foreach (var syntaxRef in onModelCreating.DeclaringSyntaxReferences)
-        {
-            var syntax = syntaxRef.GetSyntax();
-
-            foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
-            {
-                if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) continue;
-
-                var methodName = memberAccess.Name.Identifier.Text;
-
-                if (methodName == "HasNoKey")
-                    TryAddResolvedType(ExtractEntityTypeNameFromChain(memberAccess.Expression), compilation, keylessEntities);
-                else if (methodName is "OwnsOne" or "OwnsMany")
-                    TryAddResolvedType(ExtractOwnedTypeName(invocation), compilation, ownedEntities);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Scans for IEntityTypeConfiguration implementations and caches configured entities.
-    /// </summary>
-    private static void ScanEntityTypeConfigurations(
-        Compilation compilation,
-        HashSet<INamedTypeSymbol> configuredEntities,
-        HashSet<INamedTypeSymbol> keylessEntities)
-    {
-        var configInterface = compilation.GetTypeByMetadataName("Microsoft.EntityFrameworkCore.IEntityTypeConfiguration`1");
-        if (configInterface == null) return;
-
-        // Search types in the source assembly only (not referenced assemblies) for performance
-        foreach (var type in GetAllTypes(compilation.Assembly.GlobalNamespace))
-        {
-            if (type.AllInterfaces.IsEmpty) continue;
-
-            foreach (var iface in type.AllInterfaces)
-            {
-                if (!SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, configInterface))
-                    continue;
-
-                if (iface.TypeArguments.Length > 0 &&
-                    iface.TypeArguments[0] is INamedTypeSymbol entityType)
-                {
-                    var (hasKey, hasNoKey) = CheckConfigureMethod(type);
-
-                    if (hasKey)
-                        configuredEntities.Add(entityType);
-
-                    if (hasNoKey)
-                        keylessEntities.Add(entityType);
-                }
-            }
-        }
-    }
-
-    private static void TryAddResolvedType(string? typeName, Compilation compilation, HashSet<INamedTypeSymbol> targetSet)
-    {
-        if (typeName == null) return;
-        var resolved = FindTypeByName(compilation, typeName);
-        if (resolved != null) targetSet.Add(resolved);
-    }
-
-    private static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol ns)
-    {
-        foreach (var type in ns.GetTypeMembers())
-        {
-            yield return type;
-            foreach (var nested in type.GetTypeMembers())
-                yield return nested;
+                break;
         }
 
-        foreach (var childNs in ns.GetNamespaceMembers())
-        {
-            foreach (var type in GetAllTypes(childNs))
-                yield return type;
-        }
-    }
-
-    private static (bool hasKey, bool hasNoKey) CheckConfigureMethod(INamedTypeSymbol configClass)
-    {
-        var configureMethod = configClass.GetMembers("Configure").FirstOrDefault() as IMethodSymbol;
-        if (configureMethod == null) return (false, false);
-
-        var hasKey = false;
-        var hasNoKey = false;
-
-        foreach (var syntaxRef in configureMethod.DeclaringSyntaxReferences)
-        {
-            var syntax = syntaxRef.GetSyntax();
-            var invocations = syntax.DescendantNodes().OfType<InvocationExpressionSyntax>();
-
-            foreach (var invocation in invocations)
-            {
-                if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
-                {
-                    var methodName = memberAccess.Name.Identifier.Text;
-                    if (methodName == "HasKey") hasKey = true;
-                    if (methodName == "HasNoKey") hasNoKey = true;
-                }
-            }
-        }
-
-        return (hasKey, hasNoKey);
-    }
-
-    private static string? ExtractEntityTypeNameFromChain(ExpressionSyntax expression)
-    {
-        var current = expression;
-
-        while (current != null)
-        {
-            if (current is InvocationExpressionSyntax invocation &&
-                invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-                memberAccess.Name is GenericNameSyntax genericName &&
-                genericName.Identifier.Text == "Entity")
-            {
-                var typeArg = genericName.TypeArgumentList.Arguments.FirstOrDefault();
-                if (typeArg != null)
-                    return typeArg.ToString();
-            }
-
-            current = current switch
-            {
-                InvocationExpressionSyntax inv => inv.Expression,
-                MemberAccessExpressionSyntax ma => ma.Expression,
-                _ => null
-            };
-        }
-
-        return null;
-    }
-
-    private static string? ExtractOwnedTypeName(InvocationExpressionSyntax invocation)
-    {
-        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-            memberAccess.Name is GenericNameSyntax genericName)
-        {
-            var typeArg = genericName.TypeArgumentList.Arguments.FirstOrDefault();
-            if (typeArg != null)
-                return typeArg.ToString();
-        }
-
-        return null;
-    }
-
-    private static INamedTypeSymbol? FindTypeByName(Compilation compilation, string typeName)
-    {
-        var type = compilation.GetTypeByMetadataName(typeName);
-        if (type != null) return type;
-
-        var simpleName = typeName.Contains('.') ? typeName.Substring(typeName.LastIndexOf('.') + 1) : typeName;
-        return FindTypeInNamespace(compilation.GlobalNamespace, simpleName, typeName);
-    }
-
-    private static INamedTypeSymbol? FindTypeInNamespace(INamespaceSymbol ns, string simpleName, string fullName)
-    {
-        foreach (var type in ns.GetTypeMembers())
-        {
-            if (type.Name == simpleName)
-            {
-                if (fullName.Contains('.'))
-                {
-                    // Use full display string comparison for precise matching
-                    var typeFullName = type.ToDisplayString();
-
-                    // Exact match takes priority
-                    if (typeFullName.Equals(fullName, StringComparison.Ordinal))
-                        return type;
-
-                    // Allow partial match only if the full name ends with qualified name
-                    // and the type name starts at a namespace boundary (after a dot)
-                    if (typeFullName.EndsWith(fullName, StringComparison.Ordinal))
-                    {
-                        var prefixLength = typeFullName.Length - fullName.Length;
-                        if (prefixLength == 0 || typeFullName[prefixLength - 1] == '.')
-                            return type;
-                    }
-                }
-                else
-                {
-                    return type;
-                }
-            }
-
-            foreach (var nested in type.GetTypeMembers())
-            {
-                if (nested.Name == simpleName)
-                {
-                    // For nested types, verify the containing type matches if fullName has dots
-                    if (fullName.Contains('.'))
-                    {
-                        var nestedFullName = nested.ToDisplayString();
-                        if (nestedFullName.EndsWith(fullName, StringComparison.Ordinal))
-                            return nested;
-                    }
-                    else
-                    {
-                        return nested;
-                    }
-                }
-            }
-        }
-
-        foreach (var childNs in ns.GetNamespaceMembers())
-        {
-            var found = FindTypeInNamespace(childNs, simpleName, fullName);
-            if (found != null) return found;
-        }
-
-        return null;
-    }
-
-    private bool IsMissingPrimaryKey(
-        INamedTypeSymbol entityType,
-        INamedTypeSymbol dbContextType,
-        HashSet<INamedTypeSymbol> configuredEntities,
-        HashSet<INamedTypeSymbol> keylessEntities,
-        HashSet<INamedTypeSymbol> ownedEntities,
-        Compilation compilation)
-    {
-        // Check 1: Is entity marked as keyless?
-        if (HasAttribute(entityType, "KeylessAttribute") || HasAttribute(entityType, "Keyless"))
-            return false;
-        if (keylessEntities.Contains(entityType))
+        if (dbSetType is not INamedTypeSymbol namedType || !namedType.IsDbSet())
             return false;
 
-        // Check 2: Is entity an owned type?
-        if (ownedEntities.Contains(entityType))
-            return false;
+        entityType = namedType.TypeArguments.Length > 0
+            ? namedType.TypeArguments[0] as INamedTypeSymbol
+            : null;
 
-        // Check 3: Has [PrimaryKey] attribute?
-        if (HasAttribute(entityType, "PrimaryKeyAttribute") || HasAttribute(entityType, "PrimaryKey"))
-            return false;
-
-        // Check 4: Has valid key property by convention or [Key] attribute?
-        if (HasValidKeyProperty(entityType))
-            return false;
-
-        // Check 5: Has fluent HasKey() in OnModelCreating?
-        if (HasFluentKeyConfiguration(dbContextType, entityType, compilation))
-            return false;
-
-        // Check 6: Has IEntityTypeConfiguration<T> with HasKey()?
-        if (configuredEntities.Contains(entityType))
-            return false;
-
-        return true;
-    }
-
-    private bool HasAttribute(ISymbol symbol, string attributeName)
-    {
-        foreach (var attr in symbol.GetAttributes())
-        {
-            if (attr.AttributeClass == null) continue;
-            if (attr.AttributeClass.Name == attributeName) return true;
-            if (attributeName.EndsWith("Attribute", StringComparison.Ordinal) &&
-                attr.AttributeClass.Name == attributeName.Substring(0, attributeName.Length - 9))
-                return true;
-        }
-
-        return false;
-    }
-
-    private bool HasValidKeyProperty(INamedTypeSymbol entityType)
-    {
-        var current = entityType;
-        while (current != null && current.SpecialType != SpecialType.System_Object)
-        {
-            foreach (var member in current.GetMembers())
-            {
-                if (member is not IPropertySymbol prop) continue;
-
-                // Check for [Key] attribute
-                if (HasAttribute(prop, "KeyAttribute") || HasAttribute(prop, "Key"))
-                {
-                    if (IsPublicProperty(prop) && IsValidKeyType(prop.Type))
-                        return true;
-                }
-
-                // Check for convention: Id or {EntityName}Id
-                if (prop.Name.Equals("Id", StringComparison.OrdinalIgnoreCase) ||
-                    prop.Name.Equals($"{entityType.Name}Id", StringComparison.OrdinalIgnoreCase))
-                {
-                    if (IsPublicProperty(prop) && IsValidKeyType(prop.Type))
-                        return true;
-                }
-            }
-
-            current = current.BaseType;
-        }
-
-        return false;
-    }
-
-    private static bool IsPublicProperty(IPropertySymbol prop)
-    {
-        return prop.DeclaredAccessibility == Accessibility.Public &&
-               prop.GetMethod?.DeclaredAccessibility == Accessibility.Public;
-    }
-
-    private static bool IsValidKeyType(ITypeSymbol type)
-    {
-        // Special types (int, long, string, etc.) are valid
-        if (type.SpecialType != SpecialType.None)
-            return true;
-
-        // Enums are valid
-        if (type.TypeKind == TypeKind.Enum)
-            return true;
-
-        // Struct types are generally valid (Guid, DateTime, custom value types)
-        if (type.TypeKind == TypeKind.Struct)
-            return true;
-
-        // Nullable value types are valid
-        if (type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
-            return true;
-
-        // Byte arrays are valid (for binary keys)
-        if (type is IArrayTypeSymbol arrayType && arrayType.ElementType.SpecialType == SpecialType.System_Byte)
-            return true;
-
-        // Reference types that are NOT entities/navigation properties are invalid
-        return false;
-    }
-
-    private bool HasFluentKeyConfiguration(INamedTypeSymbol dbContextType, INamedTypeSymbol entityType, Compilation compilation)
-    {
-        var methods = dbContextType.GetMembers("OnModelCreating");
-        if (methods.IsEmpty) return false;
-
-        if (methods[0] is not IMethodSymbol onModelCreating) return false;
-
-        foreach (var syntaxRef in onModelCreating.DeclaringSyntaxReferences)
-        {
-            var syntax = syntaxRef.GetSyntax();
-
-            foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
-            {
-                if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) continue;
-                if (memberAccess.Name.Identifier.Text != "HasKey") continue;
-
-                var entityTypeName = ExtractEntityTypeNameFromChain(memberAccess.Expression);
-                if (entityTypeName == null) continue;
-
-                var matchedType = FindTypeByName(compilation, entityTypeName);
-                if (matchedType != null && SymbolEqualityComparer.Default.Equals(matchedType, entityType))
-                    return true;
-            }
-        }
-
-        return false;
+        return entityType != null && location != null;
     }
 }

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyConfigurationScan.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyConfigurationScan.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LinqContraband.Analyzers.LC011_EntityMissingPrimaryKey;
+
+public sealed partial class EntityMissingPrimaryKeyAnalyzer
+{
+    private static void ScanOnModelCreating(
+        INamedTypeSymbol dbContextType,
+        HashSet<INamedTypeSymbol> keylessEntities,
+        HashSet<INamedTypeSymbol> ownedEntities,
+        Compilation compilation)
+    {
+        var methods = dbContextType.GetMembers("OnModelCreating");
+        if (methods.IsEmpty || methods[0] is not IMethodSymbol onModelCreating)
+            return;
+
+        foreach (var syntaxRef in onModelCreating.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxRef.GetSyntax();
+
+            foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+                    continue;
+
+                var methodName = memberAccess.Name.Identifier.Text;
+                if (methodName == "HasNoKey")
+                    TryAddResolvedType(ExtractEntityTypeNameFromChain(memberAccess.Expression), compilation, keylessEntities);
+                else if (methodName is "OwnsOne" or "OwnsMany")
+                    TryAddResolvedType(ExtractOwnedTypeName(invocation), compilation, ownedEntities);
+            }
+        }
+    }
+
+    private static void ScanEntityTypeConfigurations(
+        Compilation compilation,
+        HashSet<INamedTypeSymbol> configuredEntities,
+        HashSet<INamedTypeSymbol> keylessEntities)
+    {
+        var configInterface = compilation.GetTypeByMetadataName("Microsoft.EntityFrameworkCore.IEntityTypeConfiguration`1");
+        if (configInterface == null)
+            return;
+
+        foreach (var type in GetAllTypes(compilation.Assembly.GlobalNamespace))
+        {
+            if (type.AllInterfaces.IsEmpty)
+                continue;
+
+            foreach (var iface in type.AllInterfaces)
+            {
+                if (!SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, configInterface))
+                    continue;
+
+                if (iface.TypeArguments.Length > 0 &&
+                    iface.TypeArguments[0] is INamedTypeSymbol entityType)
+                {
+                    var (hasKey, hasNoKey) = CheckConfigureMethod(type);
+
+                    if (hasKey)
+                        configuredEntities.Add(entityType);
+
+                    if (hasNoKey)
+                        keylessEntities.Add(entityType);
+                }
+            }
+        }
+    }
+
+    private static (bool hasKey, bool hasNoKey) CheckConfigureMethod(INamedTypeSymbol configClass)
+    {
+        var configureMethod = configClass.GetMembers("Configure").FirstOrDefault() as IMethodSymbol;
+        if (configureMethod == null)
+            return (false, false);
+
+        var hasKey = false;
+        var hasNoKey = false;
+
+        foreach (var syntaxRef in configureMethod.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxRef.GetSyntax();
+            var invocations = syntax.DescendantNodes().OfType<InvocationExpressionSyntax>();
+
+            foreach (var invocation in invocations)
+            {
+                if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+                    continue;
+
+                var methodName = memberAccess.Name.Identifier.Text;
+                if (methodName == "HasKey")
+                    hasKey = true;
+                if (methodName == "HasNoKey")
+                    hasNoKey = true;
+            }
+        }
+
+        return (hasKey, hasNoKey);
+    }
+
+    private bool HasFluentKeyConfiguration(INamedTypeSymbol dbContextType, INamedTypeSymbol entityType, Compilation compilation)
+    {
+        var methods = dbContextType.GetMembers("OnModelCreating");
+        if (methods.IsEmpty || methods[0] is not IMethodSymbol onModelCreating)
+            return false;
+
+        foreach (var syntaxRef in onModelCreating.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxRef.GetSyntax();
+
+            foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+                    continue;
+                if (memberAccess.Name.Identifier.Text != "HasKey")
+                    continue;
+
+                var entityTypeName = ExtractEntityTypeNameFromChain(memberAccess.Expression);
+                if (entityTypeName == null)
+                    continue;
+
+                var matchedType = FindTypeByName(compilation, entityTypeName);
+                if (matchedType != null && SymbolEqualityComparer.Default.Equals(matchedType, entityType))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyKeyRules.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyKeyRules.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace LinqContraband.Analyzers.LC011_EntityMissingPrimaryKey;
+
+public sealed partial class EntityMissingPrimaryKeyAnalyzer
+{
+    private bool IsMissingPrimaryKey(
+        INamedTypeSymbol entityType,
+        INamedTypeSymbol dbContextType,
+        HashSet<INamedTypeSymbol> configuredEntities,
+        HashSet<INamedTypeSymbol> keylessEntities,
+        HashSet<INamedTypeSymbol> ownedEntities,
+        Compilation compilation)
+    {
+        if (HasAttribute(entityType, "KeylessAttribute") || HasAttribute(entityType, "Keyless"))
+            return false;
+        if (keylessEntities.Contains(entityType))
+            return false;
+
+        if (ownedEntities.Contains(entityType))
+            return false;
+
+        if (HasAttribute(entityType, "PrimaryKeyAttribute") || HasAttribute(entityType, "PrimaryKey"))
+            return false;
+
+        if (HasValidKeyProperty(entityType))
+            return false;
+
+        if (HasFluentKeyConfiguration(dbContextType, entityType, compilation))
+            return false;
+
+        if (configuredEntities.Contains(entityType))
+            return false;
+
+        return true;
+    }
+
+    private bool HasAttribute(ISymbol symbol, string attributeName)
+    {
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (attr.AttributeClass == null)
+                continue;
+            if (attr.AttributeClass.Name == attributeName)
+                return true;
+            if (attributeName.EndsWith("Attribute", StringComparison.Ordinal) &&
+                attr.AttributeClass.Name == attributeName.Substring(0, attributeName.Length - 9))
+                return true;
+        }
+
+        return false;
+    }
+
+    private bool HasValidKeyProperty(INamedTypeSymbol entityType)
+    {
+        var current = entityType;
+        while (current != null && current.SpecialType != SpecialType.System_Object)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if (member is not IPropertySymbol prop)
+                    continue;
+
+                if ((HasAttribute(prop, "KeyAttribute") || HasAttribute(prop, "Key")) &&
+                    IsPublicProperty(prop) &&
+                    IsValidKeyType(prop.Type))
+                {
+                    return true;
+                }
+
+                if ((prop.Name.Equals("Id", StringComparison.OrdinalIgnoreCase) ||
+                     prop.Name.Equals($"{entityType.Name}Id", StringComparison.OrdinalIgnoreCase)) &&
+                    IsPublicProperty(prop) &&
+                    IsValidKeyType(prop.Type))
+                {
+                    return true;
+                }
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static bool IsPublicProperty(IPropertySymbol prop)
+    {
+        return prop.DeclaredAccessibility == Accessibility.Public &&
+               prop.GetMethod?.DeclaredAccessibility == Accessibility.Public;
+    }
+
+    private static bool IsValidKeyType(ITypeSymbol type)
+    {
+        if (type.SpecialType != SpecialType.None)
+            return true;
+
+        if (type.TypeKind == TypeKind.Enum)
+            return true;
+
+        if (type.TypeKind == TypeKind.Struct)
+            return true;
+
+        if (type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+            return true;
+
+        if (type is IArrayTypeSymbol arrayType && arrayType.ElementType.SpecialType == SpecialType.System_Byte)
+            return true;
+
+        return false;
+    }
+}

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyTypeLookup.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyTypeLookup.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LinqContraband.Analyzers.LC011_EntityMissingPrimaryKey;
+
+public sealed partial class EntityMissingPrimaryKeyAnalyzer
+{
+    private static void TryAddResolvedType(string? typeName, Compilation compilation, HashSet<INamedTypeSymbol> targetSet)
+    {
+        if (typeName == null)
+            return;
+        var resolved = FindTypeByName(compilation, typeName);
+        if (resolved != null)
+            targetSet.Add(resolved);
+    }
+
+    private static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol ns)
+    {
+        foreach (var type in ns.GetTypeMembers())
+        {
+            yield return type;
+            foreach (var nested in type.GetTypeMembers())
+                yield return nested;
+        }
+
+        foreach (var childNs in ns.GetNamespaceMembers())
+        {
+            foreach (var type in GetAllTypes(childNs))
+                yield return type;
+        }
+    }
+
+    private static string? ExtractEntityTypeNameFromChain(ExpressionSyntax expression)
+    {
+        var current = expression;
+
+        while (current != null)
+        {
+            if (current is InvocationExpressionSyntax invocation &&
+                invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Name is GenericNameSyntax genericName &&
+                genericName.Identifier.Text == "Entity")
+            {
+                var typeArg = genericName.TypeArgumentList.Arguments.FirstOrDefault();
+                if (typeArg != null)
+                    return typeArg.ToString();
+            }
+
+            current = current switch
+            {
+                InvocationExpressionSyntax inv => inv.Expression,
+                MemberAccessExpressionSyntax ma => ma.Expression,
+                _ => null
+            };
+        }
+
+        return null;
+    }
+
+    private static string? ExtractOwnedTypeName(InvocationExpressionSyntax invocation)
+    {
+        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+            memberAccess.Name is GenericNameSyntax genericName)
+        {
+            var typeArg = genericName.TypeArgumentList.Arguments.FirstOrDefault();
+            if (typeArg != null)
+                return typeArg.ToString();
+        }
+
+        return null;
+    }
+
+    private static INamedTypeSymbol? FindTypeByName(Compilation compilation, string typeName)
+    {
+        var type = compilation.GetTypeByMetadataName(typeName);
+        if (type != null)
+            return type;
+
+        var simpleName = typeName.Contains(".", StringComparison.Ordinal)
+            ? typeName.Substring(typeName.LastIndexOf(".", StringComparison.Ordinal) + 1)
+            : typeName;
+        return FindTypeInNamespace(compilation.GlobalNamespace, simpleName, typeName);
+    }
+
+    private static INamedTypeSymbol? FindTypeInNamespace(INamespaceSymbol ns, string simpleName, string fullName)
+    {
+        foreach (var type in ns.GetTypeMembers())
+        {
+            if (type.Name == simpleName)
+            {
+                if (fullName.Contains(".", StringComparison.Ordinal))
+                {
+                    var typeFullName = type.ToDisplayString();
+                    if (typeFullName.Equals(fullName, StringComparison.Ordinal))
+                        return type;
+
+                    if (typeFullName.EndsWith(fullName, StringComparison.Ordinal))
+                    {
+                        var prefixLength = typeFullName.Length - fullName.Length;
+                        if (prefixLength == 0 || typeFullName[prefixLength - 1] == '.')
+                            return type;
+                    }
+                }
+                else
+                {
+                    return type;
+                }
+            }
+
+            foreach (var nested in type.GetTypeMembers())
+            {
+                if (nested.Name != simpleName)
+                    continue;
+
+                if (fullName.Contains(".", StringComparison.Ordinal))
+                {
+                    var nestedFullName = nested.ToDisplayString();
+                    if (nestedFullName.EndsWith(fullName, StringComparison.Ordinal))
+                        return nested;
+                }
+                else
+                {
+                    return nested;
+                }
+            }
+        }
+
+        foreach (var childNs in ns.GetNamespaceMembers())
+        {
+            var found = FindTypeInNamespace(childNs, simpleName, fullName);
+            if (found != null)
+                return found;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- split `LC011`'s analyzer into smaller helper files
- separate configuration scanning, type lookup, and key-rule analysis
- keep analyzer behavior unchanged while reducing local complexity

## Validation
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0 --filter FullyQualifiedName~LC011_EntityMissingPrimaryKey`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0`
- `dotnet build LinqContraband.sln -p:ContinuousIntegrationBuild=true`

## Follow-up
- Created an issue for the next likely hotspot after LC011.
