### PR TITLE
[codex] Harden LC034 raw SQL analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Hardened `LC034` so `ExecuteSqlRaw` / `ExecuteSqlRawAsync` diagnostics resolve the `sql` parameter by symbol binding, including named/reordered arguments, and report the correct safe replacement API for sync vs async calls
+- Tightened the `LC034` fixer contract so it only rewrites direct interpolated-string calls with no additional raw SQL parameters
+- Expanded `LC034` analyzer/fixer coverage around nested concatenation, named arguments, parameterized raw SQL, safe `ExecuteSql*` calls, and `LC037`-owned constructed SQL flows
+- Updated `LC034` docs, README guidance, sample code, and analyzer-health status to match the hardened behavior
+
 ## [5.1.0] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1177,7 +1177,7 @@ await db.Database.ExecuteSqlAsync($"DELETE FROM Users WHERE Name = {name}");
 ```
 
 **🛡️ Reliability Notes:**
-- LC034 only offers a fixer when the replacement is analyzer-proven and keeps the same semantics.
+- LC034 only offers a fixer for direct interpolated-string calls with no additional raw SQL parameters.
 - LC034 owns direct interpolated-string and direct non-constant `+` concatenation passed straight into `ExecuteSqlRaw(...)` and `ExecuteSqlRawAsync(...)`.
 - More complex string-building cases are covered separately by [LC037](docs/LC037_RawSqlStringConstruction.md).
 

--- a/docs/LC034_AvoidExecuteSqlRawWithInterpolation.md
+++ b/docs/LC034_AvoidExecuteSqlRawWithInterpolation.md
@@ -16,7 +16,7 @@ await db.Database.ExecuteSqlRawAsync($"DELETE FROM Users WHERE Name = '{name}'")
 Use the safe interpolated API so values are parameterized.
 
 ```csharp
