### PR TITLE
[codex] Upgrade LC006 cartesian explosion analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.2] - 2026-04-24
+
+### Changed
+- Reworked `LC006` cartesian explosion analysis around EF query-chain navigation paths so diagnostics now focus on distinct sibling collection includes instead of every later include call
+- Added `LC006` coverage for nested sibling `ThenInclude` collections, filtered includes, resolvable string include paths, duplicate include suppression, and final `AsSplitQuery()` / `AsSingleQuery()` ordering
+- Hardened the `LC006` fixer so it inserts `AsSplitQuery()` at the stable query root and replaces an effective downstream `AsSingleQuery()` when needed
+- Updated `LC006` docs, README guidance, and sample wording to describe sibling collection risk and the preferred split-query placement
+
 ## [5.2.1] - 2026-04-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ var query = db.Users.OrderBy(u => u.Name).ThenBy(u => u.Age);
 
 ### LC006: Cartesian Explosion Risk
 
-If User has 10 Orders, and Order has 10 Items, fetching all creates 100 rows per User. With 1000 Users, that's 100,000
-rows transferred. `AsSplitQuery` fetches Users, Orders, and Items in 3 separate, clean queries.
+If User has 10 Orders and 10 Roles, fetching both sibling collections in one SQL query creates 100 rows per User. With
+1000 Users, that's 100,000 rows transferred. `AsSplitQuery` fetches Users, Orders, and Roles in separate, clean queries.
 
 **👶 Explain it like I'm a ten year old:** Imagine a teacher asks 30 students what they ate. Instead of getting 30
 answers, she asks every student to list every single fry they ate individually. You end up with thousands of answers ("I
@@ -238,7 +238,7 @@ Use `.AsSplitQuery()` to fetch related data in separate SQL queries.
 
 ```csharp
 // Fetches Users, then Orders, then Roles (3 queries).
-var query = db.Users.Include(u => u.Orders).AsSplitQuery().Include(u => u.Roles).ToList();
+var query = db.Users.AsSplitQuery().Include(u => u.Orders).Include(u => u.Roles).ToList();
 ```
 
 ---

--- a/docs/LC006_CartesianExplosion.md
+++ b/docs/LC006_CartesianExplosion.md
@@ -1,10 +1,10 @@
 # Spec: LC006 - Cartesian Explosion Risk
 
 ## Goal
-Detect usage of multiple `Include` calls for collection properties without using `AsSplitQuery()`.
+Detect sibling collection `Include` paths on the same query without an effective `AsSplitQuery()`.
 
 ## The Problem
-When you `Include` multiple related collections in a single SQL query, the database generates a Cartesian product. For example, if a User has 10 Orders and 10 Roles, the query returns 100 rows for that single User. This can rapidly "explode" and crash your application or the database.
+When you `Include` multiple sibling collections in a single SQL query, the database generates a Cartesian product. For example, if a User has 10 Orders and 10 Roles, the query returns 100 rows for that single User. A linear nested path such as `Users -> Orders -> Items` is not the same shape and is not reported by LC006.
 
 ### Example Violation
 ```csharp
@@ -17,10 +17,12 @@ Use `.AsSplitQuery()` to fetch each collection in its own separate SQL query.
 
 ```csharp
 // Correct: Fetches Users, then Orders, then Roles (3 clean queries)
-var users = db.Users.Include(u => u.Orders).AsSplitQuery().Include(u => u.Roles).ToList();
+var users = db.Users.AsSplitQuery().Include(u => u.Orders).Include(u => u.Roles).ToList();
 ```
 
 ## Analyzer Logic
+
+LC006 resolves lambda, filtered, and literal string include paths when the navigation symbols are provable. It deduplicates repeated include paths and reports once for each risky query chain. A final explicit `AsSplitQuery()` suppresses the diagnostic; a final explicit `AsSingleQuery()` keeps it active.
 
 ### ID: `LC006`
 ### Category: `Performance`

--- a/samples/LinqContraband.Sample/Samples/LC006_CartesianExplosion/CartesianExplosionSample.cs
+++ b/samples/LinqContraband.Sample/Samples/LC006_CartesianExplosion/CartesianExplosionSample.cs
@@ -8,8 +8,8 @@ namespace LinqContraband.Sample.Samples.LC006_CartesianExplosion;
 /// </summary>
 /// <remarks>
 ///     <para>
-///         <strong>The Crime:</strong> Using multiple <c>Include()</c> calls on different collection navigations
-///         in a single query without splitting it.
+///         <strong>The Crime:</strong> Using multiple <c>Include()</c> calls on sibling collection navigations in a
+///         single query without splitting it.
 ///     </para>
 ///     <para>
 ///         <strong>Why it's bad:</strong> Relational databases join tables to produce the result.
@@ -33,7 +33,7 @@ public class CartesianExplosionSample
     {
         Console.WriteLine("Testing LC006...");
 
-        // VIOLATION: Fetching multiple collection navigations (Orders, Roles) in a single query.
+        // VIOLATION: Fetching sibling collection navigations (Orders, Roles) in a single query.
         // This creates a Cartesian product (Users * Orders * Roles).
         var cartesianResult = users.OrderBy(u => u.Id).Take(10).Include(u => u.Orders).Include(u => u.Roles).ToList();
     }

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs
@@ -1,7 +1,7 @@
 using System.Collections.Immutable;
+using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -25,7 +25,7 @@ public sealed partial class CartesianExplosionAnalyzer : DiagnosticAnalyzer
     private static readonly LocalizableString Title = "Cartesian Explosion Risk: Multiple Collection Includes";
 
     private static readonly LocalizableString MessageFormat =
-        "Including multiple collections ('{0}') in a single query causes Cartesian Explosion. Use AsSplitQuery().";
+        "Including sibling collections ('{0}') in a single query can cause cartesian explosion. Use AsSplitQuery().";
 
     private static readonly LocalizableString Description =
         "Loading multiple collections in a single query causes geometric data duplication. Use .AsSplitQuery() to separate them into distinct SQL queries.";
@@ -51,37 +51,123 @@ public sealed partial class CartesianExplosionAnalyzer : DiagnosticAnalyzer
     private void AnalyzeInvocation(OperationAnalysisContext context)
     {
         var invocation = (IInvocationOperation)context.Operation;
-        var method = invocation.TargetMethod;
 
-        if (!IsIncludeMethod(method))
+        if (!IsRelevantQueryOperator(invocation.TargetMethod))
             return;
 
-        var semanticModel = context.Operation.SemanticModel;
-        if (semanticModel == null || invocation.Syntax is not InvocationExpressionSyntax invocationSyntax)
+        if (HasRelevantQueryOperatorAncestor(invocation))
             return;
 
-        if (!TryGetIncludedNavigation(invocationSyntax, semanticModel, out var currentNavigation))
+        if (!TryAnalyzeIncludeChain(invocation, out var chain))
             return;
 
-        var chain = AnalyzeIncludeChain(invocationSyntax, semanticModel);
-        if (HasSplitQueryDownstream(invocationSyntax, semanticModel) || chain.HasSplitQuery)
+        if (chain.EffectiveQueryMode == QuerySplittingMode.Split)
             return;
 
-        if (chain.CollectionIncludes.Count > 1)
+        if (chain.TryGetRiskySiblingCollections(out var siblings))
         {
             context.ReportDiagnostic(
-                Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), currentNavigation));
+                Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), string.Join("', '", siblings)));
         }
     }
 
-    private static bool IsIncludeMethod(IMethodSymbol method)
+    private static bool IsRelevantQueryOperator(IMethodSymbol method)
     {
-        return method.Name == "Include" && method.ContainingNamespace?.ToString() == "Microsoft.EntityFrameworkCore";
+        return method.Name is "Include" or "ThenInclude" or "AsSplitQuery" or "AsSingleQuery" &&
+               method.ContainingNamespace?.ToString() == "Microsoft.EntityFrameworkCore";
+    }
+
+    private enum QuerySplittingMode
+    {
+        None,
+        Split,
+        Single
+    }
+
+    private readonly struct NavigationSegment
+    {
+        public NavigationSegment(string name, bool isCollection)
+        {
+            Name = name;
+            IsCollection = isCollection;
+        }
+
+        public string Name { get; }
+        public bool IsCollection { get; }
+    }
+
+    private sealed class IncludePath
+    {
+        public IncludePath(ImmutableArray<NavigationSegment> segments)
+        {
+            Segments = segments;
+        }
+
+        public ImmutableArray<NavigationSegment> Segments { get; }
+
+        public string Key => string.Join(".", Segments.Select(segment => segment.Name));
+
+        public IncludePath Append(IncludePath childPath)
+        {
+            return new IncludePath(Segments.AddRange(childPath.Segments));
+        }
     }
 
     private sealed class IncludeChainAnalysis
     {
-        public bool HasSplitQuery { get; set; }
-        public System.Collections.Generic.List<string> CollectionIncludes { get; } = new();
+        private readonly System.Collections.Generic.List<IncludePath> includePaths = new();
+
+        public QuerySplittingMode EffectiveQueryMode { get; set; }
+
+        public void AddIncludePath(IncludePath path)
+        {
+            if (path.Segments.Length > 0)
+                includePaths.Add(path);
+        }
+
+        public bool TryGetRiskySiblingCollections(out ImmutableArray<string> siblings)
+        {
+            var seenIncludePaths = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
+            var groups = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>>(System.StringComparer.Ordinal);
+            var groupSets = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>(System.StringComparer.Ordinal);
+
+            foreach (var path in includePaths)
+            {
+                if (!seenIncludePaths.Add(path.Key))
+                    continue;
+
+                var parent = new System.Collections.Generic.List<string>();
+                foreach (var segment in path.Segments)
+                {
+                    if (segment.IsCollection)
+                    {
+                        var parentKey = string.Join(".", parent);
+                        if (!groups.TryGetValue(parentKey, out var group))
+                        {
+                            group = new System.Collections.Generic.List<string>();
+                            groups[parentKey] = group;
+                            groupSets[parentKey] = new System.Collections.Generic.HashSet<string>(System.StringComparer.Ordinal);
+                        }
+
+                        if (groupSets[parentKey].Add(segment.Name))
+                            group.Add(segment.Name);
+                    }
+
+                    parent.Add(segment.Name);
+                }
+            }
+
+            foreach (var group in groups.Values)
+            {
+                if (group.Count > 1)
+                {
+                    siblings = group.ToImmutableArray();
+                    return true;
+                }
+            }
+
+            siblings = ImmutableArray<string>.Empty;
+            return false;
+        }
     }
 }

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionChainAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionChainAnalysis.cs
@@ -1,59 +1,106 @@
+using System.Collections.Immutable;
+using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace LinqContraband.Analyzers.LC006_CartesianExplosion;
 
 public sealed partial class CartesianExplosionAnalyzer
 {
-    private static IncludeChainAnalysis AnalyzeIncludeChain(
-        InvocationExpressionSyntax invocationSyntax,
-        SemanticModel semanticModel)
+    private static bool TryAnalyzeIncludeChain(
+        IInvocationOperation outermostInvocation,
+        out IncludeChainAnalysis analysis)
     {
-        var result = new IncludeChainAnalysis();
-        InvocationExpressionSyntax? current = invocationSyntax;
+        analysis = new IncludeChainAnalysis();
+        var semanticModel = outermostInvocation.SemanticModel;
+        if (semanticModel == null)
+            return false;
 
-        while (current?.Expression is MemberAccessExpressionSyntax memberAccess)
+        var invocations = CollectReceiverChainInvocations(outermostInvocation);
+        IncludePath? currentIncludePath = null;
+        var foundInclude = false;
+
+        foreach (var invocation in invocations)
         {
-            var symbol = semanticModel.GetSymbolInfo(current).Symbol as IMethodSymbol;
-            if (symbol?.ContainingNamespace?.ToString() != "Microsoft.EntityFrameworkCore")
+            var methodName = invocation.TargetMethod.Name;
+            if (!IsRelevantQueryOperator(invocation.TargetMethod))
+                continue;
+
+            if (methodName == "AsSplitQuery")
             {
-                current = memberAccess.Expression as InvocationExpressionSyntax;
+                analysis.EffectiveQueryMode = QuerySplittingMode.Split;
                 continue;
             }
 
-            var methodName = memberAccess.Name.Identifier.Text;
-            if (methodName == "AsSplitQuery")
+            if (methodName == "AsSingleQuery")
             {
-                result.HasSplitQuery = true;
-            }
-            else if (methodName == "Include" &&
-                     TryGetIncludedNavigation(current, semanticModel, out var navigation))
-            {
-                result.CollectionIncludes.Add(navigation);
+                analysis.EffectiveQueryMode = QuerySplittingMode.Single;
+                continue;
             }
 
-            current = memberAccess.Expression as InvocationExpressionSyntax;
+            if (!TryGetIncludePath(invocation, semanticModel, currentIncludePath, out var includePath))
+                continue;
+
+            foundInclude = true;
+            currentIncludePath = includePath;
+            analysis.AddIncludePath(includePath);
         }
 
-        result.CollectionIncludes.Reverse();
-        return result;
+        return foundInclude;
     }
 
-    private static bool HasSplitQueryDownstream(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+    private static ImmutableArray<IInvocationOperation> CollectReceiverChainInvocations(IInvocationOperation outermostInvocation)
     {
-        var current = invocation.Parent;
+        var builder = ImmutableArray.CreateBuilder<IInvocationOperation>();
+        IOperation? current = outermostInvocation;
+
         while (current != null)
         {
-            if (current is InvocationExpressionSyntax parentInvocation &&
-                parentInvocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-                memberAccess.Name.Identifier.Text == "AsSplitQuery" &&
-                semanticModel.GetSymbolInfo(parentInvocation).Symbol is IMethodSymbol method &&
-                method.ContainingNamespace?.ToString() == "Microsoft.EntityFrameworkCore")
-            {
+            current = current.UnwrapConversions();
+            if (current is not IInvocationOperation invocation)
+                break;
+
+            builder.Add(invocation);
+            current = invocation.GetInvocationReceiver();
+        }
+
+        builder.Reverse();
+        return builder.ToImmutable();
+    }
+
+    private static bool HasRelevantQueryOperatorAncestor(IInvocationOperation invocation)
+    {
+        for (var current = invocation.Parent; current != null; current = current.Parent)
+        {
+            if (current is not IInvocationOperation parentInvocation)
+                continue;
+
+            if (!IsRelevantQueryOperator(parentInvocation.TargetMethod))
+                continue;
+
+            if (InvocationUsesReceiverChain(parentInvocation.GetInvocationReceiver(), invocation))
                 return true;
+        }
+
+        return false;
+    }
+
+    private static bool InvocationUsesReceiverChain(IOperation? current, IInvocationOperation target)
+    {
+        current = current?.UnwrapConversions();
+
+        while (current != null)
+        {
+            if (ReferenceEquals(current, target))
+                return true;
+
+            if (current is IInvocationOperation invocation)
+            {
+                current = invocation.GetInvocationReceiver();
+                continue;
             }
 
-            current = current.Parent;
+            break;
         }
 
         return false;

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionFixer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionFixer.cs
@@ -52,6 +52,14 @@ public class CartesianExplosionFixer : CodeFixProvider
 
         editor.EnsureUsing("Microsoft.EntityFrameworkCore");
 
+        if (FindEffectiveAsSingleQueryInvocation(invocation) is { Expression: MemberAccessExpressionSyntax asSingleMemberAccess } asSingleQuery)
+        {
+            var replacementMemberAccess = asSingleMemberAccess.WithName(
+                SyntaxFactory.IdentifierName("AsSplitQuery").WithTriviaFrom(asSingleMemberAccess.Name));
+            editor.ReplaceNode(asSingleQuery, asSingleQuery.WithExpression(replacementMemberAccess));
+            return editor.GetChangedDocument();
+        }
+
         var firstInclude = FindFirstIncludeInvocation(invocation);
         if (firstInclude?.Expression is not MemberAccessExpressionSyntax memberAccess) return document;
 
@@ -70,6 +78,25 @@ public class CartesianExplosionFixer : CodeFixProvider
         editor.ReplaceNode(source, asSplitQueryInvocation.WithTriviaFrom(source));
 
         return editor.GetChangedDocument();
+    }
+
+    private static InvocationExpressionSyntax? FindEffectiveAsSingleQueryInvocation(InvocationExpressionSyntax invocation)
+    {
+        ExpressionSyntax? current = invocation;
+
+        while (current is InvocationExpressionSyntax currentInvocation &&
+               currentInvocation.Expression is MemberAccessExpressionSyntax currentMemberAccess)
+        {
+            if (currentMemberAccess.Name.Identifier.Text == "AsSingleQuery")
+                return currentInvocation;
+
+            if (currentMemberAccess.Name.Identifier.Text == "AsSplitQuery")
+                return null;
+
+            current = currentMemberAccess.Expression;
+        }
+
+        return null;
     }
 
     private static InvocationExpressionSyntax? FindFirstIncludeInvocation(InvocationExpressionSyntax invocation)

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionNavigationAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionNavigationAnalysis.cs
@@ -1,37 +1,204 @@
+using System.Collections.Immutable;
+using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace LinqContraband.Analyzers.LC006_CartesianExplosion;
 
 public sealed partial class CartesianExplosionAnalyzer
 {
-    private static bool TryGetIncludedNavigation(
-        InvocationExpressionSyntax invocationSyntax,
+    private static readonly ImmutableHashSet<string> FilteredIncludeMethods = ImmutableHashSet.Create(
+        System.StringComparer.Ordinal,
+        "Where",
+        "OrderBy",
+        "OrderByDescending",
+        "ThenBy",
+        "ThenByDescending",
+        "Skip",
+        "Take");
+
+    private static bool TryGetIncludePath(
+        IInvocationOperation invocation,
         SemanticModel semanticModel,
-        out string navigationName)
+        IncludePath? previousIncludePath,
+        out IncludePath includePath)
     {
-        navigationName = string.Empty;
-        if (invocationSyntax.ArgumentList.Arguments.Count == 0)
-            return false;
+        includePath = new IncludePath(ImmutableArray<NavigationSegment>.Empty);
 
-        var lambdaExpression = invocationSyntax.ArgumentList.Arguments[invocationSyntax.ArgumentList.Arguments.Count - 1].Expression;
-        var lambdaBody = lambdaExpression switch
+        if (invocation.TargetMethod.Name == "Include" &&
+            TryGetStringIncludePath(invocation, out includePath))
         {
-            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Body,
-            ParenthesizedLambdaExpressionSyntax parenthesizedLambda => parenthesizedLambda.Body,
-            _ => null
-        };
+            return true;
+        }
 
-        if (lambdaBody is not MemberAccessExpressionSyntax memberAccess)
+        if (!TryGetLambdaExpression(invocation, out var lambdaExpression))
             return false;
 
-        var propertySymbol = semanticModel.GetSymbolInfo(memberAccess).Symbol as IPropertySymbol;
-        var propertyType = propertySymbol?.Type ?? semanticModel.GetTypeInfo(memberAccess).Type;
-        if (propertyType == null || !IsCollection(propertyType))
+        if (!TryGetNavigationPath(lambdaExpression.Body, semanticModel, out var lambdaPath))
             return false;
 
-        navigationName = memberAccess.Name.Identifier.Text;
+        if (invocation.TargetMethod.Name == "ThenInclude")
+        {
+            if (previousIncludePath == null)
+                return false;
+
+            includePath = previousIncludePath.Append(lambdaPath);
+            return true;
+        }
+
+        includePath = lambdaPath;
         return true;
+    }
+
+    private static bool TryGetStringIncludePath(IInvocationOperation invocation, out IncludePath includePath)
+    {
+        includePath = new IncludePath(ImmutableArray<NavigationSegment>.Empty);
+        if (invocation.Arguments.Length == 0)
+            return false;
+
+        var value = invocation.Arguments[invocation.Arguments.Length - 1].Value;
+        if (!value.ConstantValue.HasValue || value.ConstantValue.Value is not string pathText)
+            return false;
+
+        if (string.IsNullOrWhiteSpace(pathText))
+            return false;
+
+        var receiverType = invocation.GetInvocationReceiverType();
+        if (!TryGetQueryableElementType(receiverType, out var currentType))
+            return false;
+
+        var builder = ImmutableArray.CreateBuilder<NavigationSegment>();
+        foreach (var rawSegment in pathText.Split('.'))
+        {
+            var segmentName = rawSegment.Trim();
+            if (segmentName.Length == 0)
+                return false;
+
+            var property = TryFindProperty(currentType, segmentName);
+            if (property == null)
+                return false;
+
+            var propertyType = property.Type;
+            var isCollection = IsCollection(propertyType);
+            builder.Add(new NavigationSegment(property.Name, isCollection));
+
+            if (isCollection)
+            {
+                if (!TryGetCollectionElementType(propertyType, out currentType))
+                    return false;
+            }
+            else
+            {
+                currentType = propertyType;
+            }
+        }
+
+        includePath = new IncludePath(builder.ToImmutable());
+        return true;
+    }
+
+    private static bool TryGetLambdaExpression(
+        IInvocationOperation invocation,
+        out LambdaExpressionSyntax lambdaExpression)
+    {
+        lambdaExpression = null!;
+        if (invocation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
+            invocationSyntax.ArgumentList.Arguments.Count == 0)
+        {
+            return false;
+        }
+
+        var expression = invocationSyntax.ArgumentList.Arguments[invocationSyntax.ArgumentList.Arguments.Count - 1].Expression;
+        if (expression is LambdaExpressionSyntax lambda)
+        {
+            lambdaExpression = lambda;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetNavigationPath(
+        CSharpSyntaxNode body,
+        SemanticModel semanticModel,
+        out IncludePath includePath)
+    {
+        includePath = new IncludePath(ImmutableArray<NavigationSegment>.Empty);
+        var builder = ImmutableArray.CreateBuilder<NavigationSegment>();
+
+        if (!TryAddNavigationSegments(body, semanticModel, builder))
+            return false;
+
+        includePath = new IncludePath(builder.ToImmutable());
+        return includePath.Segments.Length > 0;
+    }
+
+    private static bool TryAddNavigationSegments(
+        CSharpSyntaxNode expression,
+        SemanticModel semanticModel,
+        ImmutableArray<NavigationSegment>.Builder builder)
+    {
+        expression = UnwrapExpression(expression);
+
+        if (expression is InvocationExpressionSyntax invocation &&
+            invocation.Expression is MemberAccessExpressionSyntax invocationMemberAccess &&
+            FilteredIncludeMethods.Contains(invocationMemberAccess.Name.Identifier.Text))
+        {
+            return TryAddNavigationSegments(invocationMemberAccess.Expression, semanticModel, builder);
+        }
+
+        if (expression is not MemberAccessExpressionSyntax memberAccess)
+            return false;
+
+        if (memberAccess.Expression is MemberAccessExpressionSyntax parentMemberAccess)
+        {
+            if (!TryAddNavigationSegments(parentMemberAccess, semanticModel, builder))
+                return false;
+        }
+
+        var property = semanticModel.GetSymbolInfo(memberAccess).Symbol as IPropertySymbol;
+        if (property == null)
+            return false;
+
+        builder.Add(new NavigationSegment(property.Name, IsCollection(property.Type)));
+        return true;
+    }
+
+    private static CSharpSyntaxNode UnwrapExpression(CSharpSyntaxNode expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    expression = parenthesized.Expression;
+                    continue;
+                case CastExpressionSyntax cast:
+                    expression = cast.Expression;
+                    continue;
+                case PostfixUnaryExpressionSyntax postfix when postfix.Kind() == Microsoft.CodeAnalysis.CSharp.SyntaxKind.SuppressNullableWarningExpression:
+                    expression = postfix.Operand;
+                    continue;
+                default:
+                    return expression;
+            }
+        }
+    }
+
+    private static IPropertySymbol? TryFindProperty(ITypeSymbol type, string name)
+    {
+        for (var current = type; current != null; current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers(name))
+            {
+                if (member is IPropertySymbol property)
+                    return property;
+            }
+        }
+
+        return null;
     }
 
     private static bool IsCollection(ITypeSymbol type)
@@ -41,25 +208,68 @@ public sealed partial class CartesianExplosionAnalyzer
         if (type.TypeKind == TypeKind.Array)
             return true;
 
-        if (type is INamedTypeSymbol namedType)
-        {
-            var ns = namedType.ContainingNamespace?.ToString();
-            if (ns == "System.Collections.Generic" && namedType.IsGenericType)
-            {
-                return namedType.Name is "List" or "IList" or "IEnumerable" or "ICollection"
-                    or "HashSet" or "ISet" or "IReadOnlyList" or "IReadOnlyCollection";
-            }
-        }
+        return TryGetCollectionElementType(type, out _);
+    }
+
+    private static bool TryGetQueryableElementType(ITypeSymbol? type, out ITypeSymbol elementType)
+    {
+        elementType = null!;
+        if (type == null)
+            return false;
+
+        if (TryGetNamedGenericElementType(type, "IQueryable", "System.Linq", out elementType))
+            return true;
 
         foreach (var iface in type.AllInterfaces)
         {
-            if (iface.Name == "IEnumerable" && iface.IsGenericType &&
-                iface.ContainingNamespace?.ToString() == "System.Collections.Generic")
-            {
+            if (TryGetNamedGenericElementType(iface, "IQueryable", "System.Linq", out elementType))
                 return true;
-            }
         }
 
         return false;
+    }
+
+    private static bool TryGetCollectionElementType(ITypeSymbol type, out ITypeSymbol elementType)
+    {
+        elementType = null!;
+        if (type.SpecialType == SpecialType.System_String)
+            return false;
+
+        if (type is IArrayTypeSymbol arrayType)
+        {
+            elementType = arrayType.ElementType;
+            return true;
+        }
+
+        if (TryGetNamedGenericElementType(type, "IEnumerable", "System.Collections.Generic", out elementType))
+            return true;
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (TryGetNamedGenericElementType(iface, "IEnumerable", "System.Collections.Generic", out elementType))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetNamedGenericElementType(
+        ITypeSymbol type,
+        string typeName,
+        string namespaceName,
+        out ITypeSymbol elementType)
+    {
+        elementType = null!;
+        if (type is not INamedTypeSymbol namedType ||
+            !namedType.IsGenericType ||
+            namedType.Name != typeName ||
+            namedType.ContainingNamespace?.ToString() != namespaceName ||
+            namedType.TypeArguments.Length != 1)
+        {
+            return false;
+        }
+
+        elementType = namedType.TypeArguments[0];
+        return true;
     }
 }

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.1</Version>
+        <Version>5.2.2</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC006_CartesianExplosion/CartesianExplosionFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC006_CartesianExplosion/CartesianExplosionFixerTests.cs
@@ -1,11 +1,7 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Testing;
 using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
     LinqContraband.Analyzers.LC006_CartesianExplosion.CartesianExplosionAnalyzer,
     LinqContraband.Analyzers.LC006_CartesianExplosion.CartesianExplosionFixer,
     Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
-using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
-    LinqContraband.Analyzers.LC006_CartesianExplosion.CartesianExplosionAnalyzer>;
 
 namespace LinqContraband.Tests.Analyzers.LC006_CartesianExplosion;
 
@@ -66,7 +62,12 @@ namespace TestNamespace
         public List<Role> Roles { get; set; }
     }
 
-    public class Order { public List<Item> Items { get; set; } }
+    public class Order
+    {
+        public int Id { get; set; }
+        public List<Item> Items { get; set; }
+    }
+
     public class Role { }
     public class Item { }
 
@@ -85,7 +86,7 @@ class Program
     void Main()
     {
         var db = new DbContext();
-        var query = db.Users.Include(u => u.Orders).Include(u => u.Roles).ToList();
+        var query = {|LC006:db.Users.Include(u => u.Orders).Include(u => u.Roles)|}.ToList();
     }
 }
 " + MockNamespace;
@@ -107,11 +108,6 @@ class Program
             FixedCode = fixedCode
         };
 
-        // The diagnostic is on the second Include. Line 14 in this file structure.
-        testObj.ExpectedDiagnostics.Add(new DiagnosticResult("LC006", DiagnosticSeverity.Warning)
-            .WithSpan(14, 21, 14, 74)
-            .WithArguments("Roles"));
-
         await testObj.RunAsync();
     }
 
@@ -124,7 +120,7 @@ class Program
     void Main()
     {
         var db = new DbContext();
-        var query = db.Users.Where(u => u.Id > 0).Include(u => u.Orders).Include(u => u.Roles).ToList();
+        var query = {|LC006:db.Users.Where(u => u.Id > 0).Include(u => u.Orders).Include(u => u.Roles)|}.ToList();
     }
 }
 " + MockNamespace;
@@ -146,15 +142,11 @@ class Program
             FixedCode = fixedCode
         };
 
-        testObj.ExpectedDiagnostics.Add(new DiagnosticResult("LC006", DiagnosticSeverity.Warning)
-            .WithSpan(14, 21, 14, 95)
-            .WithArguments("Roles"));
-
         await testObj.RunAsync();
     }
 
     [Fact]
-    public async Task AnalyzerIgnoresStringIncludeChains()
+    public async Task FixCrime_WithFinalAsSingleQuery_ReplacesWithAsSplitQuery()
     {
         var test = Usings + @"
 class Program
@@ -162,11 +154,96 @@ class Program
     void Main()
     {
         var db = new DbContext();
-        var query = db.Users.Include(""Orders"").Include(""Roles"").ToList();
+        var query = {|LC006:db.Users.AsSplitQuery().Include(u => u.Orders).Include(u => u.Roles).AsSingleQuery()|}.ToList();
     }
 }
 " + MockNamespace;
 
-        await VerifyCS.VerifyAnalyzerAsync(test);
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.AsSplitQuery().Include(u => u.Orders).Include(u => u.Roles).AsSplitQuery().ToList();
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixCrime_StringIncludeChain_InjectsAsSplitQuery()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = {|LC006:db.Users.Include(""Orders"").Include(""Roles"")|}.ToList();
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.AsSplitQuery().Include(""Orders"").Include(""Roles"").ToList();
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixCrime_FilteredIncludeChain_InjectsAsSplitQuery()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = {|LC006:db.Users.Include(u => u.Orders.Where(o => o.Id > 0).OrderBy(o => o.Id)).Include(u => u.Roles)|}.ToList();
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.AsSplitQuery().Include(u => u.Orders.Where(o => o.Id > 0).OrderBy(o => o.Id)).Include(u => u.Roles).ToList();
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        await testObj.RunAsync();
     }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC006_CartesianExplosion/CartesianExplosionTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC006_CartesianExplosion/CartesianExplosionTests.cs
@@ -26,6 +26,11 @@ namespace Microsoft.EntityFrameworkCore
 
     public static class EntityFrameworkQueryableExtensions
     {
+        public static IQueryable<TEntity> Include<TEntity>(
+            this IQueryable<TEntity> source,
+            string navigationPropertyPath)
+            => source;
+
         public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TProperty>(
             this IQueryable<TEntity> source, 
             System.Linq.Expressions.Expression<Func<TEntity, TProperty>> navigationPropertyPath) 
@@ -53,6 +58,7 @@ namespace TestNamespace
         public int Id { get; set; }
         public List<Order> Orders { get; set; }
         public List<Role> Roles { get; set; }
+        public HashSet<Tag> Tags { get; set; }
         public Address Address { get; set; }
     }
 
@@ -60,11 +66,15 @@ namespace TestNamespace
     {
         public int Id { get; set; }
         public List<Item> Items { get; set; }
+        public ICollection<Comment> Comments { get; set; }
+        public ICollection<Tag> Tags { get; set; }
     }
 
     public class Role { }
     public class Address { }
     public class Item { }
+    public class Comment { }
+    public class Tag { }
 
     public class DbContext
     {
@@ -87,12 +97,9 @@ class Program
 }
 " + MockNamespace;
 
-        // The diagnostic spans the entire chain up to the second Include.
-        // Line 15 starts with `var query = ...`
-        // The usage `db.Users...` starts at column 21.
         var expected = VerifyCS.Diagnostic("LC006")
             .WithSpan(15, 21, 15, 74)
-            .WithArguments("Roles");
+            .WithArguments("Orders', 'Roles");
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
@@ -184,8 +191,156 @@ class Program
 
         var expected = VerifyCS.Diagnostic("LC006")
             .WithSpan(14, 21, 14, 90)
-            .WithArguments("Roles");
+            .WithArguments("Orders', 'Roles");
 
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_FinalAsSingleQueryAfterAsSplitQuery_StillTriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.AsSplitQuery().Include(u => u.Orders).Include(u => u.Roles).AsSingleQuery().ToList();
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC006")
+            .WithSpan(14, 21, 14, 105)
+            .WithArguments("Orders', 'Roles");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_ThreeCollectionIncludes_ReportsOnlyOnce()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Include(u => u.Orders).Include(u => u.Roles).Include(u => u.Tags).ToList();
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC006")
+            .WithSpan(14, 21, 14, 95)
+            .WithArguments("Orders', 'Roles', 'Tags");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_NestedSiblingCollectionThenIncludes_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users
+            .Include(u => u.Orders)
+                .ThenInclude(o => o.Comments)
+            .Include(u => u.Orders)
+                .ThenInclude(o => o.Tags)
+            .ToList();
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC006")
+            .WithSpan(14, 21, 18, 42)
+            .WithArguments("Comments', 'Tags");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_FilteredSiblingCollectionIncludes_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users
+            .Include(u => u.Orders.Where(o => o.Id > 0).OrderBy(o => o.Id))
+            .Include(u => u.Roles)
+            .ToList();
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC006")
+            .WithSpan(14, 21, 16, 35)
+            .WithArguments("Orders', 'Roles");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_ResolvableStringIncludeSiblings_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Include(""Orders"").Include(""Roles"").ToList();
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC006")
+            .WithSpan(14, 21, 14, 64)
+            .WithArguments("Orders', 'Roles");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestInnocent_DuplicateCollectionInclude_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var query = db.Users.Include(u => u.Orders).Include(u => u.Orders).ToList();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_UnresolvableStringInclude_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var navigation = ""Orders"";
+        var query = db.Users.Include(navigation).Include(""Roles"").ToList();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 }

--- a/tests/LinqContraband.Tests/Architecture/CoverageBoostTests.cs
+++ b/tests/LinqContraband.Tests/Architecture/CoverageBoostTests.cs
@@ -86,7 +86,7 @@ class Program {
         // Corrected line: 59
         var expected = VerifyCS_LC006.Diagnostic("LC006")
             .WithSpan(59, 21, 59, 77)
-            .WithArguments("Tags");
+            .WithArguments("Roles', 'Tags");
 
         await VerifyCS_LC006.VerifyAnalyzerAsync(test, expected);
     }


### PR DESCRIPTION
## Summary
- Rework LC006 around EF query-chain navigation paths so it reports one diagnostic for distinct sibling collection includes.
- Add support for nested sibling `ThenInclude` collections, filtered includes, resolvable string include paths, duplicate include suppression, and final `AsSplitQuery()` / `AsSingleQuery()` ordering.
- Harden the fixer to insert `AsSplitQuery()` at the stable query root or replace an effective downstream `AsSingleQuery()`.
- Prepare patch release `5.2.2` with CHANGELOG, README, docs, sample, and package version updates.

## Impact
LC006 should be materially better for high-frequency use: fewer duplicate/noisy diagnostics, fewer false positives from duplicate or linear include chains, and more true positives for real sibling collection risks that were previously missed.

## Release
- Bumps `src/LinqContraband/LinqContraband.csproj` to `5.2.2`.
- Adds `CHANGELOG.md` release notes under `## [5.2.2] - 2026-04-24`.
- Publishing GitHub Release `v5.2.2` after merge should trigger `.github/workflows/publish.yml` and push the NuGet package.

## Validation
- `/opt/homebrew/bin/dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter "FullyQualifiedName~LC006_CartesianExplosion|FullyQualifiedName~CoverageBoostTests"` — 22 passed
- `/opt/homebrew/bin/dotnet test LinqContraband.sln --no-restore --framework net10.0` — 555 passed
- `git diff --check` — passed

## Notes
The repository default branch is `master`. The local machine only has the arm64 .NET 10 runtime installed, so unqualified multi-target test runs still abort locally for net8/net9 hosts; GitHub Actions supplies all target runtimes.