### PR TITLE
refactor(LC042): split missing-query-tags analysis helpers

### DIFF
--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC042_MissingQueryTags/MissingQueryTagsAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC042_MissingQueryTags/MissingQueryTagsAnalyzer.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -10,7 +8,7 @@ using Microsoft.CodeAnalysis.Operations;
 namespace LinqContraband.Analyzers.LC042_MissingQueryTags;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class MissingQueryTagsAnalyzer : DiagnosticAnalyzer
+public sealed partial class MissingQueryTagsAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC042";
     private const string Category = "Performance";
@@ -119,73 +117,6 @@ public sealed class MissingQueryTagsAnalyzer : DiagnosticAnalyzer
             return;
 
         context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), count));
-    }
-
-    private static bool TryAnalyzeChain(IOperation receiver, out int count)
-    {
-        count = 0;
-        var current = receiver;
-
-        while (current != null)
-        {
-            current = current.UnwrapConversions();
-
-            if (current is IInvocationOperation invocation)
-            {
-                var methodName = invocation.TargetMethod.Name;
-
-                if (methodName is "TagWith" or "TagWithCallSite")
-                    return false;
-
-                if (QuerySteps.Contains(methodName))
-                {
-                    count++;
-                    current = invocation.GetInvocationReceiver();
-                    continue;
-                }
-
-                if (methodName == "Set" && invocation.TargetMethod.ContainingType.IsDbContext())
-                {
-                    return true;
-                }
-
-                return false;
-            }
-
-            if (current.Type != null && current.Type.IsDbSet())
-                return true;
-
-            if (current is IPropertyReferenceOperation propertyReference &&
-                propertyReference.Type.IsDbSet())
-            {
-                return true;
-            }
-
-            if (current is IFieldReferenceOperation fieldReference &&
-                fieldReference.Type.IsDbSet())
-            {
-                return true;
-            }
-
-            if (current is ILocalReferenceOperation localReference &&
-                localReference.Type.IsDbSet())
-            {
-                return true;
-            }
-
-            if (current is IParameterReferenceOperation parameterReference &&
-                parameterReference.Type.IsDbSet())
-            {
-                return true;
-            }
-
-            if (current is IPropertyReferenceOperation or IFieldReferenceOperation or ILocalReferenceOperation or IParameterReferenceOperation)
-                return false;
-
-            return false;
-        }
-
-        return false;
     }
 
     private static int GetThreshold(AnalyzerConfigOptionsProvider provider, SyntaxTree syntaxTree)

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC042_MissingQueryTags/MissingQueryTagsChainAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC042_MissingQueryTags/MissingQueryTagsChainAnalysis.cs
@@ -1,0 +1,64 @@
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC042_MissingQueryTags;
+
+public sealed partial class MissingQueryTagsAnalyzer
+{
+    private static bool TryAnalyzeChain(IOperation receiver, out int count)
+    {
+        count = 0;
+        var current = receiver;
+
+        while (current != null)
+        {
+            current = current.UnwrapConversions();
+
+            if (current is IInvocationOperation invocation)
+            {
+                var methodName = invocation.TargetMethod.Name;
+
+                if (methodName is "TagWith" or "TagWithCallSite")
+                    return false;
+
+                if (QuerySteps.Contains(methodName))
+                {
+                    count++;
+                    current = invocation.GetInvocationReceiver();
+                    continue;
+                }
+
+                if (methodName == "Set" && invocation.TargetMethod.ContainingType.IsDbContext())
+                    return true;
+
+                return false;
+            }
+
+            if (IsDbSetSource(current))
+                return true;
+
+            if (current is IPropertyReferenceOperation or IFieldReferenceOperation or ILocalReferenceOperation or IParameterReferenceOperation)
+                return false;
+
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool IsDbSetSource(IOperation operation)
+    {
+        if (operation.Type != null && operation.Type.IsDbSet())
+            return true;
+
+        return operation switch
+        {
+            IPropertyReferenceOperation propertyReference when propertyReference.Type.IsDbSet() => true,
+            IFieldReferenceOperation fieldReference when fieldReference.Type.IsDbSet() => true,
+            ILocalReferenceOperation localReference when localReference.Type.IsDbSet() => true,
+            IParameterReferenceOperation parameterReference when parameterReference.Type.IsDbSet() => true,
+            _ => false
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- split `LC042`'s analyzer into smaller helper files
- separate query-chain analysis from analyzer orchestration
- keep analyzer behavior unchanged while reducing local complexity

Closes #75

## Validation
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0 --filter FullyQualifiedName~LC042_MissingQueryTags`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net9.0`
- `dotnet build LinqContraband.sln -p:ContinuousIntegrationBuild=true`