-await db.Database.ExecuteSqlInterpolatedAsync($"DELETE FROM Users WHERE Name = {name}");
+await db.Database.ExecuteSqlAsync($"DELETE FROM Users WHERE Name = {name}");
 ```
 
 ## Analyzer Logic
@@ -26,7 +26,8 @@ await db.Database.ExecuteSqlInterpolatedAsync($"DELETE FROM Users WHERE Name = {
 ### Severity: `Warning`
 
 ### Notes
-The fixer is intentionally narrow. It appears only when the analyzer can prove the rewrite keeps the SQL text and argument flow semantically safe.
+The fixer is intentionally narrow. It appears only for direct interpolated-string calls with no additional raw SQL
+parameters, where the method-name rewrite keeps the SQL text and argument flow semantically safe.
 
 ## Rule Boundary
 - LC034 owns direct interpolated-string and direct non-constant `+` concatenation passed straight into `ExecuteSqlRaw(...)` or `ExecuteSqlRawAsync(...)`.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -1,0 +1,87 @@
+# Analyzer Health
+
+Reviewed: 2026-04-24
+
+This is an actionable health audit for the 44 analyzers in `RuleCatalog`. The current catalog declares 30 rules with code fixes and 14 rules as manual-only with explicit rationale. Scores are 1-5, where `5` is excellent, `3` is usable with gaps, and `1` needs urgent attention.
+
+## Rubric
+
+| Metric | Meaning |
+| --- | --- |
+| Analyzer | Accuracy and semantic depth of the analyzer implementation. |
+| False Positives | Conservatism around ambiguous sources, opt-outs, edge cases, and intentional usage. |
+| Fix Strategy | Quality of the fixer, or quality of the manual-only rationale when no safe fixer exists. |
+| Tests | Strength of analyzer, fixer, negative, edge-case, and cross-analyzer tests. |
+| Docs/Samples | Clarity and consistency of rule docs, sample coverage, metadata, and documented non-goals. |
+| Importance | User-facing usefulness based on frequency, severity, security/reliability/performance impact, and actionability. |
+
+Priority is a planning signal: `High` means the analyzer is important and has meaningful health gaps, `Medium` means useful follow-up work is warranted, and `Low` means no immediate work is needed.
+
+## Scorecard
+
+| Rule | Title | Domain | Severity | Analyzer | False Positives | Fix Strategy | Tests | Docs/Samples | Importance | Priority | Notes |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| LC001 | Local method usage in IQueryable | Query Shape & Translation | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Healthy core translation rule; keep expanding negative tests as new LINQ patterns appear. |
+| LC002 | Premature query continuation after materialization | Materialization & Projection | Warning | 5 | 4 | 5 | 5 | 5 | 5 | Low | Strong analyzer/fixer/test depth; good model for complex performance rules. |
+| LC003 | Prefer Any() over Count() existence checks | Materialization & Projection | Warning | 5 | 5 | 5 | 5 | 4 | 4 | Low | Mature rule with broad edge-case and fixer coverage. |
+| LC004 | IQueryable passed as IEnumerable | Query Shape & Translation | Warning | 5 | 4 | 4 | 4 | 5 | 4 | Low | Strong semantic implementation; keep watching for intentional API-boundary cases. |
+| LC005 | Multiple OrderBy calls | Query Shape & Translation | Warning | 4 | 4 | 3 | 3 | 4 | 3 | Medium | Analyzer is straightforward; add explicit fixer tests to raise confidence. |
+| LC006 | Multiple collection Includes | Loading & Includes | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | Useful high-impact EF performance rule; fixer to `AsSplitQuery` is appropriately conservative. |
+| LC007 | Database execution inside loop | Execution & Async | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Excellent rule with clear ignored cases and conservative explicit-loading fixer behavior. |
+| LC008 | Synchronous EF method in async context | Execution & Async | Warning | 5 | 4 | 4 | 5 | 4 | 4 | Low | Strong coverage including edge cases; keep async API mapping current. |
+| LC009 | Missing AsNoTracking in read-only path | Change Tracking & Context Lifetime | Info | 4 | 4 | 4 | 4 | 4 | 3 | Low | Good write-detection coverage; low severity makes this a tuning rule, not a top priority. |
+| LC010 | SaveChanges inside loop | Change Tracking & Context Lifetime | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | High-value write-side N+1 rule; current fixer guidance appears sufficient. |
+| LC011 | Entity missing primary key | Schema & Modeling | Warning | 5 | 5 | 4 | 5 | 4 | 4 | Low | Strong convention/configuration handling and broad edge-case tests. |
+| LC012 | Use ExecuteDelete instead of RemoveRange | Bulk Operations & Set-Based Writes | Warning | 3 | 3 | 3 | 3 | 4 | 4 | Medium | Useful but semantically delicate; add more negative tests around cascades, tracked entities, and provider/version limits. |
+| LC013 | Disposed context query | Change Tracking & Context Lifetime | Warning | 5 | 5 | 5 | 5 | 4 | 5 | Low | Excellent manual-only candidate with strong lifetime edge-case coverage. |
+| LC014 | Avoid string case conversion in queries | Query Shape & Translation | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Healthy rule; future work is provider/collation nuance rather than core correctness. |
+| LC015 | Missing OrderBy before pagination | Query Shape & Translation | Warning | 4 | 4 | 4 | 4 | 3 | 5 | Medium | High-value reliability rule; docs contain implementation-note residue and should be tightened. |
+| LC016 | Avoid DateTime.Now/UtcNow in queries | Query Shape & Translation | Warning | 5 | 5 | 4 | 5 | 4 | 3 | Low | Well-tested rule; importance is moderate because impact is usually cacheability/testability. |
+| LC017 | Whole entity projection | Materialization & Projection | Info | 5 | 5 | 5 | 5 | 4 | 4 | Low | Very strong edge-case coverage for a heuristic Info rule. |
+| LC018 | FromSqlRaw with interpolated strings | Raw SQL & Security | Warning | 4 | 4 | 3 | 3 | 4 | 5 | High | Security-important; add explicit fixer tests and more constructed-SQL negative/positive cases. |
+| LC019 | Conditional Include expression | Loading & Includes | Warning | 4 | 4 | 5 | 3 | 4 | 5 | Medium | Manual-only rationale is sound; add more Include/ThenInclude shape and non-EF negative tests. |
+| LC020 | Untranslatable string comparison overloads | Query Shape & Translation | Warning | 4 | 4 | 3 | 3 | 4 | 4 | Medium | Add explicit fixer tests and provider translation edge cases. |
+| LC021 | IgnoreQueryFilters usage | Raw SQL & Security | Warning | 4 | 3 | 4 | 3 | 4 | 4 | Medium | Intentional bypasses can be valid; consider suppression/allow-list guidance and more negative tests. |
+| LC022 | ToList/ToArray inside Select projection | Materialization & Projection | Warning | 4 | 4 | 3 | 4 | 4 | 4 | Medium | Analyzer coverage is decent; add dedicated fixer tests if fixer behavior is meant to be supported. |
+| LC023 | Prefer Find/FindAsync for primary key lookups | Materialization & Projection | Info | 3 | 3 | 3 | 3 | 4 | 3 | Medium | Useful but schema-sensitive; add fixer tests and more composite-key/provider edge cases. |
+| LC024 | GroupBy with non-translatable projection | Query Shape & Translation | Warning | 4 | 4 | 5 | 3 | 4 | 5 | Medium | Manual-only is correct; expand translation-boundary tests because runtime failure impact is high. |
+| LC025 | AsNoTracking with Update/Remove | Change Tracking & Context Lifetime | Warning | 4 | 4 | 3 | 3 | 4 | 4 | Medium | Reliability value is clear; add fixer tests or narrow catalog confidence if fixer coverage is intentionally absent. |
+| LC026 | Missing CancellationToken in async call | Execution & Async | Info | 4 | 4 | 3 | 4 | 4 | 3 | Medium | Good analyzer scope; add fixer tests across method parameters, locals, and default token cases. |
+| LC027 | Missing explicit foreign key property | Schema & Modeling | Info | 4 | 4 | 3 | 4 | 4 | 3 | Medium | Design guidance is useful; add fixer tests and more model-configuration negative cases. |
+| LC028 | Deep ThenInclude chain | Loading & Includes | Warning | 3 | 3 | 5 | 3 | 4 | 3 | Medium | Heuristic rule; manual-only is right, but thresholds and false-positive guidance need more tests. |
+| LC029 | Redundant identity Select | Materialization & Projection | Info | 5 | 5 | 5 | 3 | 4 | 2 | Low | Simple, safe cleanup rule; low importance but healthy implementation. |
+| LC030 | DbContext lifetime mismatch | Change Tracking & Context Lifetime | Info | 3 | 3 | 3 | 3 | 4 | 4 | High | Important architecture smell; fixer surface is complex and needs broader DI/lifetime tests. |
+| LC031 | Unbounded query materialization | Materialization & Projection | Info | 3 | 3 | 5 | 3 | 4 | 4 | Medium | Valuable but heuristic; expand safe opt-out, Take/Where ordering, and intentional full-scan coverage. |
+| LC032 | ExecuteUpdate for bulk scalar updates | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 5 | 4 | 4 | 4 | Low | Conservative manual-only rule with solid analysis split; revisit fixer only after more semantics are modeled. |
+| LC033 | Use FrozenSet for static membership caches | Materialization & Projection | Info | 5 | 5 | 5 | 4 | 4 | 2 | Low | Strong implementation for a niche optimization; not a planning priority. |
+| LC034 | ExecuteSqlRaw with interpolated strings | Raw SQL & Security | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Hardened to reference quality with parameter-aware SQL argument resolution, narrow safe fixer behavior, raw-parameter guardrails, LC037 boundary coverage, and aligned docs/sample guidance. |
+| LC035 | Missing Where before bulk execute | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 5 | 3 | 4 | 5 | Medium | Safety impact is high; add more ExecuteDelete/ExecuteUpdate chain and intentional full-table operation tests. |
+| LC036 | DbContext captured by thread work item | Execution & Async | Warning | 4 | 4 | 5 | 3 | 4 | 5 | Medium | Important safety rule; add coverage for more task/parallel APIs and safe factory/scope patterns. |
+| LC037 | Constructed raw SQL strings | Raw SQL & Security | Warning | 5 | 5 | 5 | 5 | 4 | 5 | Low | Strong manual-only security rule with broad string-construction coverage. |
+| LC038 | Excessive eager loading | Loading & Includes | Info | 3 | 3 | 5 | 3 | 4 | 3 | Medium | Heuristic rule; add threshold documentation and more examples of legitimate deep loads. |
+| LC039 | Repeated SaveChanges on same context | Change Tracking & Context Lifetime | Info | 4 | 4 | 5 | 3 | 4 | 4 | Medium | Useful reliability smell; add more transaction, branch, and intentional boundary tests. |
+| LC040 | Mixed tracking and no-tracking modes | Change Tracking & Context Lifetime | Info | 4 | 4 | 5 | 3 | 4 | 4 | Medium | Manual-only is appropriate; add broader context-resolution and split-workflow tests. |
+| LC041 | Single entity over-fetches one consumed property | Materialization & Projection | Info | 4 | 4 | 3 | 3 | 4 | 3 | Medium | Useful but subtle; add explicit fixer tests and more multi-use/side-effect negative cases. |
+| LC042 | Complex query should be tagged | Loading & Includes | Info | 3 | 3 | 5 | 3 | 4 | 2 | Low | Team-policy rule; low importance unless observability standards require tags. |
+| LC043 | Prefer await foreach over buffering async streams | Execution & Async | Info | 3 | 3 | 3 | 3 | 4 | 3 | Medium | Add fixer tests and more cases around multiple enumeration, ordering, and list reuse. |
+| LC044 | AsNoTracking entity mutated then SaveChanges | Change Tracking & Context Lifetime | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Excellent high-impact data-loss rule with strong edge-case coverage and clear manual guidance. |
+
+## Planning Shortlist
+
+The next improvement batch should focus on rules that combine high importance with weaker health:
+
+| Priority | Rules | Work |
+| --- | --- | --- |
+| High | LC018 | Add explicit security fixer tests and bring query raw-SQL coverage up to LC034 parity. |
+| High | LC030 | Broaden DI lifetime and fixer tests; validate safe patterns using factories/scopes. |
+| Medium | LC012, LC023, LC025, LC026, LC027, LC041, LC043 | Add missing or thin fixer test coverage before relying on these fixes heavily. |
+| Medium | LC019, LC024, LC028, LC031, LC035, LC036, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
+| Low | LC002, LC003, LC007, LC013, LC017, LC034, LC037, LC044 | Treat as reference-quality examples for future analyzer work. |
+
+## Verification Baseline
+
+`dotnet restore LinqContraband.sln` completed successfully.
+
+`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 522 passing tests.
+
+`dotnet test LinqContraband.sln --no-restore` currently builds and runs the `net10.0` test target successfully with 522 passing tests. The `net8.0` and `net9.0` test hosts abort in this local environment because arm64 .NET 8 and .NET 9 runtimes are not installed; no test failures were reported before those host aborts.

