### PR TITLE
refactor(LC037): split raw-sql construction analysis helpers

### DIFF
--- a/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC037_RawSqlStringConstruction/RawSqlStringConstructionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC037_RawSqlStringConstruction/RawSqlStringConstructionAnalyzer.cs
@@ -1,6 +1,4 @@
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -9,7 +7,7 @@ using Microsoft.CodeAnalysis.Operations;
 namespace LinqContraband.Analyzers.LC037_RawSqlStringConstruction;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class RawSqlStringConstructionAnalyzer : DiagnosticAnalyzer
+public sealed partial class RawSqlStringConstructionAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC037";
     private const string Category = "Security";
@@ -50,186 +48,44 @@ public sealed class RawSqlStringConstructionAnalyzer : DiagnosticAnalyzer
         var invocation = (IInvocationOperation)context.Operation;
         var method = invocation.TargetMethod;
 
-        if (!TargetMethods.Contains(method.Name) ||
-            method.ContainingNamespace?.ToString().StartsWith("Microsoft.EntityFrameworkCore", System.StringComparison.Ordinal) != true)
-        {
+        if (!IsTargetRawSqlMethod(method))
             return;
-        }
 
         var sqlArgument = GetSqlArgument(invocation, method);
         if (sqlArgument == null)
             return;
 
-        if (IsOwnedBySpecificRawSqlAnalyzer(sqlArgument.Value, invocation.FindOwningExecutableRoot()))
+        var executableRoot = invocation.FindOwningExecutableRoot();
+        if (IsOwnedBySpecificRawSqlAnalyzer(sqlArgument.Value, executableRoot))
             return;
 
-        if (!IsConstructedRawSql(sqlArgument.Value, invocation.FindOwningExecutableRoot()))
+        if (!IsConstructedRawSql(sqlArgument.Value, executableRoot))
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(Rule, sqlArgument.Value.Syntax.GetLocation(), method.Name));
     }
 
