### PR TITLE
[codex] Harden analyzer health gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.3] - 2026-04-24
+
+### Changed
+- Hardened `LC018` `FromSqlRaw(...)` security analysis with named `sql:` argument handling, nested direct concatenation coverage, and LC037 boundary tests for alias-owned constructed SQL
+- Narrowed the `LC018` fixer so it only rewrites direct interpolated-string calls with no additional raw SQL parameters
+- Narrowed `LC012` to query-shaped `RemoveRange(...)` sources and guarded its fixer from materialized lists, arrays, tracked collections, and params-style entity arguments
+- Expanded `LC030` lifetime review coverage for singleton service/implementation registrations, configured long-lived base/interface types, and factory/scope-safe patterns
+- Added `LC035` coverage for async bulk execute calls, chained query filters, and simple filtered local query initializers
+- Hardened `LC043` so cancellation-token buffer calls and reused buffers are not rewritten to `await foreach`
+- Refreshed analyzer-health and per-rule docs to distinguish shipped behavior from remaining roadmap items
+
 ## [5.2.2] - 2026-04-24
 
 ### Changed

--- a/docs/LC012_OptimizeRemoveRange.md
+++ b/docs/LC012_OptimizeRemoveRange.md
@@ -8,8 +8,7 @@ Suggest using `ExecuteDelete()` instead of `RemoveRange()` for bulk deletions.
 
 ### Example Violation
 ```csharp
-var oldLogs = db.Logs.Where(l => l.Date < oneYearAgo).ToList();
-// Slow: Fetches all rows first
+var oldLogs = db.Logs.Where(l => l.Date < oneYearAgo);
 db.Logs.RemoveRange(oldLogs);
 ```
 
@@ -26,3 +25,6 @@ db.Logs.Where(l => l.Date < oneYearAgo).ExecuteDelete();
 ### ID: `LC012`
 ### Category: `Performance`
 ### Severity: `Warning`
+
+### Notes
+LC012 is conservative. It reports only when the `RemoveRange(...)` argument is still query-shaped (`IQueryable<T>`/`DbSet<T>`) so the fixer can safely rewrite that source to `ExecuteDelete()`. It stays quiet for materialized lists, arrays, tracked entity collections, and `params` entity arguments because `ExecuteDelete()` bypasses change tracking, client-side cascades, and in-memory state.

--- a/docs/LC015_MissingOrderBy.md
+++ b/docs/LC015_MissingOrderBy.md
@@ -30,47 +30,11 @@ var page2 = db.Users.OrderBy(u => u.Id).Skip(10).Take(10).ToList();
 ## Analyzer Logic
 
 ### ID: `LC015`
-### Category: `Correctness` (or `Reliability`)
-### Severity: `Warning` (or `Error`?)
+### Category: `Reliability`
+### Severity: `Warning`
 