--- a/samples/LinqContraband.Sample/Samples/LC034_AvoidExecuteSqlRawWithInterpolation/ExecuteSqlRawInterpolationSample.cs
+++ b/samples/LinqContraband.Sample/Samples/LC034_AvoidExecuteSqlRawWithInterpolation/ExecuteSqlRawInterpolationSample.cs
@@ -15,6 +15,6 @@ public static class ExecuteSqlRawInterpolationSample
         await db.Database.ExecuteSqlRawAsync($"DELETE FROM Users WHERE Name = '{name}'");
 
         // CORRECT: Use the safe interpolated API instead.
-        await db.Database.ExecuteSqlInterpolatedAsync($"DELETE FROM Users WHERE Name = {name}");
+        await db.Database.ExecuteSqlAsync($"DELETE FROM Users WHERE Name = {name}");
     }
 }

--- a/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC034_AvoidExecuteSqlRawWithInterpolation/AvoidExecuteSqlRawWithInterpolationAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC034_AvoidExecuteSqlRawWithInterpolation/AvoidExecuteSqlRawWithInterpolationAnalyzer.cs
@@ -15,7 +15,7 @@ public sealed class AvoidExecuteSqlRawWithInterpolationAnalyzer : DiagnosticAnal
     private static readonly LocalizableString Title = "Avoid ExecuteSqlRaw with interpolated strings";
 
     private static readonly LocalizableString MessageFormat =