+    private static bool IsTargetRawSqlMethod(IMethodSymbol method)
+    {
+        return TargetMethods.Contains(method.Name) &&
+               method.ContainingNamespace?.ToString().StartsWith("Microsoft.EntityFrameworkCore", System.StringComparison.Ordinal) == true;
+    }
+
     private static IArgumentOperation? GetSqlArgument(IInvocationOperation invocation, IMethodSymbol method)
     {
-        var sqlParameterIndex = method.Parameters.ToList().FindIndex(parameter => parameter.Name == "sql");
+        var sqlParameterIndex = -1;
+        for (var i = 0; i < method.Parameters.Length; i++)
+        {
+            if (method.Parameters[i].Name == "sql")
+            {
+                sqlParameterIndex = i;
+                break;
+            }
+        }
+
         if (sqlParameterIndex < 0 || sqlParameterIndex >= invocation.Arguments.Length)
             return null;
 
         return invocation.Arguments[sqlParameterIndex];
-    }
-
-    private static bool IsOwnedBySpecificRawSqlAnalyzer(IOperation operation, IOperation? executableRoot)
-    {
-        var current = operation.UnwrapConversions();
-
-        if (current is IInterpolatedStringOperation)
-            return true;
-
-        return current is IBinaryOperation binary &&
-               binary.OperatorKind == BinaryOperatorKind.Add &&
-               IsConcatWithNonConstant(binary, executableRoot);
-    }
-
-    private static bool IsConstructedRawSql(IOperation operation, IOperation? executableRoot)
-    {
-        var current = operation.UnwrapConversions();
-
-        if (current.ConstantValue.HasValue)
-            return false;
-
-        if (current is IInterpolatedStringOperation)
-            return true;
-
-        if (current is IBinaryOperation binary && binary.OperatorKind == BinaryOperatorKind.Add)
-            return IsConcatWithNonConstant(binary, executableRoot);
-
-        if (current is IInvocationOperation invocation)
-            return IsSuspiciousInvocation(invocation, executableRoot);
-
-        if (current is ILocalReferenceOperation localReference)
-            return TryResolveLocalValue(localReference.Local, executableRoot, out var resolvedValue) &&
-                   IsConstructedRawSql(resolvedValue, executableRoot);
-
-        return false;
-    }
-
-    private static bool IsConcatWithNonConstant(IBinaryOperation binary, IOperation? executableRoot)
-    {
-        return IsNonConstant(binary.LeftOperand, executableRoot) || IsNonConstant(binary.RightOperand, executableRoot);
-    }
-
-    private static bool IsNonConstant(IOperation operation, IOperation? executableRoot)
-    {
-        var current = operation.UnwrapConversions();
-        if (current.ConstantValue.HasValue)
-            return false;
-
-        return current switch
-        {
-            IInterpolatedStringOperation => true,
-            IBinaryOperation binary when binary.OperatorKind == BinaryOperatorKind.Add => IsConcatWithNonConstant(binary, executableRoot),
-            IInvocationOperation invocation => IsSuspiciousInvocation(invocation, executableRoot),
-            ILocalReferenceOperation localReference => TryResolveLocalValue(localReference.Local, executableRoot, out var resolvedValue) &&
-                                                       IsConstructedRawSql(resolvedValue, executableRoot),
-            IFieldReferenceOperation => true,
-            IPropertyReferenceOperation => true,
-            _ => true
-        };
-    }
-
-    private static bool IsSuspiciousInvocation(IInvocationOperation invocation, IOperation? executableRoot)
-    {
-        var method = invocation.TargetMethod;
-
-        if (method.Name == "Format" &&
-            method.ContainingType.Name == "String" &&
-            method.ContainingNamespace?.ToString() == "System")
-        {
-            return invocation.Arguments.Any(arg => !arg.Value.UnwrapConversions().ConstantValue.HasValue);
-        }
-
-        if (method.Name == "Concat" &&
-            method.ContainingType.Name == "String" &&
-            method.ContainingNamespace?.ToString() == "System")
-        {
-            return invocation.Arguments.Any(arg => IsNonConstant(arg.Value, executableRoot));
-        }
-
-        if (method.Name == "ToString" &&
-            invocation.GetInvocationReceiver()?.Type is INamedTypeSymbol receiverType &&
-            receiverType.Name == "StringBuilder" &&
-            receiverType.ContainingNamespace?.ToString() == "System.Text")
-        {
-            return ContainsSuspiciousStringBuilderAppend(invocation.GetInvocationReceiver(), executableRoot);
-        }
-
-        return false;
-    }
-
-    private static bool ContainsSuspiciousStringBuilderAppend(IOperation? receiver, IOperation? executableRoot)
-    {
-        if (receiver == null)
-            return false;
-
-        var current = receiver.UnwrapConversions();
-
-        if (current is IInvocationOperation invocation)
-        {
-            if (invocation.TargetMethod.ContainingType.Name == nameof(StringBuilder) &&
-                invocation.TargetMethod.ContainingNamespace?.ToString() == "System.Text" &&
-                invocation.TargetMethod.Name.StartsWith("Append", System.StringComparison.Ordinal))
-            {
-                if (invocation.Arguments.Any(arg => IsNonConstant(arg.Value, executableRoot)))
-                    return true;
-
-                return ContainsSuspiciousStringBuilderAppend(invocation.GetInvocationReceiver(), executableRoot);
-            }
-
-            return ContainsSuspiciousStringBuilderAppend(invocation.GetInvocationReceiver(), executableRoot);
-        }
-
-        if (current is ILocalReferenceOperation localReference)
-        {
-            return TryResolveLocalValue(localReference.Local, executableRoot, out var resolvedValue) &&
-                   ContainsSuspiciousStringBuilderAppend(resolvedValue, executableRoot);
-        }
-
-        return false;
-    }
-
-    private static bool TryResolveLocalValue(ILocalSymbol local, IOperation? executableRoot, out IOperation value)
-    {
-        value = null!;
-
-        if (executableRoot == null)
-            return false;
-
-        foreach (var descendant in executableRoot.Descendants())
-        {
-            if (descendant is IVariableDeclarationOperation declaration)
-            {
-                foreach (var declarator in declaration.Declarators)
-                {
-                    if (!SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) ||
-                        declarator.Initializer == null)
-                    {
-                        continue;
-                    }
-
-                    value = declarator.Initializer.Value;
-                    return true;
-                }
-            }
-
-            if (descendant is ISimpleAssignmentOperation assignment &&
-                assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal &&
-                SymbolEqualityComparer.Default.Equals(targetLocal.Local, local))
-            {
-                value = assignment.Value;
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC037_RawSqlStringConstruction/RawSqlStringConstructionDetection.cs
+++ b/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC037_RawSqlStringConstruction/RawSqlStringConstructionDetection.cs
@@ -1,0 +1,138 @@
+using System.Linq;
+using System.Text;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC037_RawSqlStringConstruction;
+
+public sealed partial class RawSqlStringConstructionAnalyzer
+{
+    private static bool IsOwnedBySpecificRawSqlAnalyzer(IOperation operation, IOperation? executableRoot)
+    {
+        var current = operation.UnwrapConversions();
+
+        if (current is IInterpolatedStringOperation)
+            return true;
+
+        return current is IBinaryOperation binary &&
+               binary.OperatorKind == BinaryOperatorKind.Add &&
+               IsConcatWithNonConstant(binary, executableRoot);
+    }
+
+    private static bool IsConstructedRawSql(IOperation operation, IOperation? executableRoot)
+    {
+        var current = operation.UnwrapConversions();
+
+        if (current.ConstantValue.HasValue)
+            return false;
+
+        return current switch
+        {
+            IInterpolatedStringOperation => true,
+            IBinaryOperation binary when binary.OperatorKind == BinaryOperatorKind.Add => IsConcatWithNonConstant(binary, executableRoot),
+            IInvocationOperation invocation => IsSuspiciousInvocation(invocation, executableRoot),
+            ILocalReferenceOperation localReference => TryResolveLocalValue(localReference.Local, executableRoot, out var resolvedValue) &&
+                                                       IsConstructedRawSql(resolvedValue, executableRoot),
+            _ => false
+        };
+    }
+
+    private static bool IsConcatWithNonConstant(IBinaryOperation binary, IOperation? executableRoot)
+    {
+        return IsNonConstant(binary.LeftOperand, executableRoot) || IsNonConstant(binary.RightOperand, executableRoot);
+    }
+
+    private static bool IsNonConstant(IOperation operation, IOperation? executableRoot)
+    {
+        var current = operation.UnwrapConversions();
+        if (current.ConstantValue.HasValue)
+            return false;
+
+        return current switch
+        {
+            IInterpolatedStringOperation => true,
+            IBinaryOperation binary when binary.OperatorKind == BinaryOperatorKind.Add => IsConcatWithNonConstant(binary, executableRoot),
+            IInvocationOperation invocation => IsSuspiciousInvocation(invocation, executableRoot),
+            ILocalReferenceOperation localReference => TryResolveLocalValue(localReference.Local, executableRoot, out var resolvedValue) &&
+                                                       IsConstructedRawSql(resolvedValue, executableRoot),
+            IFieldReferenceOperation => true,
+            IPropertyReferenceOperation => true,
+            _ => true
+        };
+    }
+
+    private static bool IsSuspiciousInvocation(IInvocationOperation invocation, IOperation? executableRoot)
+    {
+        var method = invocation.TargetMethod;
+
+        if (IsStringFormat(method))
+            return invocation.Arguments.Any(arg => !arg.Value.UnwrapConversions().ConstantValue.HasValue);
+
+        if (IsStringConcat(method))
+            return invocation.Arguments.Any(arg => IsNonConstant(arg.Value, executableRoot));
+
+        if (IsStringBuilderToString(invocation))
+            return ContainsSuspiciousStringBuilderAppend(invocation.GetInvocationReceiver(), executableRoot);
+
+        return false;
+    }
+
+    private static bool IsStringFormat(IMethodSymbol method)
+    {
+        return method.Name == "Format" &&
+               method.ContainingType.Name == "String" &&
+               method.ContainingNamespace?.ToString() == "System";
+    }
+
+    private static bool IsStringConcat(IMethodSymbol method)
+    {
+        return method.Name == "Concat" &&
+               method.ContainingType.Name == "String" &&
+               method.ContainingNamespace?.ToString() == "System";
+    }
+
+    private static bool IsStringBuilderToString(IInvocationOperation invocation)
+    {
+        return invocation.TargetMethod.Name == "ToString" &&
+               invocation.GetInvocationReceiver()?.Type is INamedTypeSymbol receiverType &&
+               receiverType.Name == "StringBuilder" &&
+               receiverType.ContainingNamespace?.ToString() == "System.Text";
+    }
+
+    private static bool ContainsSuspiciousStringBuilderAppend(IOperation? receiver, IOperation? executableRoot)
+    {
+        if (receiver == null)
+            return false;
+
+        var current = receiver.UnwrapConversions();
+
+        if (current is IInvocationOperation invocation)
+        {
+            if (IsStringBuilderAppend(invocation.TargetMethod))
+            {
+                if (invocation.Arguments.Any(arg => IsNonConstant(arg.Value, executableRoot)))
+                    return true;
+
+                return ContainsSuspiciousStringBuilderAppend(invocation.GetInvocationReceiver(), executableRoot);
+            }
+
+            return ContainsSuspiciousStringBuilderAppend(invocation.GetInvocationReceiver(), executableRoot);
+        }
+
+        if (current is ILocalReferenceOperation localReference)
+        {
+            return TryResolveLocalValue(localReference.Local, executableRoot, out var resolvedValue) &&
+                   ContainsSuspiciousStringBuilderAppend(resolvedValue, executableRoot);
+        }
+
+        return false;
+    }
+
+    private static bool IsStringBuilderAppend(IMethodSymbol method)
+    {
+        return method.ContainingType.Name == nameof(StringBuilder) &&
+               method.ContainingNamespace?.ToString() == "System.Text" &&
+               method.Name.StartsWith("Append", System.StringComparison.Ordinal);
+    }
+}

--- a/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC037_RawSqlStringConstruction/RawSqlStringConstructionLocalResolution.cs
+++ b/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC037_RawSqlStringConstruction/RawSqlStringConstructionLocalResolution.cs
@@ -1,0 +1,41 @@
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC037_RawSqlStringConstruction;
+
+public sealed partial class RawSqlStringConstructionAnalyzer
+{
+    private static bool TryResolveLocalValue(ILocalSymbol local, IOperation? executableRoot, out IOperation value)
+    {
+        value = null!;
+
+        if (executableRoot == null)
+            return false;
+
+        foreach (var descendant in executableRoot.Descendants())
+        {
+            if (descendant is IVariableDeclarationOperation declaration)
+            {
+                foreach (var declarator in declaration.Declarators)
+                {
+                    if (!SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) || declarator.Initializer == null)
+                        continue;
+
+                    value = declarator.Initializer.Value;
+                    return true;
+                }
+            }
+
+            if (descendant is ISimpleAssignmentOperation assignment &&
+                assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal &&
+                SymbolEqualityComparer.Default.Equals(targetLocal.Local, local))
+            {
+                value = assignment.Value;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- split `LC037`'s analyzer into smaller helper files
- separate construction detection and local-resolution logic
- keep analyzer behavior unchanged while reducing local complexity

Closes #67

## Validation
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0 --filter FullyQualifiedName~LC037_RawSqlStringConstruction`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0`
- `dotnet build LinqContraband.sln -p:ContinuousIntegrationBuild=true`
