### PR TITLE
[codex] Prepare 5.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-04-24
+
 ### Changed
 - Upgraded `LC030` to strict-by-default lifetime review: it now reports only when a `DbContext` member or constructor injection is paired with proven long-lived evidence such as hosted services, conventional middleware, `AddHostedService<T>()`, `AddSingleton(...)`, or explicit singleton `DbContext` registrations
 - Added `LC030` `.editorconfig` knobs for expanded name-based review and project-specific long-lived base/interface types

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.1.0</Version>
+        <Version>5.2.0</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Bump package version to 5.2.0
- Move the current changelog entries under the 2026-04-24 5.2.0 release heading

## Validation
- /opt/homebrew/bin/dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --filter FullyQualifiedName~Architecture --no-restore