-        "Use 'ExecuteSql' instead of '{0}' when passing interpolated strings or concatenated SQL";
+        "Use '{0}' instead of '{1}' when passing interpolated strings or concatenated SQL";
 
     private static readonly LocalizableString Description =
         "Raw SQL execution APIs should receive constant SQL text plus parameters. Interpolated strings and concatenation are safer through ExecuteSql/ExecuteSqlAsync.";
@@ -54,7 +54,11 @@ public sealed class AvoidExecuteSqlRawWithInterpolationAnalyzer : DiagnosticAnal
         if (!IsPotentiallyUnsafeSql(sqlArgument.Value))
             return;
 
-        context.ReportDiagnostic(Diagnostic.Create(Rule, sqlArgument.Value.Syntax.GetLocation(), method.Name));
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            sqlArgument.Value.Syntax.GetLocation(),
+            GetReplacementMethodName(method.Name),
+            method.Name));
     }
 
     private static bool IsTargetMethod(IMethodSymbol method)
@@ -63,13 +67,23 @@ public sealed class AvoidExecuteSqlRawWithInterpolationAnalyzer : DiagnosticAnal
                method.ContainingNamespace?.ToString().StartsWith("Microsoft.EntityFrameworkCore", System.StringComparison.Ordinal) == true;
     }
 
