### PR TITLE
[codex] Harden LC002 continuation precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Hardened `LC002` continuation reporting with a conservative provider-safety classifier for lambda-based operators, suppressing client-only continuations such as delegated predicates, local/source methods, `Regex`, and `StringComparison` string calls
+- Expanded `LC002` analyzer and fixer coverage for safe lambda continuations, no-fix boundaries, and mixed fix-all behavior
+- Updated `LC002` docs and README reliability notes to describe the new precision-first continuation gate
+
 ## [5.2.0] - 2026-04-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.1] - 2026-04-24
+
 ### Changed
 - Hardened `LC002` continuation reporting with a conservative provider-safety classifier for lambda-based operators, suppressing client-only continuations such as delegated predicates, local/source methods, `Regex`, and `StringComparison` string calls
 - Expanded `LC002` analyzer and fixer coverage for safe lambda continuations, no-fix boundaries, and mixed fix-all behavior

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ var query3 = db.Users.ToList();
 
 **🛡️ Reliability Notes:**
 - LC002 follows direct chains, single-assignment local hops, and collection constructors only when the `IQueryable` origin is provable.
-- It stays silent on ambiguous multi-assignment, field/property provenance, and overloads without a clear `IQueryable`-safe equivalent.
+- It gates lambda continuations through a conservative provider-safety classifier and stays silent on ambiguous multi-assignment, field/property provenance, delegated predicates, local/source methods, `Regex`, `StringComparison` string calls, and overloads without a clear `IQueryable`-safe equivalent.
 - The fixer is intentionally conservative and skips risky cases such as local-hop rewrites or shape-changing materializers like `ToDictionary(...).Where(...)`.
 
 ---

--- a/docs/LC002_PrematureMaterialization.md
+++ b/docs/LC002_PrematureMaterialization.md
@@ -7,6 +7,7 @@ Catch query work that moves from the provider to LINQ-to-Objects only because an
 
 ### 1. Premature query continuation
 LC002 reports approved `Enumerable` operators that run after a materializer sourced from `IQueryable`.
