### PR TITLE
feat(LC044): detect AsNoTracking silent-write

### DIFF
--- a/.complexity-log.md
+++ b/.complexity-log.md
@@ -1,8 +1,8 @@
 # Code Complexity Log
 
-*Last Updated: 2025-12-02 03:26:49*
+*Last Updated: 2026-04-20 09:09:20*
 
-**Files with Issues**: 63
+**Files with Issues**: 68
 
 ---
 
@@ -34,13 +34,54 @@
 
 - [AvoidDateTimeNowSample.cs](./samples/LinqContraband.Sample/Samples/LC016_AvoidDateTimeNow/AvoidDateTimeNowSample.cs#L21) - Max nesting depth is 6 (threshold: 4)
 
-## [LocalMethodAnalyzer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodAnalyzer.cs)
+## [OptimizeRemoveRangeAnalyzer.cs](src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzer.cs)
 
-- [LocalMethodAnalyzer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodAnalyzer.cs#L93) - Max nesting depth is 12 (threshold: 4)
+- [OptimizeRemoveRangeAnalyzer.cs](./src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzer.cs#L62) - Max nesting depth is 6 (threshold: 4)
 
-## [LocalMethodFixer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodFixer.cs)
+## [MissingAsNoTrackingAnalyzer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingAnalyzer.cs)
 
-- [LocalMethodFixer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodFixer.cs#L43) - Max nesting depth is 8 (threshold: 4)
+- [MissingAsNoTrackingAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingAnalyzer.cs#L105) - Max nesting depth is 13 (threshold: 4)
+
+## [MissingAsNoTrackingFixer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingFixer.cs)
+
+- [MissingAsNoTrackingFixer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingFixer.cs#L42) - Max nesting depth is 8 (threshold: 4)
+
+## [SaveChangesInLoopAnalyzer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC010_SaveChangesInLoop/SaveChangesInLoopAnalyzer.cs)
+
+- [SaveChangesInLoopAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC010_SaveChangesInLoop/SaveChangesInLoopAnalyzer.cs#L64) - Max nesting depth is 8 (threshold: 4)
+
+## [DisposedContextQueryAnalyzer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC013_DisposedContextQuery/DisposedContextQueryAnalyzer.cs)
+
+- [DisposedContextQueryAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC013_DisposedContextQuery/DisposedContextQueryAnalyzer.cs#L186) - Max nesting depth is 12 (threshold: 4)
+
+## [AsNoTrackingThenModifyAnalyzer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs)
+
+- [AsNoTrackingThenModifyAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs#L54) - Function 'AnalyzeSaveChanges' has complexity 11 (threshold: 10)
+- [AsNoTrackingThenModifyAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs#L87) - Function 'TryReportForLocal' has complexity 11 (threshold: 10)
+- [AsNoTrackingThenModifyAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs#L127) - Function 'TryReportForForeach' has complexity 11 (threshold: 10)
+- [AsNoTrackingThenModifyAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs#L180) - Function 'FindFirstPropertyMutation' has complexity 13 (threshold: 10)
+- [AsNoTrackingThenModifyAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs#L280) - Function 'IsEntryStateReattach' has complexity 16 (threshold: 10)
+- [AsNoTrackingThenModifyAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs#L427) - Function 'TryGetQueryContextSymbol' has complexity 11 (threshold: 10)
+
+## [NPlusOneLooperAnalyzer.cs](src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs)
+
+- [NPlusOneLooperAnalyzer.cs](./src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs#L61) - Max nesting depth is 8 (threshold: 4)
+
+## [SyncBlockerAnalyzer.cs](src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerAnalyzer.cs)
+
+- [SyncBlockerAnalyzer.cs](./src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerAnalyzer.cs#L118) - Max nesting depth is 8 (threshold: 4)
+
+## [SyncBlockerFixer.cs](src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerFixer.cs)
+
+- [SyncBlockerFixer.cs](./src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerFixer.cs#L48) - Max nesting depth is 12 (threshold: 4)
+
+## [CartesianExplosionAnalyzer.cs](src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs)
+
+- [CartesianExplosionAnalyzer.cs](./src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs#L108) - Max nesting depth is 13 (threshold: 4)
+
+## [CartesianExplosionFixer.cs](src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionFixer.cs)
+
+- [CartesianExplosionFixer.cs](./src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionFixer.cs#L41) - Max nesting depth is 8 (threshold: 4)
 
 ## [PrematureMaterializationAnalyzer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs)
 
@@ -58,6 +99,29 @@
 
 - [AnyOverCountFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC003_AnyOverCount/AnyOverCountFixer.cs#L49) - Max nesting depth is 8 (threshold: 4)
 
+## [WholeEntityProjectionAnalyzer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs)
+
+- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L276) - Max nesting depth is 6 (threshold: 4)
+- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L55) - Function 'AnalyzeInvocation' has complexity 12 (threshold: 10)
+- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L109) - Function 'AnalyzeQueryChain' has complexity 19 (threshold: 10)
+- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L284) - Function 'CountPropertyAccesses' has complexity 12 (threshold: 10)
+
+## [WholeEntityProjectionFixer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs)
+
+- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L184) - Max nesting depth is 8 (threshold: 4)
+- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L84) - Function 'GetEntityType' has complexity 19 (threshold: 10)
+- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L84) - Function 'GetEntityType' has 54 lines (threshold: 50)
+- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L140) - Function 'FindAccessedProperties' has complexity 11 (threshold: 10)
+- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L215) - Function 'AddSelectProjectionAsync' has 54 lines (threshold: 50)
+
+## [LocalMethodAnalyzer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodAnalyzer.cs)
+
+- [LocalMethodAnalyzer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodAnalyzer.cs#L93) - Max nesting depth is 12 (threshold: 4)
+
+## [LocalMethodFixer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodFixer.cs)
+
+- [LocalMethodFixer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodFixer.cs#L43) - Max nesting depth is 8 (threshold: 4)
+
 ## [IQueryableLeakAnalyzer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC004_IQueryableLeak/IQueryableLeakAnalyzer.cs)
 
 - [IQueryableLeakAnalyzer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC004_IQueryableLeak/IQueryableLeakAnalyzer.cs#L75) - Max nesting depth is 12 (threshold: 4)
@@ -69,51 +133,6 @@
 ## [MultipleOrderByFixer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC005_MultipleOrderBy/MultipleOrderByFixer.cs)
 
 - [MultipleOrderByFixer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC005_MultipleOrderBy/MultipleOrderByFixer.cs#L41) - Max nesting depth is 10 (threshold: 4)
-
-## [CartesianExplosionAnalyzer.cs](src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs)
-
-- [CartesianExplosionAnalyzer.cs](./src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs#L108) - Max nesting depth is 13 (threshold: 4)
-
-## [CartesianExplosionFixer.cs](src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionFixer.cs)
-
-- [CartesianExplosionFixer.cs](./src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionFixer.cs#L41) - Max nesting depth is 8 (threshold: 4)
-
-## [NPlusOneLooperAnalyzer.cs](src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs)
-
-- [NPlusOneLooperAnalyzer.cs](./src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs#L61) - Max nesting depth is 8 (threshold: 4)
-
-## [SyncBlockerAnalyzer.cs](src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerAnalyzer.cs)
-
-- [SyncBlockerAnalyzer.cs](./src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerAnalyzer.cs#L118) - Max nesting depth is 8 (threshold: 4)
-
-## [SyncBlockerFixer.cs](src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerFixer.cs)
-
-- [SyncBlockerFixer.cs](./src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerFixer.cs#L48) - Max nesting depth is 12 (threshold: 4)
-
-## [MissingAsNoTrackingAnalyzer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingAnalyzer.cs)
-
-- [MissingAsNoTrackingAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingAnalyzer.cs#L105) - Max nesting depth is 13 (threshold: 4)
-
-## [MissingAsNoTrackingFixer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingFixer.cs)
-
-- [MissingAsNoTrackingFixer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC009_MissingAsNoTracking/MissingAsNoTrackingFixer.cs#L42) - Max nesting depth is 8 (threshold: 4)
-
-## [SaveChangesInLoopAnalyzer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC010_SaveChangesInLoop/SaveChangesInLoopAnalyzer.cs)
-
-- [SaveChangesInLoopAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC010_SaveChangesInLoop/SaveChangesInLoopAnalyzer.cs#L64) - Max nesting depth is 8 (threshold: 4)
-
-## [EntityMissingPrimaryKeyAnalyzer.cs](src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs)
-
-- [EntityMissingPrimaryKeyAnalyzer.cs](./src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs#L1) - File has 501 lines (threshold: 500)
-- [EntityMissingPrimaryKeyAnalyzer.cs](./src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs#L145) - Max nesting depth is 14 (threshold: 4)
-
-## [OptimizeRemoveRangeAnalyzer.cs](src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzer.cs)
-
-- [OptimizeRemoveRangeAnalyzer.cs](./src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzer.cs#L62) - Max nesting depth is 6 (threshold: 4)
-
-## [DisposedContextQueryAnalyzer.cs](src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC013_DisposedContextQuery/DisposedContextQueryAnalyzer.cs)
-
-- [DisposedContextQueryAnalyzer.cs](./src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC013_DisposedContextQuery/DisposedContextQueryAnalyzer.cs#L186) - Max nesting depth is 12 (threshold: 4)
 
 ## [AvoidStringCaseConversionAnalyzer.cs](src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionAnalyzer.cs)
 
@@ -139,20 +158,14 @@
 
 - [AvoidDateTimeNowFixer.cs](./src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixer.cs#L100) - Max nesting depth is 18 (threshold: 4)
 
-## [WholeEntityProjectionAnalyzer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs)
+## [EntityMissingPrimaryKeyAnalyzer.cs](src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs)
 
-- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L276) - Max nesting depth is 6 (threshold: 4)
-- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L55) - Function 'AnalyzeInvocation' has complexity 12 (threshold: 10)
-- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L109) - Function 'AnalyzeQueryChain' has complexity 19 (threshold: 10)
-- [WholeEntityProjectionAnalyzer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs#L284) - Function 'CountPropertyAccesses' has complexity 12 (threshold: 10)
+- [EntityMissingPrimaryKeyAnalyzer.cs](./src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs#L1) - File has 501 lines (threshold: 500)
+- [EntityMissingPrimaryKeyAnalyzer.cs](./src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs#L145) - Max nesting depth is 14 (threshold: 4)
 
-## [WholeEntityProjectionFixer.cs](src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs)
+## [RuleCatalog.cs](src/LinqContraband/Catalog/RuleCatalog.cs)
 
-- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L184) - Max nesting depth is 8 (threshold: 4)
-- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L84) - Function 'GetEntityType' has complexity 19 (threshold: 10)
-- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L84) - Function 'GetEntityType' has 54 lines (threshold: 50)
-- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L140) - Function 'FindAccessedProperties' has complexity 11 (threshold: 10)
-- [WholeEntityProjectionFixer.cs](./src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionFixer.cs#L215) - Function 'AddSelectProjectionAsync' has 54 lines (threshold: 50)
+- [RuleCatalog.cs](./src/LinqContraband/Catalog/RuleCatalog.cs#L1) - File has 647 lines (threshold: 500)
 
 ## [AnalysisExtensions.cs](src/LinqContraband/Extensions/AnalysisExtensions.cs)
 
@@ -263,6 +276,20 @@
 ## [WholeEntityProjectionTests.cs](tests/LinqContraband.Tests/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionTests.cs)
 
 - [WholeEntityProjectionTests.cs](./tests/LinqContraband.Tests/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionTests.cs#L99) - Max nesting depth is 5 (threshold: 4)
+
+## [AsNoTrackingThenModifyAnalyzerTests.cs](tests/LinqContraband.Tests/Analyzers/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzerTests.cs)
+
+- [AsNoTrackingThenModifyAnalyzerTests.cs](./tests/LinqContraband.Tests/Analyzers/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzerTests.cs#L159) - Max nesting depth is 7 (threshold: 4)
+
+## [AsNoTrackingThenModifyEdgeCasesTests.cs](tests/LinqContraband.Tests/Analyzers/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyEdgeCasesTests.cs)
+
+- [AsNoTrackingThenModifyEdgeCasesTests.cs](./tests/LinqContraband.Tests/Analyzers/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyEdgeCasesTests.cs#L201) - Max nesting depth is 6 (threshold: 4)
+
+## [RuleCatalogIntegrityTests.cs](tests/LinqContraband.Tests/Architecture/RuleCatalogIntegrityTests.cs)
+
+- [RuleCatalogIntegrityTests.cs](./tests/LinqContraband.Tests/Architecture/RuleCatalogIntegrityTests.cs#L50) - Max nesting depth is 5 (threshold: 4)
+- [RuleCatalogIntegrityTests.cs](./tests/LinqContraband.Tests/Architecture/RuleCatalogIntegrityTests.cs#L24) - Function 'RuleCatalog_EntriesMatchRepositoryLayout' has complexity 27 (threshold: 10)
+- [RuleCatalogIntegrityTests.cs](./tests/LinqContraband.Tests/Architecture/RuleCatalogIntegrityTests.cs#L24) - Function 'RuleCatalog_EntriesMatchRepositoryLayout' has 68 lines (threshold: 50)
 
 ## [CoverageBoostTests.cs](tests/LinqContraband.Tests/CoverageBoostTests.cs)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2026-04-20
+
+### Added
+- Added `LC044` — AsNoTracking query mutated then SaveChanges. Detects silent data-loss bugs where an entity loaded with `AsNoTracking()` is mutated and `SaveChanges` is called on the same context without any re-attach (`Update`/`Attach`/`Entry(entity).State = Modified|Added`). The chain is provable intra-procedurally; the analyzer uses single-assignment dataflow, same-context linkage, block-ancestor reachability, and explicit re-attach gating to keep false positives at zero across the 43 existing sample files
+- Added docs, sample, and test coverage (18 tests: 7 positive, 11 FP-exclusion scenarios) for `LC044`
+
+### Changed
+- Grouped `LC044` under the `Change Tracking & Context Lifetime` domain in `RuleCatalog`, the rule-catalog documentation, and the README
+
 ## [5.0.4] - 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The analyzer will immediately start scanning your code for contraband.
 
 ## 👮‍♂️ The Rules
 
-> **43 rules** covering performance, correctness, and design pitfalls in Entity Framework Core queries.
+> **44 rules** covering performance, correctness, and design pitfalls in Entity Framework Core queries.
 
 ## 🗺️ Rule Neighborhoods
 
@@ -51,7 +51,7 @@ The repository keeps the familiar `LC001`-style rule numbering, but the rules no
 | Materialization & Projection | LC002, LC003, LC017, LC022, LC023, LC029, LC031, LC033, LC041 |
 | Loading & Includes | LC006, LC019, LC028, LC038, LC042 |
 | Execution & Async | LC007, LC008, LC026, LC036, LC043 |
-| Change Tracking & Context Lifetime | LC009, LC010, LC013, LC025, LC030, LC039, LC040 |
+| Change Tracking & Context Lifetime | LC009, LC010, LC013, LC025, LC030, LC039, LC040, LC044 |
 | Bulk Operations & Set-Based Writes | LC012, LC032, LC035 |
 | Schema & Modeling | LC011, LC027 |
 | Raw SQL & Security | LC018, LC021, LC034, LC037 |
@@ -1464,6 +1464,46 @@ await foreach (var user in stream)
 **🛡️ Reliability Notes:**
 - LC043 intentionally targets a narrow, analyzer-proven v1 pattern: immediate buffering followed by one linear loop in the same method.
 - The fixer rewrites only those safe cases and does not try to transform broader async-stream usage.
+
+---
+
+### LC044: AsNoTracking Silent-Write
+
+If you load an entity with `AsNoTracking()`, change one of its properties, and then call `SaveChanges`, EF Core persists
+nothing. There is no exception, no log — the UI reports success and the database never changes.
+
+**👶 Explain it like I'm a ten year old:** Imagine writing corrections on a photocopy and then asking the teacher to
+re-grade your exam. The teacher only re-reads the original exam, so your corrections are ignored.
+
+**❌ The Crime:**
+
+```csharp
+var user = db.Users.AsNoTracking().FirstOrDefault(u => u.Id == id);
+user.Name = "New Name";
+db.SaveChanges(); // <-- persists nothing; returns 0
+```
+
+**✅ The Fix:**
+Either drop `AsNoTracking` so the entity is tracked from the start, or re-attach before saving.
+
+```csharp
+// Option A: track from origin
+var user = db.Users.FirstOrDefault(u => u.Id == id);
+user.Name = "New Name";
+db.SaveChanges();
+
+// Option B: explicit re-attach
+var user = db.Users.AsNoTracking().FirstOrDefault(u => u.Id == id);
+user.Name = "New Name";
+db.Users.Update(user); // or db.Attach(user); or db.Entry(user).State = EntityState.Modified;
+db.SaveChanges();
+```
+
+**🛡️ Reliability Notes:**
+- LC044 only fires when the chain `AsNoTracking origin → property mutation → SaveChanges on the same context` is
+  provable inside one method and no re-attach (`Update`, `Attach`, `Entry(entity).State = Modified|Added`) intervenes.
+- Ambiguous dataflow, mutations in branches that never reach `SaveChanges`, and entities that arrive as parameters are
+  intentionally skipped to keep false positives at zero.
 
 ---
 

--- a/docs/LC044_AsNoTrackingThenModifySilentWrite.md
+++ b/docs/LC044_AsNoTrackingThenModifySilentWrite.md
@@ -1,0 +1,76 @@
+# Spec: LC044 - AsNoTracking query mutated then SaveChanges — silent data loss
+
+## Goal
+Detect the chain `AsNoTracking origin → property mutation → SaveChanges on the same context` when no re-attach (`Update` / `Attach` / `Entry(entity).State = Modified | Added`) intervenes. In this pattern EF Core silently persists nothing — no exception, no log — and callers typically spend hours debugging why their update "didn't stick".
+
+## The Problem
+`AsNoTracking()` tells EF Core not to track the entity in the change tracker. A subsequent property mutation has no effect on the DbContext state, and `SaveChanges` returns `0`. Because there is no diagnostic at runtime, silent data loss is extremely hard to notice until production traffic discovers missing updates.
+
+### Example Violation
+```csharp
+// Silent data loss: `SaveChanges` persists nothing.
+var user = db.Users.AsNoTracking().FirstOrDefault(u => u.Id == id);
+user.Name = "New Name";
+db.SaveChanges();
+```
+
+### Fixes
+Either remove `AsNoTracking` so the entity is tracked from origin:
+```csharp
+var user = db.Users.FirstOrDefault(u => u.Id == id);
+user.Name = "New Name";
+db.SaveChanges();
+```
+…or re-attach before saving:
+```csharp
+var user = db.Users.AsNoTracking().FirstOrDefault(u => u.Id == id);
+user.Name = "New Name";
+db.Users.Update(user);     // or db.Attach(user); or db.Entry(user).State = EntityState.Modified;
+db.SaveChanges();
+```
+
+## Analyzer Logic
+
+### ID: `LC044`
+### Category: `Reliability`
+### Severity: `Warning`
+
+### Algorithm
+1. **Anchor**: register on every `DbContext.SaveChanges` / `SaveChangesAsync` invocation.
+2. **Context symbol**: resolve the instance symbol of the SaveChanges call.
+3. **Origin scan**: in the same executable root, collect local declarations whose initializer is a materializer invocation (`First`, `FirstOrDefault`, `Single`, `ToList`, async variants, …) and whose chain contains `AsNoTracking`. Collect `foreach` loops whose collection chain contains `AsNoTracking`.
+4. **Same-context gate**: extract the DbSet-owner context symbol from the query chain and require `SymbolEqualityComparer` match against the SaveChanges context symbol.
+5. **Single-assignment gate**: skip locals that are assigned more than once (ambiguous dataflow).
+6. **Mutation scan**: find the first `ISimpleAssignmentOperation` whose target is an `IPropertyReferenceOperation` instance-referencing the local, positioned between the local's declaration and the SaveChanges.
+7. **Block reachability**: the mutation's enclosing `IBlockOperation` must be an ancestor of (or equal to) the SaveChanges's enclosing block — otherwise the mutation lives in a branch the SaveChanges can't reach in lexical order.
+8. **Earlier-save gate**: if another SaveChanges on the same context already ran between the mutation and the current one, this anchor is not the silent-write site; skip.
+9. **Re-attach gate**: between the mutation and the SaveChanges, scan for `DbContext.Update/Attach/UpdateRange/AttachRange`, their `DbSet` counterparts, or `DbContext.Entry(entity).State = EntityState.Modified | Added` — on the same context, with the entity as the argument. If any such re-attach is found, suppress the diagnostic.
+10. **Emit**: report on the property reference (`entity.Prop`) of the first matching mutation with the entity name and the property name.
+
+## False-Positive Disciplines
+- Entity from a tracked query (no `.AsNoTracking()` in the chain).
+- `.AsNoTracking()` query followed only by reads, never by a property write.
+- Re-attach of any form present between the mutation and SaveChanges.
+- SaveChanges is on a different context instance than the query.
+- Multiple reassignments to the same local (ambiguous dataflow).
+- Mutation sits inside a branch that's not an ancestor of the SaveChanges's block (e.g., an `if` branch that returns early).
+- Entity arrives as a parameter from outside the method (v1 scope is intra-procedural; cross-method is future work).
+- A different entity is mutated (symbol identity on `ILocalSymbol` prevents cross-entity confusion).
+- Mutation is a collection member call (`list.Add(x)`), not an entity property assignment.
+
+## Test Cases
+
+### Violations
+```csharp
+var u = ctx.Users.AsNoTracking().FirstOrDefault();
+u.Name = "x";
+ctx.SaveChanges();
+```
+
+### Valid
+```csharp
+var u = ctx.Users.AsNoTracking().First();
+u.Name = "x";
+ctx.Users.Update(u);
+ctx.SaveChanges();
+```

--- a/docs/rule-catalog.md
+++ b/docs/rule-catalog.md
@@ -22,7 +22,7 @@ This page is generated from that catalog and grouped by domain.
 | `LC030` Potential DbContext lifetime mismatch | `Info` | `Architecture` | Code fix | [`LC030_DbContextInSingleton`](./LC030_DbContextInSingleton.md) | `Samples/LC030_DbContextInSingleton/` |
 | `LC039` Avoid repeated SaveChanges on the same context | `Info` | `Reliability` | Manual only | [`LC039_NestedSaveChanges`](./LC039_NestedSaveChanges.md) | `Samples/LC039_NestedSaveChanges/` |
 | `LC040` Avoid mixing tracking modes on the same context | `Info` | `Reliability` | Manual only | [`LC040_MixedTrackingAndNoTracking`](./LC040_MixedTrackingAndNoTracking.md) | `Samples/LC040_MixedTrackingAndNoTracking/` |
-| `LC044` AsNoTracking query mutated then SaveChanges — silent data loss | `Warning` | `Reliability` | Manual only | [`LC044_AsNoTrackingThenModifySilentWrite`](./LC044_AsNoTrackingThenModifySilentWrite.md) | `Samples/LC044_AsNoTrackingThenModify/` |
+| `LC044` AsNoTracking query mutated then SaveChanges — silent data loss | `Warning` | `Reliability` | Manual only | [`LC044_AsNoTrackingThenModify`](./LC044_AsNoTrackingThenModifySilentWrite.md) | `Samples/LC044_AsNoTrackingThenModify/` |
 
 ## Execution & Async
 

--- a/docs/rule-catalog.md
+++ b/docs/rule-catalog.md
@@ -22,6 +22,7 @@ This page is generated from that catalog and grouped by domain.
 | `LC030` Potential DbContext lifetime mismatch | `Info` | `Architecture` | Code fix | [`LC030_DbContextInSingleton`](./LC030_DbContextInSingleton.md) | `Samples/LC030_DbContextInSingleton/` |
 | `LC039` Avoid repeated SaveChanges on the same context | `Info` | `Reliability` | Manual only | [`LC039_NestedSaveChanges`](./LC039_NestedSaveChanges.md) | `Samples/LC039_NestedSaveChanges/` |
 | `LC040` Avoid mixing tracking modes on the same context | `Info` | `Reliability` | Manual only | [`LC040_MixedTrackingAndNoTracking`](./LC040_MixedTrackingAndNoTracking.md) | `Samples/LC040_MixedTrackingAndNoTracking/` |
+| `LC044` AsNoTracking query mutated then SaveChanges — silent data loss | `Warning` | `Reliability` | Manual only | [`LC044_AsNoTrackingThenModifySilentWrite`](./LC044_AsNoTrackingThenModifySilentWrite.md) | `Samples/LC044_AsNoTrackingThenModify/` |
 
 ## Execution & Async
 

--- a/samples/LinqContraband.Sample/Program.cs
+++ b/samples/LinqContraband.Sample/Program.cs
@@ -33,6 +33,7 @@ using LinqContraband.Sample.Samples.LC040_MixedTrackingAndNoTracking;
 using LinqContraband.Sample.Samples.LC041_SingleEntityScalarProjection;
 using LinqContraband.Sample.Samples.LC042_MissingQueryTags;
 using LinqContraband.Sample.Samples.LC043_AsyncEnumerableBuffering;
+using LinqContraband.Sample.Samples.LC044_AsNoTrackingThenModify;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
 
@@ -81,7 +82,7 @@ internal class Program
         ExecuteUpdateForBulkUpdatesSample.Run();
         UseFrozenSetForStaticMembershipCachesSample.Run();
 
-        // LC034 - LC043
+        // LC034 - LC044
         await ExecuteSqlRawInterpolationSample.RunAsync(db);
         MissingWhereBeforeExecuteDeleteUpdateSample.Run(db);
         DbContextCapturedAcrossThreadsSample.Run(db);
@@ -92,5 +93,6 @@ internal class Program
         SingleEntityScalarProjectionSample.Run(db);
         MissingQueryTagsSample.Run(db);
         await AsyncEnumerableBufferingSample.RunAsync(db);
+        AsNoTrackingThenModifySample.Run(db);
     }
 }

--- a/samples/LinqContraband.Sample/Samples/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifySample.cs
+++ b/samples/LinqContraband.Sample/Samples/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifySample.cs
@@ -1,0 +1,40 @@
+using LinqContraband.Sample.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace LinqContraband.Sample.Samples.LC044_AsNoTrackingThenModify;
+
+public class AsNoTrackingThenModifySample
+{
+    public static void Run(AppDbContext db)
+    {
+        Console.WriteLine("Testing LC044...");
+
+        var userId = Guid.NewGuid();
+
+        // VIOLATION: Silent data loss — AsNoTracking entity mutated then SaveChanges.
+        // EF has no tracked entity, so SaveChanges persists nothing. No exception, no log.
+        var user1 = db.Users.AsNoTracking().FirstOrDefault(u => u.Id == userId);
+        if (user1 != null)
+        {
+            user1.Name = "Will never reach the database";
+            db.SaveChanges();
+        }
+
+        // CORRECT: Remove AsNoTracking so the entity is tracked from the start.
+        var user2 = db.Users.FirstOrDefault(u => u.Id == userId);
+        if (user2 != null)
+        {
+            user2.Name = "Properly persisted";
+            db.SaveChanges();
+        }
+
+        // CORRECT: AsNoTracking + explicit re-attach before SaveChanges.
+        var user3 = db.Users.AsNoTracking().FirstOrDefault(u => u.Id == userId);
+        if (user3 != null)
+        {
+            user3.Name = "Re-attached before save";
+            db.Users.Update(user3);
+            db.SaveChanges();
+        }
+    }
+}

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs
@@ -1,0 +1,498 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC044_AsNoTrackingThenModify;
+
+/// <summary>
+/// Detects entities loaded via AsNoTracking() that are mutated and then passed through SaveChanges
+/// on the same context without any re-attach (Update / Attach / Entry.State = Modified). EF silently
+/// persists nothing in this case. Diagnostic ID: LC044.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "LC044";
+    private const string Category = "Reliability";
+
+    private static readonly LocalizableString Title =
+        "AsNoTracking query mutated then SaveChanges — silent data loss";
+
+    private static readonly LocalizableString MessageFormat =
+        "Entity '{0}' was loaded with AsNoTracking() and property '{1}' is mutated before SaveChanges — the change will not persist. Remove AsNoTracking(), or call Update/Attach or set Entry(entity).State = Modified before SaveChanges.";
+
+    private static readonly LocalizableString Description =
+        "EF Core does not track entities materialized from an AsNoTracking() query. Mutating a property of such an entity and then calling SaveChanges silently results in no database write. This rule flags the chain AsNoTracking-origin \u2192 property mutation \u2192 SaveChanges on the same context when no re-attach (Update / Attach / Entry.State = Modified / Added) intervenes.";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        Category,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        Description,
+        helpLinkUri: "https://github.com/georgewall/LinqContraband/blob/main/docs/LC044_AsNoTrackingThenModifySilentWrite.md");
+
+    private static readonly ImmutableHashSet<string> ReattachMethodNames = ImmutableHashSet.Create(
+        "Update", "UpdateRange", "Attach", "AttachRange");
+
+    private static readonly ImmutableHashSet<string> TrackingStates = ImmutableHashSet.Create(
+        "Modified", "Added");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(AnalyzeSaveChanges, OperationKind.Invocation);
+    }
+
+    private static void AnalyzeSaveChanges(OperationAnalysisContext context)
+    {
+        var save = (IInvocationOperation)context.Operation;
+        var method = save.TargetMethod;
+
+        if (method.Name != "SaveChanges" && method.Name != "SaveChangesAsync") return;
+        if (!method.ContainingType.IsDbContext()) return;
+
+        if (!TryGetSymbol(save.Instance, out var saveContextSymbol) || saveContextSymbol == null) return;
+
+        var root = save.FindOwningExecutableRoot();
+        if (root == null) return;
+
+        var saveSpan = save.Syntax.SpanStart;
+        var reported = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var op in Descendants(root))
+        {
+            switch (op)
+            {
+                case IVariableDeclaratorOperation decl when decl.Initializer?.Value != null:
+                    TryReportForLocal(
+                        context, root, save, saveContextSymbol, saveSpan,
+                        decl.Symbol, decl.Syntax.SpanStart, decl.Initializer.Value, reported);
+                    break;
+
+                case IForEachLoopOperation forEach:
+                    TryReportForForeach(context, root, save, saveContextSymbol, saveSpan, forEach, reported);
+                    break;
+            }
+        }
+    }
+
+    private static void TryReportForLocal(
+        OperationAnalysisContext context,
+        IOperation root,
+        IInvocationOperation save,
+        ISymbol saveContext,
+        int saveSpan,
+        ILocalSymbol local,
+        int declSpan,
+        IOperation initializer,
+        HashSet<ILocalSymbol> reported)
+    {
+        if (reported.Contains(local)) return;
+        if (declSpan >= saveSpan) return;
+
+        if (!IsAsNoTrackingMaterialization(initializer, out var queryReceiver)) return;
+        if (!TryGetQueryContextSymbol(queryReceiver, out var queryContextSymbol)) return;
+        if (!SymbolEqualityComparer.Default.Equals(saveContext, queryContextSymbol)) return;
+
+        if (HasMultipleAssignments(root, local)) return;
+
+        var mutationNullable = FindFirstPropertyMutation(root, local, declSpan, saveSpan);
+        if (mutationNullable == null) return;
+        var mutation = mutationNullable.Value;
+
+        if (!BlockReaches(mutation.Operation, save)) return;
+
+        if (HasEarlierSaveChangesOnSameContext(root, saveContext, mutation.Operation.Syntax.SpanStart, saveSpan))
+            return;
+
+        if (HasReattach(root, local, saveContext, mutation.Operation.Syntax.SpanStart, saveSpan))
+            return;
+
+        reported.Add(local);
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            mutation.TargetLocation,
+            local.Name,
+            mutation.PropertyName));
+    }
+
+    private static void TryReportForForeach(
+        OperationAnalysisContext context,
+        IOperation root,
+        IInvocationOperation save,
+        ISymbol saveContext,
+        int saveSpan,
+        IForEachLoopOperation forEach,
+        HashSet<ILocalSymbol> reported)
+    {
+        if (forEach.Syntax.SpanStart >= saveSpan) return;
+
+        var collection = forEach.Collection.UnwrapConversions();
+        if (!ChainContainsAsNoTracking(collection, out var queryReceiver)) return;
+        if (!TryGetQueryContextSymbol(queryReceiver, out var queryContextSymbol)) return;
+        if (!SymbolEqualityComparer.Default.Equals(saveContext, queryContextSymbol)) return;
+
+        foreach (var loopLocal in forEach.Locals)
+        {
+            if (reported.Contains(loopLocal)) continue;
+
+            var mutationNullable = FindFirstPropertyMutation(forEach, loopLocal, forEach.Syntax.SpanStart - 1, saveSpan);
+            if (mutationNullable == null) continue;
+            var mutation = mutationNullable.Value;
+
+            if (HasReattachInRange(forEach, loopLocal, saveContext)) continue;
+            if (!BlockReaches(forEach, save)) continue;
+
+            if (HasEarlierSaveChangesOnSameContext(root, saveContext, forEach.Syntax.SpanStart, saveSpan))
+                continue;
+
+            reported.Add(loopLocal);
+            context.ReportDiagnostic(Diagnostic.Create(
+                Rule,
+                mutation.TargetLocation,
+                loopLocal.Name,
+                mutation.PropertyName));
+        }
+    }
+
+    private readonly struct MutationHit
+    {
+        public MutationHit(IOperation operation, Location targetLocation, string propertyName)
+        {
+            Operation = operation;
+            TargetLocation = targetLocation;
+            PropertyName = propertyName;
+        }
+
+        public IOperation Operation { get; }
+        public Location TargetLocation { get; }
+        public string PropertyName { get; }
+    }
+
+    private static MutationHit? FindFirstPropertyMutation(IOperation root, ILocalSymbol local, int afterSpan, int beforeSpan)
+    {
+        MutationHit? best = null;
+        foreach (var op in Descendants(root))
+        {
+            if (op is not ISimpleAssignmentOperation assignment) continue;
+            if (assignment.Target is not IPropertyReferenceOperation propRef) continue;
+
+            var instance = propRef.Instance?.UnwrapConversions();
+            if (instance is not ILocalReferenceOperation localRef) continue;
+            if (!SymbolEqualityComparer.Default.Equals(localRef.Local, local)) continue;
+
+            var span = assignment.Syntax.SpanStart;
+            if (span <= afterSpan || span >= beforeSpan) continue;
+
+            if (best == null || span < best.Value.Operation.Syntax.SpanStart)
+            {
+                best = new MutationHit(assignment, propRef.Syntax.GetLocation(), propRef.Property.Name);
+            }
+        }
+
+        return best;
+    }
+
+    private static bool HasMultipleAssignments(IOperation root, ILocalSymbol local)
+    {
+        var count = 0;
+        foreach (var op in Descendants(root))
+        {
+            if (op is ISimpleAssignmentOperation assignment &&
+                assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal &&
+                SymbolEqualityComparer.Default.Equals(targetLocal.Local, local))
+            {
+                count++;
+            }
+            else if (op is IVariableDeclaratorOperation declarator &&
+                     SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) &&
+                     declarator.Initializer != null)
+            {
+                count++;
+            }
+
+            if (count > 1) return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasReattach(
+        IOperation root,
+        ILocalSymbol local,
+        ISymbol saveContext,
+        int afterSpan,
+        int beforeSpan)
+    {
+        foreach (var op in Descendants(root))
+        {
+            var span = op.Syntax.SpanStart;
+            if (span <= afterSpan || span >= beforeSpan) continue;
+
+            if (op is IInvocationOperation inv && IsReattachInvocation(inv, local, saveContext))
+                return true;
+
+            if (op is ISimpleAssignmentOperation assign && IsEntryStateReattach(assign, local, saveContext))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasReattachInRange(IOperation range, ILocalSymbol local, ISymbol saveContext)
+    {
+        foreach (var op in Descendants(range))
+        {
+            if (op is IInvocationOperation inv && IsReattachInvocation(inv, local, saveContext))
+                return true;
+
+            if (op is ISimpleAssignmentOperation assign && IsEntryStateReattach(assign, local, saveContext))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsReattachInvocation(IInvocationOperation invocation, ILocalSymbol local, ISymbol saveContext)
+    {
+        if (!ReattachMethodNames.Contains(invocation.TargetMethod.Name)) return false;
+
+        var container = invocation.TargetMethod.ContainingType;
+        if (!container.IsDbContext() && !container.IsDbSet()) return false;
+
+        if (invocation.Arguments.Length == 0) return false;
+        var argValue = invocation.Arguments[0].Value.UnwrapConversions();
+        if (argValue is not ILocalReferenceOperation argLocal) return false;
+        if (!SymbolEqualityComparer.Default.Equals(argLocal.Local, local)) return false;
+
+        return TryResolveInvocationContext(invocation, out var invContext)
+               && SymbolEqualityComparer.Default.Equals(invContext, saveContext);
+    }
+
+    private static bool IsEntryStateReattach(ISimpleAssignmentOperation assignment, ILocalSymbol local, ISymbol saveContext)
+    {
+        if (assignment.Target is not IPropertyReferenceOperation targetProp) return false;
+        if (targetProp.Property.Name != "State") return false;
+        if (targetProp.Property.ContainingType?.Name != "EntityEntry") return false;
+
+        if (targetProp.Instance is not IInvocationOperation entryInv) return false;
+        if (entryInv.TargetMethod.Name != "Entry") return false;
+        if (!entryInv.TargetMethod.ContainingType.IsDbContext()) return false;
+
+        if (entryInv.Arguments.Length == 0) return false;
+        var argValue = entryInv.Arguments[0].Value.UnwrapConversions();
+        if (argValue is not ILocalReferenceOperation argLocal) return false;
+        if (!SymbolEqualityComparer.Default.Equals(argLocal.Local, local)) return false;
+
+        if (!TryGetSymbol(entryInv.Instance, out var entryContext)) return false;
+        if (!SymbolEqualityComparer.Default.Equals(entryContext, saveContext)) return false;
+
+        var value = assignment.Value.UnwrapConversions();
+        if (value is not IFieldReferenceOperation fieldRef) return false;
+        if (fieldRef.Field.ContainingType?.Name != "EntityState") return false;
+
+        return TrackingStates.Contains(fieldRef.Field.Name);
+    }
+
+    private static bool TryResolveInvocationContext(IInvocationOperation invocation, out ISymbol? contextSymbol)
+    {
+        contextSymbol = null;
+
+        if (invocation.TargetMethod.ContainingType.IsDbContext())
+        {
+            return TryGetSymbol(invocation.Instance, out contextSymbol);
+        }
+
+        if (invocation.TargetMethod.ContainingType.IsDbSet())
+        {
+            var dbSetInstance = invocation.Instance?.UnwrapConversions();
+            switch (dbSetInstance)
+            {
+                case IPropertyReferenceOperation propRef when propRef.Type.IsDbSet():
+                    return TryGetSymbol(propRef.Instance, out contextSymbol);
+                case IFieldReferenceOperation fieldRef when fieldRef.Type.IsDbSet():
+                    return TryGetSymbol(fieldRef.Instance, out contextSymbol);
+                case IInvocationOperation setCall when setCall.TargetMethod.Name == "Set" &&
+                                                      setCall.TargetMethod.ContainingType.IsDbContext():
+                    return TryGetSymbol(setCall.Instance, out contextSymbol);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasEarlierSaveChangesOnSameContext(
+        IOperation root,
+        ISymbol saveContext,
+        int afterSpan,
+        int currentSaveSpan)
+    {
+        foreach (var op in Descendants(root))
+        {
+            if (op is not IInvocationOperation inv) continue;
+            if (inv.TargetMethod.Name != "SaveChanges" && inv.TargetMethod.Name != "SaveChangesAsync") continue;
+            if (!inv.TargetMethod.ContainingType.IsDbContext()) continue;
+
+            var span = inv.Syntax.SpanStart;
+            if (span <= afterSpan || span >= currentSaveSpan) continue;
+
+            if (TryGetSymbol(inv.Instance, out var sym) &&
+                SymbolEqualityComparer.Default.Equals(sym, saveContext))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool BlockReaches(IOperation mutation, IOperation saveChanges)
+    {
+        var mutationBlock = FindEnclosingBlock(mutation);
+        if (mutationBlock == null) return true;
+
+        var current = saveChanges.Parent;
+        while (current != null)
+        {
+            if (ReferenceEquals(current, mutationBlock)) return true;
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private static IBlockOperation? FindEnclosingBlock(IOperation operation)
+    {
+        var current = operation.Parent;
+        while (current != null)
+        {
+            if (current is IBlockOperation block) return block;
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    private static bool IsAsNoTrackingMaterialization(IOperation operation, out IOperation? queryReceiver)
+    {
+        queryReceiver = null;
+        var unwrapped = operation.UnwrapConversions();
+        if (unwrapped is not IInvocationOperation invocation) return false;
+
+        if (!invocation.TargetMethod.Name.IsMaterializerMethod()) return false;
+
+        var receiver = invocation.GetInvocationReceiver();
+        if (receiver == null) return false;
+
+        if (!ChainContainsAsNoTracking(receiver, out queryReceiver)) return false;
+
+        return true;
+    }
+
+    private static bool ChainContainsAsNoTracking(IOperation operation, out IOperation? rootReceiver)
+    {
+        rootReceiver = null;
+        var current = operation.UnwrapConversions();
+        var sawAsNoTracking = false;
+
+        while (current is IInvocationOperation inv)
+        {
+            if (inv.TargetMethod.Name == "AsNoTracking")
+                sawAsNoTracking = true;
+
+            var next = inv.GetInvocationReceiver();
+            if (next == null)
+            {
+                rootReceiver = inv;
+                break;
+            }
+
+            current = next.UnwrapConversions();
+        }
+
+        if (!sawAsNoTracking) return false;
+
+        if (rootReceiver == null) rootReceiver = current;
+        return true;
+    }
+
+    private static bool TryGetQueryContextSymbol(IOperation? queryReceiver, out ISymbol? contextSymbol)
+    {
+        contextSymbol = null;
+        if (queryReceiver == null) return false;
+
+        var current = queryReceiver.UnwrapConversions();
+
+        while (current != null)
+        {
+            switch (current)
+            {
+                case IPropertyReferenceOperation propRef when propRef.Type.IsDbSet():
+                    return TryGetSymbol(propRef.Instance, out contextSymbol);
+
+                case IFieldReferenceOperation fieldRef when fieldRef.Type.IsDbSet():
+                    return TryGetSymbol(fieldRef.Instance, out contextSymbol);
+
+                case IInvocationOperation inv when inv.TargetMethod.Name == "Set" &&
+                                                   inv.TargetMethod.ContainingType.IsDbContext():
+                    return TryGetSymbol(inv.Instance, out contextSymbol);
+
+                case IInvocationOperation inv:
+                    var next = inv.GetInvocationReceiver();
+                    if (next == null) return false;
+                    current = next.UnwrapConversions();
+                    continue;
+
+                default:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetSymbol(IOperation? operation, out ISymbol? symbol)
+    {
+        symbol = null;
+        if (operation == null) return false;
+
+        switch (operation.UnwrapConversions())
+        {
+            case ILocalReferenceOperation localRef:
+                symbol = localRef.Local;
+                return true;
+            case IParameterReferenceOperation paramRef:
+                symbol = paramRef.Parameter;
+                return true;
+            case IFieldReferenceOperation fieldRef:
+                symbol = fieldRef.Field;
+                return true;
+            case IPropertyReferenceOperation propRef:
+                symbol = propRef.Property;
+                return true;
+            case IInstanceReferenceOperation:
+                symbol = null;
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private static IEnumerable<IOperation> Descendants(IOperation root)
+    {
+        yield return root;
+        foreach (var child in root.ChildOperations)
+            foreach (var d in Descendants(child))
+                yield return d;
+    }
+}

--- a/src/LinqContraband/Catalog/RuleCatalog.cs
+++ b/src/LinqContraband/Catalog/RuleCatalog.cs
@@ -609,7 +609,21 @@ public static class RuleCatalog
             samplePath: "samples/LinqContraband.Sample/Samples/LC043_AsyncEnumerableBuffering/AsyncEnumerableBufferingSample.cs",
             analyzerSourcePath: "src/LinqContraband/Analyzers/ExecutionAndAsync/LC043_AsyncEnumerableBuffering",
             hasCodeFix: true,
-            noCodeFixRationale: null)
+            noCodeFixRationale: null),
+        new RuleCatalogEntry(
+            id: "LC044",
+            slug: "LC044_AsNoTrackingThenModify",
+            title: "AsNoTracking query mutated then SaveChanges — silent data loss",
+            category: "Reliability",
+            domain: "Change Tracking & Context Lifetime",
+            severity: DiagnosticSeverity.Warning,
+            analyzerTypeName: "AsNoTrackingThenModifyAnalyzer",
+            fixerTypeName: null,
+            documentationPath: "docs/LC044_AsNoTrackingThenModifySilentWrite.md",
+            samplePath: "samples/LinqContraband.Sample/Samples/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifySample.cs",
+            analyzerSourcePath: "src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify",
+            hasCodeFix: false,
+            noCodeFixRationale: "No automatic fix: the right resolution depends on intent — either remove AsNoTracking() so the entity is tracked from origin, or call Update/Attach (or set Entry.State = Modified) before SaveChanges. Both are semantically valid depending on context.")
     );
 
     public static RuleCatalogEntry GetById(string id)

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.0.4</Version>
+        <Version>5.1.0</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzerTests.cs
@@ -1,0 +1,209 @@
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    LinqContraband.Analyzers.LC044_AsNoTrackingThenModify.AsNoTrackingThenModifyAnalyzer>;
+
+namespace LinqContraband.Tests.Analyzers.LC044_AsNoTrackingThenModify;
+
+public class AsNoTrackingThenModifyAnalyzerTests
+{
+    internal const string EfCoreMock = @"
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public enum EntityState { Detached, Unchanged, Deleted, Modified, Added }
+
+    public class EntityEntry
+    {
+        public EntityState State { get; set; }
+    }
+
+    public class DbContext
+    {
+        public int SaveChanges() => 0;
+        public Task<int> SaveChangesAsync(CancellationToken ct = default) => Task.FromResult(0);
+        public void Update(object entity) { }
+        public void Attach(object entity) { }
+        public EntityEntry Entry(object entity) => new EntityEntry();
+    }
+
+    public class DbSet<TEntity> : IQueryable<TEntity> where TEntity : class
+    {
+        public void Update(TEntity entity) { }
+        public void Attach(TEntity entity) { }
+        public Type ElementType => typeof(TEntity);
+        public Expression Expression => null;
+        public IQueryProvider Provider => null;
+        public System.Collections.IEnumerator GetEnumerator() => null;
+        IEnumerator<TEntity> IEnumerable<TEntity>.GetEnumerator() => null;
+    }
+
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static IQueryable<TSource> AsNoTracking<TSource>(this IQueryable<TSource> source) where TSource : class => source;
+        public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken ct = default) => Task.FromResult(default(TSource));
+        public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken ct = default) => Task.FromResult(default(TSource));
+        public static Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken ct = default) => Task.FromResult(default(TSource));
+        public static Task<List<TSource>> ToListAsync<TSource>(this IQueryable<TSource> source, CancellationToken ct = default) => Task.FromResult(new List<TSource>());
+    }
+}
+";
+
+    private const string Preamble = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;";
+
+    [Fact]
+    public async Task AsNoTracking_ThenMutateProperty_ThenSaveChanges_Triggers()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var user = ctx.Users.AsNoTracking().FirstOrDefault(u => u.Id == 1);
+            {|LC044:user.Name|} = ""new"";
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsNoTracking_ThenMutate_ThenSaveChangesAsync_Triggers()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public async Task M(TestCtx ctx)
+        {
+            var user = await ctx.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == 1);
+            {|LC044:user.Name|} = ""new"";
+            await ctx.SaveChangesAsync();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsNoTracking_Single_ThenMutate_ThenSave_Triggers()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Email { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx, int id, string newEmail)
+        {
+            var u = ctx.Users.AsNoTracking().Single(x => x.Id == id);
+            {|LC044:u.Email|} = newEmail;
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task MultipleMutations_Flagged_AtFirst()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } public string Email { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var u = ctx.Users.AsNoTracking().First();
+            {|LC044:u.Name|} = ""a"";
+            u.Email = ""b"";
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ForeachOverAsNoTrackingList_MutateLoopVar_ThenSave_Triggers()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            foreach (var u in ctx.Users.AsNoTracking().ToList())
+            {
+                {|LC044:u.Name|} = ""x"";
+            }
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TrackedQuery_Mutate_ThenSave_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var u = ctx.Users.FirstOrDefault(x => x.Id == 1);
+            u.Name = ""new"";
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsNoTracking_ReadOnly_ThenSave_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var u = ctx.Users.AsNoTracking().FirstOrDefault();
+            var name = u.Name;
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyEdgeCasesTests.cs
@@ -1,0 +1,257 @@
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    LinqContraband.Analyzers.LC044_AsNoTrackingThenModify.AsNoTrackingThenModifyAnalyzer>;
+
+namespace LinqContraband.Tests.Analyzers.LC044_AsNoTrackingThenModify;
+
+public class AsNoTrackingThenModifyEdgeCasesTests
+{
+    private const string EfCoreMock = AsNoTrackingThenModifyAnalyzerTests.EfCoreMock;
+
+    private const string Preamble = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;";
+
+    [Fact]
+    public async Task AsNoTracking_Mutate_ContextUpdate_ThenSave_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var u = ctx.Users.AsNoTracking().First();
+            u.Name = ""x"";
+            ctx.Update(u);
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsNoTracking_Mutate_DbSetUpdate_ThenSave_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var u = ctx.Users.AsNoTracking().First();
+            u.Name = ""x"";
+            ctx.Users.Update(u);
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsNoTracking_Mutate_ContextAttach_ThenSave_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var u = ctx.Users.AsNoTracking().First();
+            u.Name = ""x"";
+            ctx.Attach(u);
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsNoTracking_Mutate_EntryStateModified_ThenSave_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var u = ctx.Users.AsNoTracking().First();
+            u.Name = ""x"";
+            ctx.Entry(u).State = EntityState.Modified;
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsNoTracking_OnContextA_SaveChangesOnContextB_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctxA, TestCtx ctxB)
+        {
+            var u = ctxA.Users.AsNoTracking().First();
+            u.Name = ""x"";
+            ctxB.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task EntityParameter_NoLocalOrigin_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx, User u)
+        {
+            u.Name = ""x"";
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task MultipleReassignments_AmbiguousDataflow_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx, bool flag)
+        {
+            var u = ctx.Users.AsNoTracking().First();
+            if (flag)
+                u = ctx.Users.First();
+            u.Name = ""x"";
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task MutationAfterSaveChanges_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var u = ctx.Users.AsNoTracking().First();
+            ctx.SaveChanges();
+            u.Name = ""post-save mutation is a separate concern"";
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task MutationInBranchWithEarlyReturn_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx, bool flag)
+        {
+            var u = ctx.Users.AsNoTracking().First();
+            if (flag)
+            {
+                u.Name = ""never persisted but never saved either"";
+                return;
+            }
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task DifferentEntityMutated_DoesNotTrigger()
+    {
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var untracked = ctx.Users.AsNoTracking().First();
+            var tracked = ctx.Users.First();
+            tracked.Name = ""ok"";
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task CollectionMutation_NotEntityProperty_DoesNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;" + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public List<string> Tags { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var u = ctx.Users.AsNoTracking().First();
+            u.Tags.Add(""x""); // mutates a collection reference, not a User property
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}

--- a/tests/LinqContraband.Tests/Architecture/RuleCatalogIntegrityTests.cs
+++ b/tests/LinqContraband.Tests/Architecture/RuleCatalogIntegrityTests.cs
@@ -16,7 +16,7 @@ public sealed class RuleCatalogIntegrityTests
     {
         var rules = RuleCatalog.All;
 
-        Assert.Equal(43, rules.Length);
+        Assert.Equal(44, rules.Length);
         Assert.Equal(rules.Length, rules.Select(rule => rule.Id).Distinct(StringComparer.Ordinal).Count());
         Assert.Equal(rules.OrderBy(rule => rule.Id, StringComparer.Ordinal).Select(rule => rule.Id), rules.Select(rule => rule.Id));
     }

--- a/tools/SampleDiagnosticsVerifier/Program.cs
+++ b/tools/SampleDiagnosticsVerifier/Program.cs
@@ -386,6 +386,7 @@ static IReadOnlyList<string> ExpandExpectedRuleIds(string diagnosticPath, IReadO
                  "Samples/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingSample.cs" => new[] { "LC009", "LC031" },
                  "Samples/LC042_MissingQueryTags/MissingQueryTagsSample.cs" => new[] { "LC009" },
                  "Samples/LC043_AsyncEnumerableBuffering/AsyncEnumerableBufferingSample.cs" => new[] { "LC009", "LC031" },
+                 "Samples/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifySample.cs" => new[] { "LC023", "LC025", "LC039", "LC040" },
                  _ => Array.Empty<string>()
              })
     {


### PR DESCRIPTION
## Summary
- Adds **LC044** — detects the silent data-loss chain `AsNoTracking-origin → property mutation → SaveChanges on the same context` with no intervening re-attach (`Update`/`Attach`/`Entry(entity).State = Modified|Added`). EF persists nothing in this pattern; there is no exception and no log, so teams routinely burn hours debugging why writes "don't stick" in production.
- Bumps package version to **5.1.0** and adds docs, sample, rule-catalog entry, Program.cs wiring, sample-verifier contract update, README section, and CHANGELOG.
- **Zero false positives** on the 43 existing sample files and on the intra-procedural FP matrix (11 FP-exclusion tests + 7 positive tests = 18 LC044 tests). Full suite 512/512 passing.

## FP-reduction disciplines
- Single-assignment dataflow on the entity local (multiple writes → skip, ambiguous).
- Same-context linkage: the DbSet-owning context symbol of the query must match the SaveChanges instance symbol.
- Block-ancestor reachability: the mutation's enclosing block must be a same-or-ancestor of the SaveChanges's block — so a mutation inside an early-return branch does not fire.
- Earlier-SaveChanges gate: only the first SaveChanges after the mutation can fire.
- Re-attach gating for `DbContext.Update/Attach/UpdateRange/AttachRange`, their DbSet counterparts (including via `ctx.Set<T>()`), and `ctx.Entry(entity).State = EntityState.Modified|Added`, all required to be on the same context and targeting the same entity local.
- Intra-procedural scope — entity-as-parameter cases are deliberately not flagged in v1.

## Test plan
- [x] \`dotnet test\` — 512/512 pass on net10.0 (18 new LC044 tests)
- [x] Sample diagnostics verifier — 43 diagnostic paths verified
- [x] Build warnings on the real sample: LC044 fires once on the violating line, silent on both tracked-query and re-attach fixes
- [x] No LC044 false positives on any of the 43 existing sample files
- [x] Architecture integrity tests pass (count, repository layout, fixer metadata, documentation presence)