+    private static string GetReplacementMethodName(string methodName)
+    {
+        return methodName == "ExecuteSqlRawAsync" ? "ExecuteSqlAsync" : "ExecuteSql";
+    }
+
     private static IArgumentOperation? GetSqlArgument(IInvocationOperation invocation, IMethodSymbol method)
     {
-        var sqlParameterIndex = method.Parameters.ToList().FindIndex(parameter => parameter.Name == "sql");
-        if (sqlParameterIndex < 0 || sqlParameterIndex >= invocation.Arguments.Length)
-            return null;
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Name == "sql")
+                return argument;
+        }
 
-        return invocation.Arguments[sqlParameterIndex];
+        var sqlParameterIndex = method.Parameters.ToList().FindIndex(parameter => parameter.Name == "sql");
+        return sqlParameterIndex >= 0 && sqlParameterIndex < invocation.Arguments.Length
+            ? invocation.Arguments[sqlParameterIndex]
+            : null;
     }
 
     private static bool IsPotentiallyUnsafeSql(IOperation operation)

--- a/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC034_AvoidExecuteSqlRawWithInterpolation/AvoidExecuteSqlRawWithInterpolationFixer.cs
+++ b/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC034_AvoidExecuteSqlRawWithInterpolation/AvoidExecuteSqlRawWithInterpolationFixer.cs
@@ -49,8 +49,11 @@ public sealed class AvoidExecuteSqlRawWithInterpolationFixer : CodeFixProvider
         if (replacementName is null)
             return;
 