-### Algorithm
-1.  **Target Methods**: Intercept invocations of:
-    -   `Skip`
-    -   `Last`
-    -   `LastOrDefault`
-    -   `Chunk` (NET 6+)
-    
-2.  **Type Check**: Verify the method is called on `IQueryable<T>`.
-    -   Ignore `IEnumerable<T>` (in-memory objects usually preserve order).
-
-3.  **Upstream Walk**: Walk up the invocation chain (the `Instance` or first argument for extensions) to find a sorting method.
-    -   **Found**: `OrderBy`, `OrderByDescending`, `ThenBy`, `ThenByDescending`.
-        -   **STOP**: Valid.
-    -   **Found**: `Skip`, `Take` (recursive check upstream).
-    -   **Found**: `Where`, `Select` (continue upstream).
-    -   **Found**: Source (e.g. `db.Users`).
-        -   **STOP**: **VIOLATION FOUND**.
-    
-    -   *Edge Case*: If the chain is broken (e.g. local variable assignment), try to resolve the variable definition and continue walking? 
-        -   *MVP*: Just walk the fluent chain. If variable usage, maybe ignore or simple check.
-
-### Corner Cases
-1.  **OrderedQueryable**: If the type is `IOrderedQueryable<T>`, we *might* assume it's sorted. However, `IQueryable<T>` interface doesn't enforce it.
-    -   Actually, `OrderBy` returns `IOrderedQueryable<T>`. `Where` returns `IQueryable<T>`.
-    -   If we call `Where` after `OrderBy`, the type reverts to `IQueryable<T>` (in some definitions) or stays `IQueryable`.
-    -   *Better approach*: Inspect the Operation tree (invocation chain) rather than static types, because `Where` preserves order but hides the `IOrderedQueryable` type sometimes.
-
-2.  **Preserved Order**:
-    -   `Where`, `Select` (projection might not preserve order if it's complex? No, SQL `SELECT ... WHERE` preserves `ORDER BY` if applied *after*?).
-    -   Actually, in SQL: `SELECT * FROM (SELECT * FROM Users ORDER BY Id) WHERE Age > 10`. The order is *usually* preserved but technically the outer query needs an ORDER BY for guarantees?
-    -   EF Core typically generates: `SELECT ... FROM ... WHERE ... ORDER BY ... OFFSET ... FETCH ...`.
-    -   The `OrderBy` must be present in the LINQ expression tree sent to EF.
-    
-    So, checking if `OrderBy` exists *anywhere* in the chain upstream is sufficient?
-    -   Wait: `db.Users.OrderBy(x => x.Id).Skip(10)` -> Valid.
-    -   `db.Users.Skip(10).OrderBy(x => x.Id)` -> **INVALID**. Skip happens *before* OrderBy (logically impossible in LINQ usually, but if written, it means "Skip arbitrary 10, THEN sort the rest").
-    
-    **Refined Rule**: The `OrderBy` call must appear **before** (i.e., as a child/descendant node in the expression tree, or "to the left" in fluent syntax) the `Skip`/`Last` call.
+### Notes
+LC015 checks `IQueryable<T>` chains where pagination or "last row" operators depend on a deterministic order. The order must be established upstream of the reported operator; an `OrderBy` after `Skip` or `Take` still leaves the page selection nondeterministic.
 
 ## Test Cases
 
@@ -89,9 +53,3 @@ db.Users.OrderByDescending(x => x.Date).Last();
 db.Users.OrderBy(x => x.Id).Where(x => x.Active).Skip(10); // Valid, order preserved through Where
 db.Users.OrderBy(x => x.Id).Select(x => x.Name).Skip(10); // Valid
 ```
-
-## Implementation Plan
-1.  Create `LC015_MissingOrderBy` directory.
-2.  Implement `MissingOrderByAnalyzer`.
-3.  Implement tests covering fluent chains and mixed operators (`Where`, `Select`).
-

--- a/docs/LC018_AvoidFromSqlRawWithInterpolation.md
+++ b/docs/LC018_AvoidFromSqlRawWithInterpolation.md
@@ -28,17 +28,8 @@ var users = db.Users.FromSqlInterpolated($"SELECT * FROM Users WHERE Name = {nam
 ### Category: `Security`
 ### Severity: `Warning`
 
-### Algorithm
-1.  **Target Method**: Intercept invocations of `FromSqlRaw`.
-2.  **Type Check**: Ensure the method is the EF Core extension method for `IQueryable` or `DbSet`.
-3.  **Argument Analysis**: Inspect the first argument (the SQL string).
-    -   If it's an **interpolated string** (`$""`): **VIOLATION**.
-    -   If it's a **string concatenation** (`+`):
-        -   Check if all parts are constant strings.
-        -   If any part is a variable or non-constant: **VIOLATION**.
-
-### Exceptions
--   If the interpolated string contains *only* constant values (though this is rare and usually better handled as a simple string).
+### Notes
+LC018 reports direct interpolated strings and direct non-constant string concatenations passed to the `sql` argument of `FromSqlRaw(...)`, including named `sql:` arguments. The fixer is intentionally narrow: it is offered only for direct interpolated-string calls with no additional raw SQL parameters, where changing the method name to `FromSqlInterpolated` preserves the argument flow.
 
 ## Test Cases
 
@@ -61,9 +52,3 @@ db.Users.FromSqlInterpolated($"SELECT * FROM Users WHERE Id = {id}");
 ## Rule Boundary
 - LC018 owns direct interpolated-string and direct non-constant `+` concatenation passed straight into `FromSqlRaw(...)`.
 - LC037 covers broader constructed-SQL flows such as local aliases, `string.Format(...)`, `string.Concat(...)`, and `StringBuilder`.
-
-## Implementation Plan
-1.  Create `LC018_AvoidFromSqlRawWithInterpolation` directory.
-2.  Implement `AvoidFromSqlRawWithInterpolationAnalyzer`.
-3.  Implement `AvoidFromSqlRawWithInterpolationFixer`.
-4.  Implement tests.

--- a/docs/LC030_DbContextInSingleton.md
+++ b/docs/LC030_DbContextInSingleton.md
@@ -59,6 +59,9 @@ public class MyService
     -   `dotnet_code_quality.LC030.detection_mode = expanded` enables conservative name-based review hints such as `*Singleton*`, `*HostedService`, and `*BackgroundWorker`.
     -   `dotnet_code_quality.LC030.long_lived_types = MyApp.IAlwaysSingleton;MyApp.LongLivedBase` treats matching base types or interfaces as long-lived.
 
+### Notes
+LC030 is intentionally manual-only. It does not provide a code fix because the correct change may be `IDbContextFactory<TContext>`, creating a scope through `IServiceScopeFactory`, changing registration lifetimes, or moving work into a scoped collaborator.
+
 ## Test Cases
 
 ### Violations

--- a/docs/LC035_MissingWhereBeforeExecuteDeleteUpdate.md
+++ b/docs/LC035_MissingWhereBeforeExecuteDeleteUpdate.md
@@ -26,4 +26,4 @@ db.Users.Where(u => u.Age < 18).ExecuteDelete();
 ### Severity: `Info`
 
 ### Notes
-This rule is advisory only. There is no automatic fixer because adding a predicate speculatively would be unsafe.
+This rule is advisory only. There is no automatic fixer because adding a predicate speculatively would be unsafe. LC035 recognizes filters in the direct fluent chain and in simple local query initializers such as `var filtered = db.Users.Where(...); filtered.ExecuteDelete();`.

--- a/docs/LC043_AsyncEnumerableBuffering.md
+++ b/docs/LC043_AsyncEnumerableBuffering.md
@@ -32,4 +32,4 @@ await foreach (var user in stream)
 ### Severity: `Info`
 
 ### Notes
-This v1 rule is intentionally narrow. It reports only immediate buffer-then-loop patterns that are safe to rewrite to `await foreach`.
+This v1 rule is intentionally narrow. It reports only immediate buffer-then-loop patterns that are safe to rewrite to `await foreach`. Calls with buffer-method arguments, such as cancellation tokens, are left alone so the fixer does not drop behavior.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -32,13 +32,13 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC009 | Missing AsNoTracking in read-only path | Change Tracking & Context Lifetime | Info | 4 | 4 | 4 | 4 | 4 | 3 | Low | Good write-detection coverage; low severity makes this a tuning rule, not a top priority. |
 | LC010 | SaveChanges inside loop | Change Tracking & Context Lifetime | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | High-value write-side N+1 rule; current fixer guidance appears sufficient. |
 | LC011 | Entity missing primary key | Schema & Modeling | Warning | 5 | 5 | 4 | 5 | 4 | 4 | Low | Strong convention/configuration handling and broad edge-case tests. |
-| LC012 | Use ExecuteDelete instead of RemoveRange | Bulk Operations & Set-Based Writes | Warning | 3 | 3 | 3 | 3 | 4 | 4 | Medium | Useful but semantically delicate; add more negative tests around cascades, tracked entities, and provider/version limits. |
+| LC012 | Use ExecuteDelete instead of RemoveRange | Bulk Operations & Set-Based Writes | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Narrowed to query-shaped sources with materialized-list and params-array guardrails; revisit provider/version capability only if configurable EF targeting is added. |
 | LC013 | Disposed context query | Change Tracking & Context Lifetime | Warning | 5 | 5 | 5 | 5 | 4 | 5 | Low | Excellent manual-only candidate with strong lifetime edge-case coverage. |
 | LC014 | Avoid string case conversion in queries | Query Shape & Translation | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Healthy rule; future work is provider/collation nuance rather than core correctness. |
-| LC015 | Missing OrderBy before pagination | Query Shape & Translation | Warning | 4 | 4 | 4 | 4 | 3 | 5 | Medium | High-value reliability rule; docs contain implementation-note residue and should be tightened. |
+| LC015 | Missing OrderBy before pagination | Query Shape & Translation | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | High-value reliability rule with docs now focused on shipped behavior rather than implementation-planning notes. |
 | LC016 | Avoid DateTime.Now/UtcNow in queries | Query Shape & Translation | Warning | 5 | 5 | 4 | 5 | 4 | 3 | Low | Well-tested rule; importance is moderate because impact is usually cacheability/testability. |
 | LC017 | Whole entity projection | Materialization & Projection | Info | 5 | 5 | 5 | 5 | 4 | 4 | Low | Very strong edge-case coverage for a heuristic Info rule. |
-| LC018 | FromSqlRaw with interpolated strings | Raw SQL & Security | Warning | 4 | 4 | 3 | 3 | 4 | 5 | High | Security-important; add explicit fixer tests and more constructed-SQL negative/positive cases. |
+| LC018 | FromSqlRaw with interpolated strings | Raw SQL & Security | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Brought closer to LC034 parity with named SQL argument handling, nested concatenation coverage, alias boundary tests, and narrow fixer guardrails. |
 | LC019 | Conditional Include expression | Loading & Includes | Warning | 4 | 4 | 5 | 3 | 4 | 5 | Medium | Manual-only rationale is sound; add more Include/ThenInclude shape and non-EF negative tests. |
 | LC020 | Untranslatable string comparison overloads | Query Shape & Translation | Warning | 4 | 4 | 3 | 3 | 4 | 4 | Medium | Add explicit fixer tests and provider translation edge cases. |
 | LC021 | IgnoreQueryFilters usage | Raw SQL & Security | Warning | 4 | 3 | 4 | 3 | 4 | 4 | Medium | Intentional bypasses can be valid; consider suppression/allow-list guidance and more negative tests. |
@@ -50,12 +50,12 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC027 | Missing explicit foreign key property | Schema & Modeling | Info | 4 | 4 | 3 | 4 | 4 | 3 | Medium | Design guidance is useful; add fixer tests and more model-configuration negative cases. |
 | LC028 | Deep ThenInclude chain | Loading & Includes | Warning | 3 | 3 | 5 | 3 | 4 | 3 | Medium | Heuristic rule; manual-only is right, but thresholds and false-positive guidance need more tests. |
 | LC029 | Redundant identity Select | Materialization & Projection | Info | 5 | 5 | 5 | 3 | 4 | 2 | Low | Simple, safe cleanup rule; low importance but healthy implementation. |
-| LC030 | DbContext lifetime mismatch | Change Tracking & Context Lifetime | Info | 3 | 3 | 3 | 3 | 4 | 4 | High | Important architecture smell; fixer surface is complex and needs broader DI/lifetime tests. |
+| LC030 | DbContext lifetime mismatch | Change Tracking & Context Lifetime | Info | 4 | 4 | 5 | 4 | 5 | 4 | Low | Broadened DI lifetime coverage across generic/type singleton registrations, configured base/interface types, and factory/scope-safe patterns; manual-only rationale is explicit. |
 | LC031 | Unbounded query materialization | Materialization & Projection | Info | 3 | 3 | 5 | 3 | 4 | 4 | Medium | Valuable but heuristic; expand safe opt-out, Take/Where ordering, and intentional full-scan coverage. |
 | LC032 | ExecuteUpdate for bulk scalar updates | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 5 | 4 | 4 | 4 | Low | Conservative manual-only rule with solid analysis split; revisit fixer only after more semantics are modeled. |
 | LC033 | Use FrozenSet for static membership caches | Materialization & Projection | Info | 5 | 5 | 5 | 4 | 4 | 2 | Low | Strong implementation for a niche optimization; not a planning priority. |
 | LC034 | ExecuteSqlRaw with interpolated strings | Raw SQL & Security | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Hardened to reference quality with parameter-aware SQL argument resolution, narrow safe fixer behavior, raw-parameter guardrails, LC037 boundary coverage, and aligned docs/sample guidance. |
-| LC035 | Missing Where before bulk execute | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 5 | 3 | 4 | 5 | Medium | Safety impact is high; add more ExecuteDelete/ExecuteUpdate chain and intentional full-table operation tests. |
+| LC035 | Missing Where before bulk execute | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 5 | 4 | 4 | 5 | Low | Added async, chained-query, and simple filtered-local coverage while keeping the rule advisory and manual-only. |
 | LC036 | DbContext captured by thread work item | Execution & Async | Warning | 4 | 4 | 5 | 3 | 4 | 5 | Medium | Important safety rule; add coverage for more task/parallel APIs and safe factory/scope patterns. |
 | LC037 | Constructed raw SQL strings | Raw SQL & Security | Warning | 5 | 5 | 5 | 5 | 4 | 5 | Low | Strong manual-only security rule with broad string-construction coverage. |
 | LC038 | Excessive eager loading | Loading & Includes | Info | 3 | 3 | 5 | 3 | 4 | 3 | Medium | Heuristic rule; add threshold documentation and more examples of legitimate deep loads. |
@@ -63,7 +63,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC040 | Mixed tracking and no-tracking modes | Change Tracking & Context Lifetime | Info | 4 | 4 | 5 | 3 | 4 | 4 | Medium | Manual-only is appropriate; add broader context-resolution and split-workflow tests. |
 | LC041 | Single entity over-fetches one consumed property | Materialization & Projection | Info | 4 | 4 | 3 | 3 | 4 | 3 | Medium | Useful but subtle; add explicit fixer tests and more multi-use/side-effect negative cases. |
 | LC042 | Complex query should be tagged | Loading & Includes | Info | 3 | 3 | 5 | 3 | 4 | 2 | Low | Team-policy rule; low importance unless observability standards require tags. |
-| LC043 | Prefer await foreach over buffering async streams | Execution & Async | Info | 3 | 3 | 3 | 3 | 4 | 3 | Medium | Add fixer tests and more cases around multiple enumeration, ordering, and list reuse. |
+| LC043 | Prefer await foreach over buffering async streams | Execution & Async | Info | 4 | 4 | 4 | 4 | 4 | 3 | Low | Hardened narrow fixer behavior around cancellation-token arguments and reused buffers. |
 | LC044 | AsNoTracking entity mutated then SaveChanges | Change Tracking & Context Lifetime | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Excellent high-impact data-loss rule with strong edge-case coverage and clear manual guidance. |
 
 ## Planning Shortlist
@@ -72,16 +72,14 @@ The next improvement batch should focus on rules that combine high importance wi
 
 | Priority | Rules | Work |
 | --- | --- | --- |
-| High | LC018 | Add explicit security fixer tests and bring query raw-SQL coverage up to LC034 parity. |
-| High | LC030 | Broaden DI lifetime and fixer tests; validate safe patterns using factories/scopes. |
-| Medium | LC012, LC023, LC025, LC026, LC027, LC041, LC043 | Add missing or thin fixer test coverage before relying on these fixes heavily. |
-| Medium | LC019, LC024, LC028, LC031, LC035, LC036, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
-| Low | LC002, LC003, LC007, LC013, LC017, LC034, LC037, LC044 | Treat as reference-quality examples for future analyzer work. |
+| Medium | LC023, LC025, LC026, LC027, LC041 | Expand existing fixer coverage for schema-sensitive and subtle projection/tracking rewrites. |
+| Medium | LC019, LC024, LC028, LC031, LC036, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
+| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC030, LC034, LC035, LC037, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
 
 ## Verification Baseline
 
 `dotnet restore LinqContraband.sln` completed successfully.
 
-`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 522 passing tests.
+`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 574 passing tests.
 
-`dotnet test LinqContraband.sln --no-restore` currently builds and runs the `net10.0` test target successfully with 522 passing tests. The `net8.0` and `net9.0` test hosts abort in this local environment because arm64 .NET 8 and .NET 9 runtimes are not installed; no test failures were reported before those host aborts.
+`dotnet --list-runtimes` currently shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -58,7 +59,15 @@ public sealed class OptimizeRemoveRangeAnalyzer : DiagnosticAnalyzer
         var type = method.ContainingType;
         if (!type.IsDbSet() && !type.IsDbContext()) return;
 
-        context.ReportDiagnostic(
-            Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), method.Name));
+        if (!HasQueryableDeleteSource(invocation))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), method.Name));
+    }
+
+    private static bool HasQueryableDeleteSource(IInvocationOperation invocation)
+    {
+        var deleteSource = invocation.Arguments.FirstOrDefault()?.Value.UnwrapConversions();
+        return deleteSource?.Type.IsIQueryable() == true || deleteSource?.Type.IsDbSet() == true;
     }
 }

--- a/src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC012_OptimizeRemoveRange/OptimizeRemoveRangeFixer.cs
+++ b/src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC012_OptimizeRemoveRange/OptimizeRemoveRangeFixer.cs
@@ -3,6 +3,7 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -38,6 +39,9 @@ public class OptimizeRemoveRangeFixer : CodeFixProvider
         var invocation = token.Parent.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
         if (invocation == null) return;
 
+        if (!await CanSafelyRewriteAsync(context.Document, invocation, context.CancellationToken).ConfigureAwait(false))
+            return;
+
         context.RegisterCodeFix(
             CodeAction.Create(
                 "Use ExecuteDelete()",
@@ -46,7 +50,7 @@ public class OptimizeRemoveRangeFixer : CodeFixProvider
             diagnostic);
     }
 
-    private async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+    private static async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
@@ -68,5 +72,21 @@ public class OptimizeRemoveRangeFixer : CodeFixProvider
         }
 
         return editor.GetChangedDocument();
+    }
+
+    private static async Task<bool> CanSafelyRewriteAsync(
+        Document document,
+        InvocationExpressionSyntax invocation,
+        CancellationToken cancellationToken)
+    {
+        if (invocation.ArgumentList.Arguments.Count != 1)
+            return false;
+
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel == null)
+            return false;
+
+        var sourceType = semanticModel.GetTypeInfo(invocation.ArgumentList.Arguments[0].Expression, cancellationToken).Type;
+        return sourceType.IsIQueryable() || sourceType.IsDbSet();
     }
 }

--- a/src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateAnalyzer.cs
@@ -1,6 +1,8 @@
 using System.Collections.Immutable;
+using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -82,13 +84,58 @@ public sealed class MissingWhereBeforeExecuteDeleteUpdateAnalyzer : DiagnosticAn
                 continue;
             }
 
-            if (current is ILocalReferenceOperation or IParameterReferenceOperation or IFieldReferenceOperation or IPropertyReferenceOperation)
+            if (current is ILocalReferenceOperation localReference)
+                return HasWhereInLocalInitializer(localReference.Local);
+
+            if (current is IParameterReferenceOperation or IFieldReferenceOperation or IPropertyReferenceOperation)
                 return false;
 
             if (current.Type.IsDbSet() || current.Type.IsIQueryable())
                 return false;
 
             current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private static bool HasWhereInLocalInitializer(ILocalSymbol local)
+    {
+        var syntaxReference = local.DeclaringSyntaxReferences.FirstOrDefault();
+        if (syntaxReference?.GetSyntax() is not VariableDeclaratorSyntax declarator)
+            return false;
+
+        return declarator.Initializer?.Value != null && HasWhereInSyntaxChain(declarator.Initializer.Value);
+    }
+
+    private static bool HasWhereInSyntaxChain(ExpressionSyntax expression)
+    {
+        var current = expression;
+        while (current != null)
+        {
+            if (current is InvocationExpressionSyntax invocation &&
+                invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+            {
+                if (memberAccess.Name.Identifier.ValueText == "Where")
+                    return true;
+
+                current = memberAccess.Expression;
+                continue;
+            }
+
+            if (current is MemberAccessExpressionSyntax bareMemberAccess)
+            {
+                current = bareMemberAccess.Expression;
+                continue;
+            }
+
+            if (current is ParenthesizedExpressionSyntax parenthesized)
+            {
+                current = parenthesized.Expression;
+                continue;
+            }
+
+            break;
         }
 
         return false;

--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC043_AsyncEnumerableBuffering/AsyncEnumerableBufferingAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC043_AsyncEnumerableBuffering/AsyncEnumerableBufferingAnalyzer.cs
@@ -119,6 +119,9 @@ public sealed class AsyncEnumerableBufferingAnalyzer : DiagnosticAnalyzer
         if (invocationSyntax.Expression is not MemberAccessExpressionSyntax memberAccess)
             return false;
 
+        if (invocationSyntax.ArgumentList.Arguments.Count != 0)
+            return false;
+
         if (!BufferMethods.Contains(memberAccess.Name.Identifier.ValueText))
             return false;
 

--- a/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC018_AvoidFromSqlRawWithInterpolation/AvoidFromSqlRawWithInterpolationAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC018_AvoidFromSqlRawWithInterpolation/AvoidFromSqlRawWithInterpolationAnalyzer.cs
@@ -45,18 +45,7 @@ public sealed class AvoidFromSqlRawWithInterpolationAnalyzer : DiagnosticAnalyze
         // Verify it's an EF Core method
         if (!IsEfCoreMethod(method)) return;
 
-        // Find the 'sql' parameter index
-        var sqlParameterIndex = method.Parameters.ToList().FindIndex(p => p.Name == "sql");
-        if (sqlParameterIndex < 0) return;
-
-        // For extension methods called with instance syntax, the 'this' parameter is the first argument
-        // but it is NOT included in the 'Parameters' list of the method if we look at it from the perspective of the call?
-        // Actually, IInvocationOperation.Arguments aligns with Method.Parameters for extension methods too
-        // IF it's an extension method call.
-
-        if (sqlParameterIndex >= invocation.Arguments.Length) return;
-
-        var sqlArgument = invocation.Arguments[sqlParameterIndex].Value;
+        var sqlArgument = invocation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == "sql")?.Value;
 
         if (sqlArgument != null && IsPotentiallyUnsafe(sqlArgument))
         {

--- a/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC018_AvoidFromSqlRawWithInterpolation/AvoidFromSqlRawWithInterpolationFixer.cs
+++ b/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC018_AvoidFromSqlRawWithInterpolation/AvoidFromSqlRawWithInterpolationFixer.cs
@@ -38,36 +38,40 @@ public class AvoidFromSqlRawWithInterpolationFixer : CodeFixProvider
         var invocation = token.Parent.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
         if (invocation == null) return;
 
-        // Ensure it's actually FromSqlRaw
-        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-            memberAccess.Name.Identifier.Text == "FromSqlRaw")
-        {
-            // Only offer fix if the first argument is an interpolated string.
-            // (Concatenations are harder to fix automatically)
-            var firstArg = invocation.ArgumentList.Arguments.FirstOrDefault();
-            if (firstArg?.Expression is InterpolatedStringExpressionSyntax)
-            {
-                context.RegisterCodeFix(
-                    CodeAction.Create(
-                        "Replace with FromSqlInterpolated",
-                        c => ApplyFixAsync(context.Document, invocation, c),
-                        "ReplaceFromSqlRawWithInterpolated"),
-                    diagnostic);
-            }
-        }
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess ||
+            memberAccess.Name.Identifier.Text != "FromSqlRaw")
+            return;
+
+        var sqlArgument = GetSqlArgument(invocation);
+        if (sqlArgument?.Expression is not InterpolatedStringExpressionSyntax)
+            return;
+
+        if (invocation.ArgumentList.Arguments.Count != 1)
+            return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                "Replace with FromSqlInterpolated",
+                c => ApplyFixAsync(context.Document, memberAccess, c),
+                "ReplaceFromSqlRawWithInterpolated"),
+            diagnostic);
     }
 
-    private async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+    private static async Task<Document> ApplyFixAsync(Document document, MemberAccessExpressionSyntax memberAccess, CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        editor.ReplaceNode(memberAccess, memberAccess.WithName(SyntaxFactory.IdentifierName("FromSqlInterpolated")));
+        return editor.GetChangedDocument();
+    }
 
-        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+    private static ArgumentSyntax? GetSqlArgument(InvocationExpressionSyntax invocation)
+    {
+        foreach (var argument in invocation.ArgumentList.Arguments)
         {
-            var newName = SyntaxFactory.IdentifierName("FromSqlInterpolated");
-            var newMemberAccess = memberAccess.WithName(newName);
-            editor.ReplaceNode(memberAccess, newMemberAccess);
+            if (argument.NameColon?.Name.Identifier.ValueText == "sql")
+                return argument;
         }
 
-        return editor.GetChangedDocument();
+        return invocation.ArgumentList.Arguments.FirstOrDefault(argument => argument.NameColon is null);
     }
 }

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.2</Version>
+        <Version>5.2.3</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC012_OptimizeRemoveRange/OptimizeRemoveRangeAnalyzerTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.EntityFrameworkCore
 ";
 
     [Fact]
-    public async Task RemoveRange_OnDbSet_ShouldTrigger()
+    public async Task RemoveRange_OnDbSetWithQueryableSource_ShouldTrigger()
     {
         var test = Usings + @"
 namespace TestApp
@@ -56,7 +56,7 @@ namespace TestApp
         public void Main()
         {
             using var db = new AppDbContext();
-            var usersToDelete = db.Users.Where(u => u.Id > 10).ToList();
+            var usersToDelete = db.Users.Where(u => u.Id > 10);
             
             // Trigger: DbSet.RemoveRange
             {|LC012:db.Users.RemoveRange(usersToDelete)|};
@@ -68,7 +68,31 @@ namespace TestApp
     }
 
     [Fact]
-    public async Task RemoveRange_OnDbContext_ShouldTrigger()
+    public async Task RemoveRange_OnDbContextWithQueryableSource_ShouldTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public class AppDbContext : DbContext {}
+
+    public class Program
+    {
+        public void Main()
+        {
+            using var db = new AppDbContext();
+            var usersToDelete = db.Users.Where(u => u.Id > 10);
+            
+            // Trigger: DbContext.RemoveRange
+            {|LC012:db.RemoveRange(usersToDelete)|};
+        }
+    }
+}" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task RemoveRange_WithMaterializedList_ShouldNotTrigger()
     {
         var test = Usings + @"
 namespace TestApp
@@ -81,9 +105,28 @@ namespace TestApp
         {
             using var db = new AppDbContext();
             var usersToDelete = db.Users.Where(u => u.Id > 10).ToList();
-            
-            // Trigger: DbContext.RemoveRange
-            {|LC012:db.RemoveRange(usersToDelete)|};
+            db.Users.RemoveRange(usersToDelete);
+        }
+    }
+}" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task RemoveRange_WithParamsArray_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public class AppDbContext : DbContext {}
+
+    public class Program
+    {
+        public void Main(User user)
+        {
+            using var db = new AppDbContext();
+            db.Users.RemoveRange(user);
         }
     }
 }" + MockNamespace;

--- a/tests/LinqContraband.Tests/Analyzers/LC012_OptimizeRemoveRange/OptimizeRemoveRangeFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC012_OptimizeRemoveRange/OptimizeRemoveRangeFixerTests.cs
@@ -65,4 +65,25 @@ namespace LinqContraband.Test
 
         await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
     }
+
+    [Fact]
+    public async Task Fixer_ShouldNotRegister_ForMaterializedList()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            var list = users.Where(x => x.Id > 0).ToList();
+            users.RemoveRange(list);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, test);
+    }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC018_AvoidFromSqlRawWithInterpolation/AvoidFromSqlRawWithInterpolationTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC018_AvoidFromSqlRawWithInterpolation/AvoidFromSqlRawWithInterpolationTests.cs
@@ -63,6 +63,47 @@ namespace LinqContraband.Test
     }
 
     [Fact]
+    public async Task FromSqlRaw_WithNestedConcatenatedString_ShouldTriggerLC018()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var id = 1;
+            var name = ""A"";
+            var query = new int[0].AsQueryable();
+            var result = query.FromSqlRaw({|LC018:""SELECT * FROM Table WHERE Name = "" + name + "" AND Id = "" + id|});
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task FromSqlRaw_WithNamedSqlArgument_ShouldTriggerLC018()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var id = 1;
+            var query = new int[0].AsQueryable();
+            var result = query.FromSqlRaw(parameters: new object[0], sql: {|LC018:$""SELECT * FROM Table WHERE Id = {id}""|});
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task FromSqlRaw_WithConstantString_ShouldNotTrigger()
     {
         var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
@@ -115,6 +156,26 @@ namespace LinqContraband.Test
             var query = new int[0].AsQueryable();
             var sql = $""SELECT * FROM Table WHERE Id = {id}"";
             var result = query.FromSqlRaw(sql);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task FromSqlInterpolated_WithInterpolatedString_ShouldNotTriggerLC018()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var id = 1;
+            var query = new int[0].AsQueryable();
+            var result = query.FromSqlInterpolated($""SELECT * FROM Table WHERE Id = {id}"");
         }
     }
 }";
@@ -176,5 +237,79 @@ namespace LinqContraband.Test
 
         var expected = VerifyFix.Diagnostic("LC018").WithSpan(22, 43, 22, 81);
         await VerifyFix.VerifyCodeFixAsync(test, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldReplaceNamedFromSqlRawWithFromSqlInterpolated()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var id = 1;
+            var query = new int[0].AsQueryable();
+            var result = query.FromSqlRaw(sql: {|LC018:$""SELECT * FROM Table WHERE Id = {id}""|});
+        }
+    }
+}";
+
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var id = 1;
+            var query = new int[0].AsQueryable();
+            var result = query.FromSqlInterpolated(sql: $""SELECT * FROM Table WHERE Id = {id}"");
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldNotRegister_WhenRawParametersArePresent()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var id = 1;
+            var query = new int[0].AsQueryable();
+            var result = query.FromSqlRaw(parameters: new object[0], sql: {|LC018:$""SELECT * FROM Table WHERE Id = {id}""|});
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, test);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldNotRegister_ForConcatenation()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var id = 1;
+            var query = new int[0].AsQueryable();
+            var result = query.FromSqlRaw({|LC018:""SELECT * FROM Table WHERE Id = "" + id|});
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, test);
     }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC030_DbContextInSingleton/DbContextInSingletonTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC030_DbContextInSingleton/DbContextInSingletonTests.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Extensions.DependencyInjection
     }
 
     public interface IServiceCollection { }
+    public interface IServiceScopeFactory { }
 
     public sealed class ServiceCollection : IServiceCollection { }
 
@@ -186,6 +187,52 @@ public static class Startup
     public static void Configure(Microsoft.Extensions.DependencyInjection.IServiceCollection services)
     {
         Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<Worker>(services);
+    }
+}
+";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AddSingletonServiceImplementation_WithStoredDbContext_ShouldTriggerLC030()
+    {
+        var test = EFCoreMock + DependencyInjectionMock + @"
+public interface IWorker { }
+
+public sealed class Worker : IWorker
+{
+    private readonly Microsoft.EntityFrameworkCore.DbContext {|LC030:_db|};
+}
+
+public static class Startup
+{
+    public static void Configure(Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+    {
+        Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<IWorker, Worker>(services);
+    }
+}
+";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AddSingletonTypeImplementation_WithStoredDbContext_ShouldTriggerLC030()
+    {
+        var test = EFCoreMock + DependencyInjectionMock + @"
+public interface IWorker { }
+
+public sealed class Worker : IWorker
+{
+    private readonly Microsoft.EntityFrameworkCore.DbContext {|LC030:_db|};
+}
+
+public static class Startup
+{
+    public static void Configure(Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+    {
+        Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton(services, typeof(IWorker), typeof(Worker));
     }
 }
 ";
@@ -337,6 +384,36 @@ dotnet_code_quality.LC030.long_lived_types = TestApp.ILongLivedWorker
     }
 
     [Fact]
+    public async Task ConfiguredLongLivedBaseType_ShouldTrigger()
+    {
+        var test = new Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<
+            LinqContraband.Analyzers.LC030_DbContextInSingleton.DbContextInSingletonAnalyzer,
+            Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>
+        {
+            TestCode = EFCoreMock + @"
+namespace TestApp
+{
+    public abstract class LongLivedBase { }
+
+    public sealed class Worker : LongLivedBase
+    {
+        private readonly Microsoft.EntityFrameworkCore.DbContext {|LC030:_db|};
+    }
+}
+"
+        };
+
+        test.TestState.AnalyzerConfigFiles.Add(("/0/.editorconfig", """
+root = true
+
+[*.cs]
+dotnet_code_quality.LC030.long_lived_types = TestApp.LongLivedBase
+"""));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task ScopedAndPerRequestTypes_ShouldNotTrigger()
     {
         var test = EFCoreMock + HttpMock + @"
@@ -415,6 +492,24 @@ public sealed class Worker : Microsoft.Extensions.Hosting.IHostedService
 {
     private readonly Microsoft.EntityFrameworkCore.IDbContextFactory<Microsoft.EntityFrameworkCore.DbContext> _factory;
     private readonly Microsoft.EntityFrameworkCore.DbContextOptions<Microsoft.EntityFrameworkCore.DbContext> _options;
+
+    public System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken) => System.Threading.Tasks.Task.CompletedTask;
+    public System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken) => System.Threading.Tasks.Task.CompletedTask;
+}
+";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task HostedService_WithScopeFactoryOnly_ShouldNotTrigger()
+    {
+        var test = EFCoreMock + HostingMock + DependencyInjectionMock + @"
+public sealed class Worker : Microsoft.Extensions.Hosting.IHostedService
+{
+    private readonly Microsoft.Extensions.DependencyInjection.IServiceScopeFactory _scopeFactory;
+
+    public Worker(Microsoft.Extensions.DependencyInjection.IServiceScopeFactory scopeFactory) => _scopeFactory = scopeFactory;
 
     public System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken) => System.Threading.Tasks.Task.CompletedTask;
     public System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken) => System.Threading.Tasks.Task.CompletedTask;

--- a/tests/LinqContraband.Tests/Analyzers/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateTests.cs
@@ -9,6 +9,7 @@ public class MissingWhereBeforeExecuteDeleteUpdateTests
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -29,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore
     public static class RelationalQueryableExtensions
     {
         public static int ExecuteDelete<TSource>(this IQueryable<TSource> source) => 0;
+        public static Task<int> ExecuteDeleteAsync<TSource>(this IQueryable<TSource> source) => Task.FromResult(0);
         public static int ExecuteUpdate<TSource>(this IQueryable<TSource> source) => 0;
+        public static Task<int> ExecuteUpdateAsync<TSource>(this IQueryable<TSource> source) => Task.FromResult(0);
         public static IQueryable<TSource> TagWith<TSource>(this IQueryable<TSource> source, string tag) => source;
         public static IQueryable<TSource> AsNoTracking<TSource>(this IQueryable<TSource> source) => source;
     }
@@ -109,6 +112,88 @@ namespace TestApp
         public void Run(DbContext db)
         {
             var result = db.Set<User>().Where(u => u.Id > 10).TagWith(""bulk"").ExecuteUpdate();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteDeleteAsync_WithoutWhere_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class User { public int Id { get; set; } }
+
+    public sealed class Program
+    {
+        public async System.Threading.Tasks.Task Run(DbContext db)
+        {
+            var result = await {|LC035:db.Set<User>().ExecuteDeleteAsync()|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteUpdateAsync_WithWhereThroughChainedOperators_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class User { public int Id { get; set; } }
+
+    public sealed class Program
+    {
+        public async System.Threading.Tasks.Task Run(DbContext db)
+        {
+            var result = await db.Set<User>().AsNoTracking().Where(u => u.Id > 10).TagWith(""bulk"").ExecuteUpdateAsync();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteDelete_WithFilteredLocalQuery_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class User { public int Id { get; set; } }
+
+    public sealed class Program
+    {
+        public void Run(DbContext db)
+        {
+            var filtered = db.Set<User>().Where(u => u.Id > 10);
+            var result = filtered.ExecuteDelete();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteDelete_WithUnfilteredLocalQuery_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class User { public int Id { get; set; } }
+
+    public sealed class Program
+    {
+        public void Run(DbContext db)
+        {
+            var allUsers = db.Set<User>();
+            var result = {|LC035:allUsers.ExecuteDelete()|};
         }
     }
 }";

--- a/tests/LinqContraband.Tests/Analyzers/LC043_AsyncEnumerableBuffering/AsyncEnumerableBufferingTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC043_AsyncEnumerableBuffering/AsyncEnumerableBufferingTests.cs
@@ -10,6 +10,7 @@ public class AsyncEnumerableBufferingTests
 {
     private const string AsyncEnumerableMock = @"
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.EntityFrameworkCore
@@ -17,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore
     public static class AsyncEnumerableExtensions
     {
         public static Task<List<TSource>> ToListAsync<TSource>(this IAsyncEnumerable<TSource> source) => Task.FromResult(new List<TSource>());
+        public static Task<List<TSource>> ToListAsync<TSource>(this IAsyncEnumerable<TSource> source, CancellationToken cancellationToken) => Task.FromResult(new List<TSource>());
         public static Task<TSource[]> ToArrayAsync<TSource>(this IAsyncEnumerable<TSource> source) => Task.FromResult(new TSource[0]);
     }
 }
@@ -45,7 +47,7 @@ namespace TestApp
     }
 }";
 
-        var expected = VerifyCS.Diagnostic("LC043").WithSpan(24, 31, 24, 50).WithArguments("ToListAsync");
+        var expected = VerifyCS.Diagnostic("LC043").WithSpan(26, 31, 26, 50).WithArguments("ToListAsync");
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
@@ -72,7 +74,7 @@ namespace TestApp
     }
 }";
 
-        var expected = VerifyCS.Diagnostic("LC043").WithSpan(24, 31, 24, 51).WithArguments("ToArrayAsync");
+        var expected = VerifyCS.Diagnostic("LC043").WithSpan(26, 31, 26, 51).WithArguments("ToArrayAsync");
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
@@ -118,7 +120,7 @@ namespace TestApp
     }
 }";
 
-        var expected = VerifyCS.Diagnostic("LC043").WithSpan(24, 31, 24, 50).WithArguments("ToListAsync");
+        var expected = VerifyCS.Diagnostic("LC043").WithSpan(26, 31, 26, 50).WithArguments("ToListAsync");
         await VerifyFix.VerifyCodeFixAsync(test, expected, fixedCode);
     }
 
@@ -142,6 +144,61 @@ namespace TestApp
             {
                 System.Console.WriteLine(item.Name);
             }
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task BufferedAsyncEnumerable_WithCancellationToken_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;" + AsyncEnumerableMock + @"
+namespace TestApp
+{
+    public class User { public string Name { get; set; } }
+
+    public class TestClass
+    {
+        public async Task Run(IAsyncEnumerable<User> users, CancellationToken cancellationToken)
+        {
+            var items = await users.ToListAsync(cancellationToken);
+            foreach (var item in items)
+            {
+                System.Console.WriteLine(item.Name);
+            }
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task BufferedAsyncEnumerable_WithSecondUse_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Threading.Tasks;" + AsyncEnumerableMock + @"
+namespace TestApp
+{
+    public class User { public string Name { get; set; } }
+
+    public class TestClass
+    {
+        public async Task Run(IAsyncEnumerable<User> users)
+        {
+            var items = await users.ToListAsync();
+            foreach (var item in items)
+            {
+                System.Console.WriteLine(item.Name);
+            }
+
+            System.Console.WriteLine(items.Count);
         }
     }
 }";


### PR DESCRIPTION
## Summary
- harden LC018 FromSqlRaw security analysis and narrow its fixer guardrails
- narrow LC012 RemoveRange suggestions to query-shaped sources and protect the fixer from materialized/tracked inputs
- expand LC030, LC035, and LC043 edge coverage while refreshing analyzer-health and rule docs
- bump package metadata and changelog for v5.2.3

## Impact
This reduces false positives and unsafe fixer availability around security, lifetime, bulk-delete, and async-stream rules. The analyzer-health roadmap now reflects the shipped state instead of stale planned-work notes.

## Validation
- `/opt/homebrew/bin/dotnet test LinqContraband.sln --no-restore --framework net10.0` passed with 574 tests
- `git diff --check` clean

Full local multi-target verification remains blocked because this machine only has .NET 10 runtimes installed; CI has .NET 8, 9, and 10 configured.