### PR TITLE
refactor(LC006): split cartesian-explosion analysis helpers

### DIFF
--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,7 +18,7 @@ namespace LinqContraband.Analyzers.LC006_CartesianExplosion;
 /// Use AsSplitQuery() to separate into distinct SQL queries or manually load collections separately.</para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class CartesianExplosionAnalyzer : DiagnosticAnalyzer
+public sealed partial class CartesianExplosionAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC006";
     private const string Category = "Performance";
@@ -55,18 +53,19 @@ public sealed class CartesianExplosionAnalyzer : DiagnosticAnalyzer
         var invocation = (IInvocationOperation)context.Operation;
         var method = invocation.TargetMethod;
 
-        if (method.Name != "Include" || method.ContainingNamespace?.ToString() != "Microsoft.EntityFrameworkCore")
+        if (!IsIncludeMethod(method))
             return;
 
         var semanticModel = context.Operation.SemanticModel;
-        if (semanticModel == null) return;
+        if (semanticModel == null || invocation.Syntax is not InvocationExpressionSyntax invocationSyntax)
+            return;
 
-        if (invocation.Syntax is not InvocationExpressionSyntax invocationSyntax) return;
-        if (!TryGetIncludedNavigation(invocationSyntax, semanticModel, out var currentNavigation)) return;
+        if (!TryGetIncludedNavigation(invocationSyntax, semanticModel, out var currentNavigation))
+            return;
 
         var chain = AnalyzeIncludeChain(invocationSyntax, semanticModel);