-        var firstArg = invocation.ArgumentList.Arguments.FirstOrDefault();
-        if (firstArg?.Expression is not InterpolatedStringExpressionSyntax)
+        var sqlArgument = GetSqlArgument(invocation);
+        if (sqlArgument?.Expression is not InterpolatedStringExpressionSyntax)
+            return;
+
+        if (invocation.ArgumentList.Arguments.Count != 1)
             return;
 
         context.RegisterCodeFix(
@@ -70,5 +73,16 @@ public sealed class AvoidExecuteSqlRawWithInterpolationFixer : CodeFixProvider
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         editor.ReplaceNode(memberAccess, memberAccess.WithName(SyntaxFactory.IdentifierName(replacementName)));
         return editor.GetChangedDocument();
+    }
+
+    private static ArgumentSyntax? GetSqlArgument(InvocationExpressionSyntax invocation)
+    {
+        foreach (var argument in invocation.ArgumentList.Arguments)
+        {
+            if (argument.NameColon?.Name.Identifier.ValueText == "sql")
+                return argument;
+        }
+
+        return invocation.ArgumentList.Arguments.FirstOrDefault(argument => argument.NameColon is null);
     }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC034_AvoidExecuteSqlRawWithInterpolation/AvoidExecuteSqlRawWithInterpolationTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC034_AvoidExecuteSqlRawWithInterpolation/AvoidExecuteSqlRawWithInterpolationTests.cs
@@ -48,7 +48,7 @@ namespace TestApp
     }
 }";
 
-        var expected = VerifyCS.Diagnostic("LC034").WithSpan(31, 52, 31, 83).WithArguments("ExecuteSqlRaw");
+        var expected = VerifyCS.Diagnostic("LC034").WithSpan(31, 52, 31, 83).WithArguments("ExecuteSql", "ExecuteSqlRaw");
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
@@ -67,7 +67,7 @@ namespace TestApp
     }
 }";
 
-        var expected = VerifyCS.Diagnostic("LC034").WithSpan(31, 63, 31, 94).WithArguments("ExecuteSqlRawAsync");
+        var expected = VerifyCS.Diagnostic("LC034").WithSpan(31, 63, 31, 94).WithArguments("ExecuteSqlAsync", "ExecuteSqlRawAsync");
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
@@ -104,8 +104,44 @@ namespace TestApp
     }
 }";
 
-        var expected = VerifyCS.Diagnostic("LC034").WithSpan(31, 52, 31, 83).WithArguments("ExecuteSqlRaw");
+        var expected = VerifyCS.Diagnostic("LC034").WithSpan(31, 52, 31, 83).WithArguments("ExecuteSql", "ExecuteSqlRaw");
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task ExecuteSqlRaw_WithNestedConcatenation_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id, string name)
+        {
+            var result = db.Database.ExecuteSqlRaw({|LC034:""UPDATE Users SET Name = "" + name + "" WHERE Id = "" + id|});
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteSqlRaw_WithNamedSqlArgument_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var result = db.Database.ExecuteSqlRaw(parameters: new object[0], sql: {|LC034:$""UPDATE Users SET Name = {id}""|});
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
@@ -128,6 +164,24 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task ExecuteSqlRaw_WithParameterizedString_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var result = db.Database.ExecuteSqlRaw(""UPDATE Users SET Active = 1 WHERE Id = {0}"", id);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task ExecuteSqlRaw_WithConcatenatedAlias_ShouldNotTriggerLC034()
     {
         var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
@@ -139,6 +193,81 @@ namespace TestApp
         {
             var sql = ""UPDATE Users SET Name = "" + id;
             var result = db.Database.ExecuteSqlRaw(sql);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteSqlRaw_WithStringFormat_ShouldNotTriggerLC034()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var result = db.Database.ExecuteSqlRaw(string.Format(""UPDATE Users SET Name = {0}"", id));
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteSqlRaw_WithStringBuilder_ShouldNotTriggerLC034()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Text;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var builder = new StringBuilder(""UPDATE Users SET Name = "");
+            builder.Append(id);
+            var result = db.Database.ExecuteSqlRaw(builder.ToString());
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteSql_WithInterpolatedString_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var result = db.Database.ExecuteSql($""UPDATE Users SET Name = {id}"");
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteSqlAsync_WithInterpolatedString_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public async Task Run(DbContext db, int id)
+        {
+            var result = await db.Database.ExecuteSqlAsync($""UPDATE Users SET Name = {id}"");
         }
     }
 }";
@@ -173,7 +302,7 @@ namespace TestApp
     }
 }";
 