+Lambda-based continuations must also pass a conservative provider-safety check before the rule reports.
 
 ```csharp
 var users = db.Users.ToList().Where(u => u.Age > 18);
@@ -35,7 +36,7 @@ var usersAgain = db.Users.ToArray().ToList();
 ## What LC002 Intentionally Ignores
 - Ambiguous provenance such as multiple local assignments or control-flow-dependent sources
 - Field/property provenance and other shapes where the analyzer cannot prove the query origin safely
-- Overloads that do not have a clear `IQueryable`-safe equivalent, such as index-aware predicates/selectors or comparer-based overloads
+- Overloads or lambdas that do not have a clear `IQueryable`-safe equivalent, such as index-aware predicates/selectors, comparer-based overloads, delegated predicates, local/source methods, `Regex`, or `StringComparison` string calls
 - Pure in-memory sequences that never came from `IQueryable`
 
 ## Fixer Behavior
@@ -44,6 +45,7 @@ The fixer is intentionally conservative.
 - It offers `Move query operator before materialization` only for analyzer-proven inline chains where the rewrite is explicit.
 - It offers `Remove redundant materialization` only for direct redundant materializer pairs.
 - It does not offer a fix for local-hop, constructor, ambiguous, or shape-changing cases such as `ToDictionary(...).Where(...)`.
+- It does not offer a fix for client-only lambda bodies because LC002 suppresses those diagnostics entirely.
 
 ## Example Fixes
 

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs
@@ -120,6 +120,7 @@ public sealed partial class PrematureMaterializationAnalyzer : DiagnosticAnalyze
 
         if (receiverType?.IsIQueryable() == true) return;
         if (!IsApprovedContinuationMethod(invocation.TargetMethod, out _)) return;
+        if (!HasProviderSafeContinuationArguments(invocation)) return;
 
         if (!TryResolveMaterializationOrigin(
                 unwrappedReceiver,

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationContinuationSafety.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationContinuationSafety.cs
@@ -1,0 +1,208 @@
+using System;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC002_PrematureMaterialization;
+
+public sealed partial class PrematureMaterializationAnalyzer
+{
+    private static bool HasProviderSafeContinuationArguments(IInvocationOperation invocation)
+    {
+        foreach (var argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Type is not INamedTypeSymbol parameterType ||
+                !IsDelegateLikeParameter(parameterType))
+            {
+                continue;
+            }
+
+            var value = argument.Value.UnwrapConversions();
+            if (value is IDelegateCreationOperation delegateCreation)
+                value = delegateCreation.Target.UnwrapConversions();
+
+            if (value is not IAnonymousFunctionOperation anonymousFunction ||
+                !IsProviderSafeLambdaBody(anonymousFunction.Body))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsDelegateLikeParameter(INamedTypeSymbol parameterType)
+    {
+        return parameterType.TypeKind == TypeKind.Delegate ||
+               parameterType.DelegateInvokeMethod != null ||
+               (parameterType.Name == "Expression" &&
+                parameterType.ContainingNamespace?.ToString() == "System.Linq.Expressions");
+    }
+
+    private static bool IsProviderSafeLambdaBody(IOperation body)
+    {
+        var unwrapped = body.UnwrapConversions();
+
+        if (unwrapped is IBlockOperation block)
+        {
+            return block.Operations.Length == 1 &&
+                   block.Operations[0] is IReturnOperation blockReturn &&
+                   blockReturn.ReturnedValue != null &&
+                   IsProviderSafeExpression(blockReturn.ReturnedValue);
+        }
+
+        if (unwrapped is IReturnOperation returnOperation)
+        {
+            return returnOperation.ReturnedValue != null &&
+                   IsProviderSafeExpression(returnOperation.ReturnedValue);
+        }
+
+        return IsProviderSafeExpression(unwrapped);
+    }
+
+    private static bool IsProviderSafeExpression(IOperation operation)
+    {
+        var unwrapped = operation.UnwrapConversions();
+
+        switch (unwrapped)
+        {
+            case ILiteralOperation:
+            case IParameterReferenceOperation:
+            case ILocalReferenceOperation:
+            case IFieldReferenceOperation:
+            case IPropertyReferenceOperation:
+            case IConditionalAccessInstanceOperation:
+            case IInstanceReferenceOperation:
+                return true;
+
+            case IUnaryOperation unary:
+                return IsProviderSafeExpression(unary.Operand);
+
+            case IBinaryOperation binary:
+                return IsProviderSafeExpression(binary.LeftOperand) &&
+                       IsProviderSafeExpression(binary.RightOperand);
+
+            case IConditionalOperation conditional:
+                return conditional.WhenTrue != null &&
+                       conditional.WhenFalse != null &&
+                       IsProviderSafeExpression(conditional.Condition) &&
+                       IsProviderSafeExpression(conditional.WhenTrue) &&
+                       IsProviderSafeExpression(conditional.WhenFalse);
+
+            case IIsTypeOperation isType:
+                return isType.ValueOperand != null &&
+                       IsProviderSafeExpression(isType.ValueOperand);
+
+            case IParenthesizedOperation parenthesized:
+                return IsProviderSafeExpression(parenthesized.Operand);
+
+            case IConversionOperation conversion:
+                return IsProviderSafeExpression(conversion.Operand);
+
+            case IAnonymousObjectCreationOperation anonymousObject:
+                foreach (var initializer in anonymousObject.Initializers)
+                {
+                    if (!IsProviderSafeExpression(initializer))
+                        return false;
+                }
+
+                return true;
+
+            case ISimpleAssignmentOperation assignment:
+                return IsProviderSafeExpression(assignment.Value);
+
+            case ITupleOperation tuple:
+                foreach (var element in tuple.Elements)
+                {
+                    if (!IsProviderSafeExpression(element))
+                        return false;
+                }
+
+                return true;
+
+            case IObjectCreationOperation objectCreation:
+                return IsProviderSafeObjectCreation(objectCreation);
+
+            case IInvocationOperation invocation:
+                return IsProviderSafeInvocation(invocation);
+
+            case IConditionalAccessOperation conditionalAccess:
+                return IsProviderSafeExpression(conditionalAccess.Operation);
+
+            case ICoalesceOperation coalesce:
+                return IsProviderSafeExpression(coalesce.Value) &&
+                       IsProviderSafeExpression(coalesce.WhenNull);
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool IsProviderSafeObjectCreation(IObjectCreationOperation objectCreation)
+    {
+        if (objectCreation.Constructor?.ContainingType?.IsAnonymousType == true)
+            return true;
+
+        if (objectCreation.Constructor?.ContainingType?.IsTupleType == true)
+        {
+            foreach (var argument in objectCreation.Arguments)
+            {
+                if (!IsProviderSafeExpression(argument.Value))
+                    return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsProviderSafeInvocation(IInvocationOperation invocation)
+    {
+        var method = invocation.TargetMethod;
+        if (!IsAllowedProviderSafeStringMethod(method))
+            return false;
+
+        var receiver = invocation.GetInvocationReceiver();
+        if (receiver != null && !IsProviderSafeExpression(receiver))
+            return false;
+
+        foreach (var argument in invocation.Arguments)
+        {
+            if (!IsProviderSafeExpression(argument.Value))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsAllowedProviderSafeStringMethod(IMethodSymbol method)
+    {
+        if (method.ContainingType.SpecialType != SpecialType.System_String)
+            return false;
+
+        if (HasStringComparisonParameter(method))
+            return false;
+
+        return method.Name is
+            "Contains" or
+            "StartsWith" or
+            "EndsWith" or
+            "IsNullOrEmpty" or
+            "IsNullOrWhiteSpace";
+    }
+
+    private static bool HasStringComparisonParameter(IMethodSymbol method)
+    {
+        foreach (var parameter in method.Parameters)
+        {
+            if (parameter.Type.Name == "StringComparison" &&
+                parameter.Type.ContainingNamespace?.ToString() == "System")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.0</Version>
+        <Version>5.2.1</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationFixerTests.cs
@@ -106,6 +106,74 @@ public class PrematureMaterializationFixerTests
     }
 
     [Fact]
+    public async Task Fixes_InlineAnyPredicateByMovingItBeforeToList()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main(string name)
+                {
+                    var db = new DbContext();
+                    var exists = {|#0:db.Users.ToList().Any(x => x.Name == name)|};
+                }
+            }
+            """ + MockTypes;
+
+        var fixedCode = CommonUsings + """
+
+            class Program
+            {
+                void Main(string name)
+                {
+                    var db = new DbContext();
+                    var exists = db.Users.Any(x => x.Name == name);
+                }
+            }
+            """ + MockTypes;
+
+        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("Any");
+
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixes_InlineCountByRemovingEarlyToList()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main()
+                {
+                    var db = new DbContext();
+                    var count = {|#0:db.Users.ToList().Count()|};
+                }
+            }
+            """ + MockTypes;
+
+        var fixedCode = CommonUsings + """
+
+            class Program
+            {
+                void Main()
+                {
+                    var db = new DbContext();
+                    var count = db.Users.Count();
+                }
+            }
+            """ + MockTypes;
+
+        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("Count");
+
+        await VerifyCS.VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
     public async Task Fixes_RedundantToArrayThenToList()
     {
         var test = CommonUsings + """
@@ -219,6 +287,82 @@ public class PrematureMaterializationFixerTests
     }
 
     [Fact]
+    public async Task DoesNotOfferFix_ForAsyncMaterialization()
+    {
+        var test = CommonUsings + """
+            using System.Threading.Tasks;
+            using Microsoft.EntityFrameworkCore;
+
+            class Program
+            {
+                async Task Main()
+                {
+                    var db = new DbContext();
+                    var query = {|#0:(await db.Users.ToListAsync()).Where(x => x.Age > 18)|};
+                }
+            }
+
+            namespace Microsoft.EntityFrameworkCore
+            {
+                public static class AsyncExtensions
+                {
+                    public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source) =>
+                        Task.FromResult(source.ToList());
+                }
+            }
+            """ + MockTypes;
+
+        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("Where");
+
+        await VerifyCS.VerifyCodeFixAsync(test, expected, test);
+    }
+
+    [Fact]
+    public async Task DoesNotOfferFix_ForConstructorMaterialization()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main()
+                {
+                    var db = new DbContext();
+                    var materialized = new HashSet<User>(db.Users);
+                    var query = {|#0:materialized.Where(x => x.Age > 18)|};
+                }
+            }
+            """ + MockTypes;
+
+        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("Where");
+
+        await VerifyCS.VerifyCodeFixAsync(test, expected, test);
+    }
+
+    [Fact]
+    public async Task DoesNotReportOrOfferFix_ForClientOnlyLambda()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main()
+                {
+                    var db = new DbContext();
+                    var query = db.Users.ToList().Where(x => IsActive(x));
+                }
+
+                private static bool IsActive(User user) => user.Age > 18;
+            }
+            """ + MockTypes;
+
+        await VerifyCS.VerifyCodeFixAsync(test, test);
+    }
+
+    [Fact]
     public async Task FixAll_RewritesAllInlineMoveBeforeMaterializationCases()
     {
         var test = CommonUsings + """
@@ -264,6 +408,66 @@ public class PrematureMaterializationFixerTests
             new DiagnosticResult(PrematureMaterializationAnalyzer.Rule)
                 .WithLocation(1)
                 .WithArguments("OrderBy"));
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixAll_RewritesOnlyFixableDiagnostics()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main()
+                {
+                    var db = new DbContext();
+                    var adults = {|#0:db.Users.ToList().Where(x => x.Age >= 18)|};
+                    var materialized = db.Users.ToList();
+                    var older = {|#1:materialized.Where(x => x.Age >= 21)|};
+                }
+            }
+            """ + MockTypes;
+
+        var fixedCode = CommonUsings + """
+
+            class Program
+            {
+                void Main()
+                {
+                    var db = new DbContext();
+                    var adults = db.Users.Where(x => x.Age >= 18).ToList();
+                    var materialized = db.Users.ToList();
+                    var older = materialized.Where(x => x.Age >= 21);
+                }
+            }
+            """ + MockTypes;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            BatchFixedCode = fixedCode,
+            NumberOfIncrementalIterations = 1,
+            CodeFixEquivalenceKey = "MoveBeforeMaterialization"
+        };
+
+        testObj.ExpectedDiagnostics.Add(
+            new DiagnosticResult(PrematureMaterializationAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("Where"));
+        testObj.ExpectedDiagnostics.Add(
+            new DiagnosticResult(PrematureMaterializationAnalyzer.Rule)
+                .WithLocation(1)
+                .WithArguments("Where"));
+        testObj.FixedState.ExpectedDiagnostics.Add(
+            new DiagnosticResult(PrematureMaterializationAnalyzer.Rule)
+                .WithSpan(12, 21, 12, 57)
+                .WithArguments("Where"));
+        testObj.BatchFixedState.ExpectedDiagnostics.Add(
+            new DiagnosticResult(PrematureMaterializationAnalyzer.Rule)
+                .WithSpan(12, 21, 12, 57)
+                .WithArguments("Where"));
 
         await testObj.RunAsync();
     }

--- a/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationTests.cs
@@ -65,6 +65,28 @@ public class PrematureMaterializationTests
     }
 
     [Fact]
+    public async Task Reports_WhenWhereWithCapturedValueRunsAfterToList()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main(int minAge)
+                {
+                    var db = new DbContext();
+                    var query = {|#0:db.Users.ToList().Where(x => x.Age > minAge)|};
+                }
+            }
+            """ + MockTypes;
+
+        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("Where");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task Reports_WhenCountRunsAfterToArray()
     {
         var test = CommonUsings + """
@@ -82,6 +104,50 @@ public class PrematureMaterializationTests
         var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
             .WithLocation(0)
             .WithArguments("Count");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Reports_WhenAnyPredicateRunsAfterToList()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main(string name)
+                {
+                    var db = new DbContext();
+                    var exists = {|#0:db.Users.ToList().Any(x => x.Name == name)|};
+                }
+            }
+            """ + MockTypes;
+
+        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("Any");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task Reports_WhenStringContainsWithoutComparisonRunsAfterToList()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main(string search)
+                {
+                    var db = new DbContext();
+                    var query = {|#0:db.Users.ToList().Where(x => x.Name.Contains(search))|};
+                }
+            }
+            """ + MockTypes;
+
+        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("Where");
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
@@ -248,6 +314,80 @@ public class PrematureMaterializationTests
                 {
                     var users = new List<User>();
                     var filtered = users.ToList().Where(x => x.Age > 18);
+                }
+            }
+            """ + MockTypes;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task DoesNotReport_WhenContinuationUsesLocalMethod()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main()
+                {
+                    var db = new DbContext();
+                    var filtered = db.Users.ToList().Where(x => IsActive(x));
+                }
+
+                private static bool IsActive(User user) => user.Age > 18;
+            }
+            """ + MockTypes;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task DoesNotReport_WhenContinuationUsesRegex()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main(string pattern)
+                {
+                    var db = new DbContext();
+                    var filtered = db.Users.ToList().Where(x => System.Text.RegularExpressions.Regex.IsMatch(x.Name, pattern));
+                }
+            }
+            """ + MockTypes;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task DoesNotReport_WhenContinuationUsesDelegatePredicate()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main(Func<User, bool> predicate)
+                {
+                    var db = new DbContext();
+                    var filtered = db.Users.ToList().Where(predicate);
+                }
+            }
+            """ + MockTypes;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task DoesNotReport_WhenStringComparisonOverloadRunsAfterToList()
+    {
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main(string search)
+                {
+                    var db = new DbContext();
+                    var filtered = db.Users.ToList().Where(x => x.Name.Contains(search, StringComparison.OrdinalIgnoreCase));
                 }
             }
             """ + MockTypes;


### PR DESCRIPTION
## Summary
- Add a conservative LC002 provider-safety classifier for lambda-based continuations.
- Suppress client-only post-materialization continuations such as delegated predicates, local/source methods, Regex, and StringComparison string calls.
- Expand LC002 analyzer/fixer tests and update CHANGELOG, README, rule docs, and package version for 5.2.1.

## Impact
LC002 should now produce fewer false positives in high-volume codebases while preserving diagnostics and fixes for provider-safe continuations that can be moved before materialization.

## Release
- Prepares patch release `5.2.1` in `src/LinqContraband/LinqContraband.csproj`.
- Moves the LC002 changelog entry under `## [5.2.1] - 2026-04-24`.
- Publishing the GitHub Release `v5.2.1` after merge should trigger `.github/workflows/publish.yml` and push the NuGet package.

## Validation
- `/usr/local/share/dotnet/dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter "FullyQualifiedName~LC002"` — 38 passed
- `/usr/local/share/dotnet/dotnet test LinqContraband.sln --no-restore --framework net10.0` — 546 passed
- `git diff --check` — passed

## Notes
The local environment only has the arm64 .NET 10 runtime installed, so unqualified multi-target test runs still abort for net8.0/net9.0 hosts here.