-        if (HasSplitQueryDownstream(invocationSyntax, semanticModel)) return;
-        if (chain.HasSplitQuery) return;
+        if (HasSplitQueryDownstream(invocationSyntax, semanticModel) || chain.HasSplitQuery)
+            return;
 
         if (chain.CollectionIncludes.Count > 1)
         {
@@ -75,127 +74,14 @@ public sealed class CartesianExplosionAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static IncludeChainAnalysis AnalyzeIncludeChain(
-        InvocationExpressionSyntax invocationSyntax,
-        SemanticModel semanticModel)
+    private static bool IsIncludeMethod(IMethodSymbol method)
     {
-        var result = new IncludeChainAnalysis();
-        InvocationExpressionSyntax? current = invocationSyntax;
-
-        while (current?.Expression is MemberAccessExpressionSyntax memberAccess)
-        {
-            var symbol = semanticModel.GetSymbolInfo(current).Symbol as IMethodSymbol;
-            if (symbol?.ContainingNamespace?.ToString() != "Microsoft.EntityFrameworkCore")
-            {
-                current = memberAccess.Expression as InvocationExpressionSyntax;
-                continue;
-            }
-
-            var methodName = memberAccess.Name.Identifier.Text;
-            if (methodName == "AsSplitQuery")
-            {
-                result.HasSplitQuery = true;
-            }
-            else if (methodName == "Include" &&
-                     TryGetIncludedNavigation(current, semanticModel, out var navigation))
-            {
-                result.CollectionIncludes.Add(navigation);
-            }
-
-            current = memberAccess.Expression as InvocationExpressionSyntax;
-        }
-
-        result.CollectionIncludes.Reverse();
-        return result;
-    }
-
-    private static bool HasSplitQueryDownstream(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
-    {
-        var current = invocation.Parent;
-        while (current != null)
-        {
-            if (current is InvocationExpressionSyntax parentInvocation &&
-                parentInvocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-                memberAccess.Name.Identifier.Text == "AsSplitQuery" &&
-                semanticModel.GetSymbolInfo(parentInvocation).Symbol is IMethodSymbol method &&
-                method.ContainingNamespace?.ToString() == "Microsoft.EntityFrameworkCore")
-            {
-                return true;
-            }
-
-            current = current.Parent;
-        }
-
-        return false;
-    }
-
-    private static bool TryGetIncludedNavigation(
-        InvocationExpressionSyntax invocationSyntax,
-        SemanticModel semanticModel,
-        out string navigationName)
-    {
-        navigationName = string.Empty;
-        if (invocationSyntax.ArgumentList.Arguments.Count == 0)
-        {
-            return false;
-        }
-
-        var lambdaExpression = invocationSyntax.ArgumentList.Arguments.Last().Expression;
-        var lambdaBody = lambdaExpression switch
-        {
-            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Body,
-            ParenthesizedLambdaExpressionSyntax parenthesizedLambda => parenthesizedLambda.Body,
-            _ => null
-        };
-
-        if (lambdaBody is MemberAccessExpressionSyntax memberAccess)
-        {
-            var propertySymbol = semanticModel.GetSymbolInfo(memberAccess).Symbol as IPropertySymbol;
-            var propertyType = propertySymbol?.Type ?? semanticModel.GetTypeInfo(memberAccess).Type;
-            if (propertyType == null || !IsCollection(propertyType)) return false;
-
-            navigationName = memberAccess.Name.Identifier.Text;
-            return true;
-        }
-
-        return false;
-    }
-
-    private static bool IsCollection(ITypeSymbol type)
-    {
-        if (type.SpecialType == SpecialType.System_String) return false;
-        // Arrays are collections
-        if (type.TypeKind == TypeKind.Array) return true;
-
-        if (type is INamedTypeSymbol namedType)
-        {
-            var ns = namedType.ContainingNamespace?.ToString();
-
-            // Check for System.Collections.Generic types with namespace verification
-            if (ns == "System.Collections.Generic" && namedType.IsGenericType)
-            {
-                return namedType.Name is "List" or "IList" or "IEnumerable" or "ICollection"
-                    or "HashSet" or "ISet" or "IReadOnlyList" or "IReadOnlyCollection";
-            }
-        }
-
-        // Also check interfaces for IEnumerable<T> implementation
-        foreach (var iface in type.AllInterfaces)
-        {
-            if (iface.Name == "IEnumerable" && iface.IsGenericType &&
-                iface.ContainingNamespace?.ToString() == "System.Collections.Generic")
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return method.Name == "Include" && method.ContainingNamespace?.ToString() == "Microsoft.EntityFrameworkCore";
     }
 
     private sealed class IncludeChainAnalysis
     {
         public bool HasSplitQuery { get; set; }
-
-        public List<string> CollectionIncludes { get; } = new();
+        public System.Collections.Generic.List<string> CollectionIncludes { get; } = new();
     }
 }

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionChainAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionChainAnalysis.cs
@@ -1,0 +1,61 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LinqContraband.Analyzers.LC006_CartesianExplosion;
+
+public sealed partial class CartesianExplosionAnalyzer
+{
+    private static IncludeChainAnalysis AnalyzeIncludeChain(
+        InvocationExpressionSyntax invocationSyntax,
+        SemanticModel semanticModel)
+    {
+        var result = new IncludeChainAnalysis();
+        InvocationExpressionSyntax? current = invocationSyntax;
+
+        while (current?.Expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            var symbol = semanticModel.GetSymbolInfo(current).Symbol as IMethodSymbol;
+            if (symbol?.ContainingNamespace?.ToString() != "Microsoft.EntityFrameworkCore")
+            {
+                current = memberAccess.Expression as InvocationExpressionSyntax;
+                continue;
+            }
+
+            var methodName = memberAccess.Name.Identifier.Text;
+            if (methodName == "AsSplitQuery")
+            {
+                result.HasSplitQuery = true;
+            }
+            else if (methodName == "Include" &&
+                     TryGetIncludedNavigation(current, semanticModel, out var navigation))
+            {
+                result.CollectionIncludes.Add(navigation);
+            }
+
+            current = memberAccess.Expression as InvocationExpressionSyntax;
+        }
+
+        result.CollectionIncludes.Reverse();
+        return result;
+    }
+
+    private static bool HasSplitQueryDownstream(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+    {
+        var current = invocation.Parent;
+        while (current != null)
+        {
+            if (current is InvocationExpressionSyntax parentInvocation &&
+                parentInvocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Name.Identifier.Text == "AsSplitQuery" &&
+                semanticModel.GetSymbolInfo(parentInvocation).Symbol is IMethodSymbol method &&
+                method.ContainingNamespace?.ToString() == "Microsoft.EntityFrameworkCore")
+            {
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+}

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionNavigationAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionNavigationAnalysis.cs
@@ -1,0 +1,65 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace LinqContraband.Analyzers.LC006_CartesianExplosion;
+
+public sealed partial class CartesianExplosionAnalyzer
+{
+    private static bool TryGetIncludedNavigation(
+        InvocationExpressionSyntax invocationSyntax,
+        SemanticModel semanticModel,
+        out string navigationName)
+    {
+        navigationName = string.Empty;
+        if (invocationSyntax.ArgumentList.Arguments.Count == 0)
+            return false;
+
+        var lambdaExpression = invocationSyntax.ArgumentList.Arguments[invocationSyntax.ArgumentList.Arguments.Count - 1].Expression;
+        var lambdaBody = lambdaExpression switch
+        {
+            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Body,
+            ParenthesizedLambdaExpressionSyntax parenthesizedLambda => parenthesizedLambda.Body,
+            _ => null
+        };
+
+        if (lambdaBody is not MemberAccessExpressionSyntax memberAccess)
+            return false;
+
+        var propertySymbol = semanticModel.GetSymbolInfo(memberAccess).Symbol as IPropertySymbol;
+        var propertyType = propertySymbol?.Type ?? semanticModel.GetTypeInfo(memberAccess).Type;
+        if (propertyType == null || !IsCollection(propertyType))
+            return false;
+
+        navigationName = memberAccess.Name.Identifier.Text;
+        return true;
+    }
+
+    private static bool IsCollection(ITypeSymbol type)
+    {
+        if (type.SpecialType == SpecialType.System_String)
+            return false;
+        if (type.TypeKind == TypeKind.Array)
+            return true;
+
+        if (type is INamedTypeSymbol namedType)
+        {
+            var ns = namedType.ContainingNamespace?.ToString();
+            if (ns == "System.Collections.Generic" && namedType.IsGenericType)
+            {
+                return namedType.Name is "List" or "IList" or "IEnumerable" or "ICollection"
+                    or "HashSet" or "ISet" or "IReadOnlyList" or "IReadOnlyCollection";
+            }
+        }
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (iface.Name == "IEnumerable" && iface.IsGenericType &&
+                iface.ContainingNamespace?.ToString() == "System.Collections.Generic")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- split `LC006`'s analyzer into smaller helper files
- separate include-chain and navigation analysis
- keep analyzer behavior unchanged while reducing local complexity

Closes #73

## Validation
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0 --filter FullyQualifiedName~LC006_CartesianExplosion`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0`
- `dotnet build LinqContraband.sln -p:ContinuousIntegrationBuild=true`