-        var expected = VerifyFix.Diagnostic("LC034").WithSpan(31, 52, 31, 83).WithArguments("ExecuteSqlRaw");
+        var expected = VerifyFix.Diagnostic("LC034").WithSpan(31, 52, 31, 83).WithArguments("ExecuteSql", "ExecuteSqlRaw");
         await VerifyFix.VerifyCodeFixAsync(test, expected, fixedCode);
     }
 
@@ -206,8 +335,58 @@ namespace TestApp
     }
 }";
 
-        var expected = VerifyFix.Diagnostic("LC034").WithSpan(32, 63, 32, 94).WithArguments("ExecuteSqlRawAsync");
+        var expected = VerifyFix.Diagnostic("LC034").WithSpan(32, 63, 32, 94).WithArguments("ExecuteSqlAsync", "ExecuteSqlRawAsync");
         await VerifyFix.VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldReplaceNamedExecuteSqlRawWithExecuteSql()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var result = db.Database.ExecuteSqlRaw(sql: $""UPDATE Users SET Name = {id}"");
+        }
+    }
+}";
+
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var result = db.Database.ExecuteSql(sql: $""UPDATE Users SET Name = {id}"");
+        }
+    }
+}";
+
+        var expected = VerifyFix.Diagnostic("LC034").WithSpan(31, 57, 31, 88).WithArguments("ExecuteSql", "ExecuteSqlRaw");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldNotRegister_WhenRawParametersArePresent()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var result = db.Database.ExecuteSqlRaw(parameters: new object[0], sql: $""UPDATE Users SET Name = {id}"");
+        }
+    }
+}";
+
+        var expected = VerifyFix.Diagnostic("LC034").WithSpan(31, 84, 31, 115).WithArguments("ExecuteSql", "ExecuteSqlRaw");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, test);
     }
 
     [Fact]
@@ -225,7 +404,26 @@ namespace TestApp
         }
     }";
 
-        var expected = VerifyCS.Diagnostic("LC034").WithSpan(31, 52, 31, 83).WithArguments("ExecuteSqlRaw");
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        var expected = VerifyFix.Diagnostic("LC034").WithSpan(31, 52, 31, 83).WithArguments("ExecuteSql", "ExecuteSqlRaw");
+        await VerifyFix.VerifyCodeFixAsync(test, expected, test);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldNotRegister_ForInterpolatedAlias()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var sql = $""UPDATE Users SET Name = {id}"";
+            var result = db.Database.ExecuteSqlRaw(sql);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, test);
     }
 }


### PR DESCRIPTION
## Summary
- Harden LC034 SQL argument resolution so diagnostics bind to the actual `sql` parameter, including named/reordered arguments.
- Tighten the LC034 fixer so it only rewrites direct interpolated-string calls with no additional raw SQL parameters.
- Expand LC034 analyzer/fixer coverage around nested concatenation, named arguments, parameterized raw SQL, safe `ExecuteSql*` APIs, and LC037-owned constructed SQL flows.
- Align LC034 docs, README guidance, sample code, changelog, and analyzer health status with the hardened behavior.

## Review
- Reviewed the PR diff for analyzer/fixer correctness, test boundaries, and documentation/sample alignment.
- No blocking issues found.
- Supersedes draft PR #81 because the connector failed to mark the draft ready for review.

## Validation
- `/opt/homebrew/bin/dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter FullyQualifiedName~LC034` passed: 19 tests.
- `/opt/homebrew/bin/dotnet test LinqContraband.sln --no-restore --framework net10.0` passed: 522 tests.
- Full multi-target `dotnet test LinqContraband.sln --no-restore` was previously checked; net10 passed, while local net8/net9 testhosts abort because arm64 .NET 8/9 runtimes are not installed in this environment.