### PR TITLE
[codex] Harden LC024 and LC036

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.4] - 2026-04-24
+
+### Changed
+- Hardened `LC024` GroupBy projection analysis around EF translation boundaries, including local helpers over grouped keys, client-only string comparison calls, direct group object construction, and nested non-aggregate group projections
+- Expanded `LC024` safe coverage for aggregate-only projections and LINQ-to-Objects grouping boundaries
+- Expanded `LC036` thread-work detection to cover `Task.Factory.StartNew(...)`, `Thread`, timer callbacks, async lambdas, and captured `DbContext` members
+- Added `LC036` safe-pattern coverage for factory-created contexts, scoped context creation inside callbacks, scalar-only capture, and work scheduled after materialization without context capture
+- Refreshed LC024/LC036 docs and analyzer-health status to mark both rules as reference-quality examples
+
 ## [5.2.3] - 2026-04-24
 
 ### Changed

--- a/docs/LC024_GroupByNonTranslatable.md
+++ b/docs/LC024_GroupByNonTranslatable.md
@@ -2,7 +2,7 @@
 
 ## What it flags
 
-Flags GroupBy pipelines that project values EF Core cannot translate cleanly to SQL, which usually triggers runtime failures or accidental client-side grouping.
+Flags `IQueryable.GroupBy(...)` pipelines that project values EF Core cannot translate cleanly to SQL, which usually triggers runtime failures or accidental client-side grouping.
 
 ## Why it matters
 
@@ -11,6 +11,8 @@ LinqContraband reports this rule when the query shape suggests a risky or non-tr
 ## Typical fix
 
 Move the projection before the grouping only when it stays translatable, aggregate on the server, or materialize intentionally before performing complex grouping in memory.
+
+LC024 is intentionally manual-only. The safe rewrite depends on whether the caller wants a server aggregate, a pre-grouped projection, or explicit client-side grouping after materialization.
 
 ## Samples
 
@@ -28,6 +30,8 @@ var query = db.Orders
     });
 ```
 
+Other risky shapes include calling local helpers over `g.Key`, using client-only string comparison overloads in the grouped projection, constructing objects from `g` directly, or nesting non-aggregate group access inside another projection object.
+
 ## A better shape
 
 ```csharp
@@ -40,3 +44,5 @@ var query = db.Orders
         Total = g.Sum(o => o.Total)
     });
 ```
+
+LC024 stays quiet for aggregate-only projections (`Key`, `Count`, `LongCount`, `Sum`, `Average`, `Min`, `Max`) and for LINQ-to-Objects grouping where the source is already `IEnumerable<T>`.

--- a/docs/LC036_DbContextCapturedAcrossThreads.md
+++ b/docs/LC036_DbContextCapturedAcrossThreads.md
@@ -4,16 +4,27 @@
 Detect a single `DbContext` captured into multi-threaded delegates.
 
 ## The Problem
-`DbContext` is not thread-safe. Capturing the same instance into `Task.Run(...)`, `Parallel.ForEach(...)`, or thread-pool work can lead to race conditions and undefined behavior.
+`DbContext` is not thread-safe. Capturing the same instance into `Task.Run(...)`, `Task.Factory.StartNew(...)`, `Parallel.ForEach(...)`, thread-pool work, `Thread`, or timer callbacks can lead to race conditions and undefined behavior.
 
 ### Example Violation
 ```csharp
 Task.Run(() => db.Users.ToList());
+Task.Factory.StartNew(() => db.SaveChanges());
 Parallel.ForEach(ids, _ => db.Users.Count());
+new Thread(() => db.SaveChanges()).Start();
+new Timer(_ => db.SaveChanges(), null, 0, 1000);
 ```
 
 ### Safer Shape
-Create a separate context per background delegate, or use `IDbContextFactory<TContext>`.
+Create a separate context inside each background delegate, create a scope inside the callback, or use `IDbContextFactory<TContext>`.
+
+```csharp
+Task.Run(() =>
+{
+    using var db = factory.CreateDbContext();
+    return db.Users.Count();
+});
+```
 
 ## Analyzer Logic
 
@@ -22,4 +33,4 @@ Create a separate context per background delegate, or use `IDbContextFactory<TCo
 ### Severity: `Warning`
 
 ### Notes
-This rule is advisory only and stays silent when the delegate creates its own context instead of capturing one from the outer scope.
+This rule is advisory only and stays silent when the delegate creates its own context, obtains one from a scope created inside the callback, or captures only scalar/materialized values. Capturing a `DbContext` field, property, local, or parameter from outside the callback is unsafe because the work can run after or concurrently with the original scope.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -44,7 +44,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC021 | IgnoreQueryFilters usage | Raw SQL & Security | Warning | 4 | 3 | 4 | 3 | 4 | 4 | Medium | Intentional bypasses can be valid; consider suppression/allow-list guidance and more negative tests. |
 | LC022 | ToList/ToArray inside Select projection | Materialization & Projection | Warning | 4 | 4 | 3 | 4 | 4 | 4 | Medium | Analyzer coverage is decent; add dedicated fixer tests if fixer behavior is meant to be supported. |
 | LC023 | Prefer Find/FindAsync for primary key lookups | Materialization & Projection | Info | 3 | 3 | 3 | 3 | 4 | 3 | Medium | Useful but schema-sensitive; add fixer tests and more composite-key/provider edge cases. |
-| LC024 | GroupBy with non-translatable projection | Query Shape & Translation | Warning | 4 | 4 | 5 | 3 | 4 | 5 | Medium | Manual-only is correct; expand translation-boundary tests because runtime failure impact is high. |
+| LC024 | GroupBy with non-translatable projection | Query Shape & Translation | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Reference-quality manual rule with aggregate-only exclusions, helper/string-comparison/object-construction coverage, nested projection tests, and LINQ-to-Objects boundary coverage. |
 | LC025 | AsNoTracking with Update/Remove | Change Tracking & Context Lifetime | Warning | 4 | 4 | 3 | 3 | 4 | 4 | Medium | Reliability value is clear; add fixer tests or narrow catalog confidence if fixer coverage is intentionally absent. |
 | LC026 | Missing CancellationToken in async call | Execution & Async | Info | 4 | 4 | 3 | 4 | 4 | 3 | Medium | Good analyzer scope; add fixer tests across method parameters, locals, and default token cases. |
 | LC027 | Missing explicit foreign key property | Schema & Modeling | Info | 4 | 4 | 3 | 4 | 4 | 3 | Medium | Design guidance is useful; add fixer tests and more model-configuration negative cases. |
@@ -56,7 +56,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC033 | Use FrozenSet for static membership caches | Materialization & Projection | Info | 5 | 5 | 5 | 4 | 4 | 2 | Low | Strong implementation for a niche optimization; not a planning priority. |
 | LC034 | ExecuteSqlRaw with interpolated strings | Raw SQL & Security | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Hardened to reference quality with parameter-aware SQL argument resolution, narrow safe fixer behavior, raw-parameter guardrails, LC037 boundary coverage, and aligned docs/sample guidance. |
 | LC035 | Missing Where before bulk execute | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 5 | 4 | 4 | 5 | Low | Added async, chained-query, and simple filtered-local coverage while keeping the rule advisory and manual-only. |
-| LC036 | DbContext captured by thread work item | Execution & Async | Warning | 4 | 4 | 5 | 3 | 4 | 5 | Medium | Important safety rule; add coverage for more task/parallel APIs and safe factory/scope patterns. |
+| LC036 | DbContext captured by thread work item | Execution & Async | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Reference-quality thread-safety rule covering Task, TaskFactory, Thread, ThreadPool, Parallel, timer callbacks, async lambdas, member capture, and factory/scope/materialized-value safe patterns. |
 | LC037 | Constructed raw SQL strings | Raw SQL & Security | Warning | 5 | 5 | 5 | 5 | 4 | 5 | Low | Strong manual-only security rule with broad string-construction coverage. |
 | LC038 | Excessive eager loading | Loading & Includes | Info | 3 | 3 | 5 | 3 | 4 | 3 | Medium | Heuristic rule; add threshold documentation and more examples of legitimate deep loads. |
 | LC039 | Repeated SaveChanges on same context | Change Tracking & Context Lifetime | Info | 4 | 4 | 5 | 3 | 4 | 4 | Medium | Useful reliability smell; add more transaction, branch, and intentional boundary tests. |
@@ -73,13 +73,13 @@ The next improvement batch should focus on rules that combine high importance wi
 | Priority | Rules | Work |
 | --- | --- | --- |
 | Medium | LC023, LC025, LC026, LC027, LC041 | Expand existing fixer coverage for schema-sensitive and subtle projection/tracking rewrites. |
-| Medium | LC019, LC024, LC028, LC031, LC036, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
-| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC030, LC034, LC035, LC037, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
+| Medium | LC019, LC028, LC031, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
+| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC024, LC030, LC034, LC035, LC036, LC037, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
 
 ## Verification Baseline
 
 `dotnet restore LinqContraband.sln` completed successfully.
 
-`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 574 passing tests.
+`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 588 passing tests.
 
 `dotnet --list-runtimes` currently shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC036_DbContextCapturedAcrossThreads/DbContextCapturedAcrossThreadsAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC036_DbContextCapturedAcrossThreads/DbContextCapturedAcrossThreadsAnalyzer.cs
@@ -40,6 +40,7 @@ public sealed class DbContextCapturedAcrossThreadsAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        context.RegisterOperationAction(AnalyzeObjectCreation, OperationKind.ObjectCreation);
     }
 
     private static void AnalyzeInvocation(OperationAnalysisContext context)
@@ -64,10 +65,33 @@ public sealed class DbContextCapturedAcrossThreadsAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    private static void AnalyzeObjectCreation(OperationAnalysisContext context)
+    {
+        var creation = (IObjectCreationOperation)context.Operation;
+        if (!IsTargetThreadObject(creation.Constructor?.ContainingType))
+            return;
+
+        var semanticModel = context.Operation.SemanticModel;
+        if (semanticModel == null)
+            return;
+
+        foreach (var argument in creation.Arguments)
+        {
+            if (TryFindCapturedDbContext(argument.Value.Syntax, semanticModel, out var symbol))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rule, creation.Syntax.GetLocation(), symbol.Name, creation.Type?.Name ?? "thread work item"));
+                return;
+            }
+        }
+    }
+
     private static bool IsTargetThreadApi(IMethodSymbol method)
     {
         return (method.Name == "Run" &&
                 method.ContainingType.Name == "Task" &&
+                method.ContainingNamespace?.ToString() == "System.Threading.Tasks") ||
+               (method.Name == "StartNew" &&
+                method.ContainingType.Name == "TaskFactory" &&
                 method.ContainingNamespace?.ToString() == "System.Threading.Tasks") ||
                (method.Name == "ForEach" &&
                 method.ContainingType.Name == "Parallel" &&
@@ -75,6 +99,15 @@ public sealed class DbContextCapturedAcrossThreadsAnalyzer : DiagnosticAnalyzer
                (method.Name == "QueueUserWorkItem" &&
                 method.ContainingType.Name == "ThreadPool" &&
                 method.ContainingNamespace?.ToString() == "System.Threading");
+    }
+
+    private static bool IsTargetThreadObject(INamedTypeSymbol? type)
+    {
+        if (type == null)
+            return false;
+
+        var ns = type.ContainingNamespace?.ToString();
+        return ns == "System.Threading" && type.Name is "Thread" or "Timer";
     }
 
     private static bool TryFindCapturedDbContext(SyntaxNode syntax, SemanticModel semanticModel, out ISymbol capturedSymbol)

--- a/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC024_GroupByNonTranslatable/GroupByNonTranslatableAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC024_GroupByNonTranslatable/GroupByNonTranslatableAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -128,6 +129,19 @@ public sealed class GroupByNonTranslatableAnalyzer : DiagnosticAnalyzer
         OperationAnalysisContext context,
         IInvocationOperation selectInvocation)
     {
+        foreach (var invocation in GetAllOperations(operation).OfType<IInvocationOperation>())
+        {
+            if (IsAllowedAggregateMethod(invocation.TargetMethod.Name))
+                continue;
+
+            if (!invocation.ReferencesParameter(groupParam))
+                continue;
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), invocation.TargetMethod.Name));
+            return;
+        }
+
         foreach (var descendant in GetAllOperations(operation))
         {
             if (descendant is IParameterReferenceOperation paramRef &&

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.3</Version>
+        <Version>5.2.4</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC024_GroupByNonTranslatable/GroupByNonTranslatableTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC024_GroupByNonTranslatable/GroupByNonTranslatableTests.cs
@@ -78,6 +78,100 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task GroupBy_Select_LocalHelperOverKey_ShouldTriggerLC024()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public class Order { public string CustomerId { get; set; } public decimal Amount { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(IQueryable<Order> orders)
+        {
+            var result = orders
+                .GroupBy(o => o.CustomerId)
+                .Select(g => {|LC024:Normalize(g.Key)|});
+        }
+
+        private static string Normalize(string value) => value.Trim().ToUpperInvariant();
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task GroupBy_Select_StringComparisonOverKey_ShouldTriggerLC024()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public class Order { public string CustomerId { get; set; } public decimal Amount { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(IQueryable<Order> orders)
+        {
+            var result = orders
+                .GroupBy(o => o.CustomerId)
+                .Select(g => {|LC024:g.Key.Equals(""vip"", StringComparison.OrdinalIgnoreCase)|});
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task GroupBy_Select_ObjectConstructionWithGroup_ShouldTriggerLC024()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public class Order { public int CustomerId { get; set; } public decimal Amount { get; set; } }
+    public sealed class Bucket
+    {
+        public Bucket(IGrouping<int, Order> group) { }
+    }
+
+    public class TestClass
+    {
+        public void TestMethod(IQueryable<Order> orders)
+        {
+            var result = orders
+                .GroupBy(o => o.CustomerId)
+                .Select(g => new Bucket({|LC024:g|}));
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task GroupBy_Select_NestedNonTranslatableProjection_ShouldTriggerLC024()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public class Order { public int CustomerId { get; set; } public decimal Amount { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(IQueryable<Order> orders)
+        {
+            var result = orders
+                .GroupBy(o => o.CustomerId)
+                .Select(g => new { Summary = new { First = {|LC024:g.First()|} } });
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task GroupBy_Select_KeyAndAggregates_ShouldNotTrigger()
     {
         var test = Usings + @"
@@ -100,6 +194,37 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task GroupBy_Select_AllSupportedAggregates_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public class Order { public int CustomerId { get; set; } public decimal Amount { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(IQueryable<Order> orders)
+        {
+            var result = orders
+                .GroupBy(o => o.CustomerId)
+                .Select(g => new
+                {
+                    Key = g.Key,
+                    Count = g.Count(),
+                    LongCount = g.LongCount(),
+                    Sum = g.Sum(o => o.Amount),
+                    Average = g.Average(o => o.Amount),
+                    Min = g.Min(o => o.Amount),
+                    Max = g.Max(o => o.Amount)
+                });
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task GroupBy_Select_KeyOnly_ShouldNotTrigger()
     {
         var test = Usings + @"
@@ -114,6 +239,28 @@ namespace TestApp
             var result = orders
                 .GroupBy(o => o.CustomerId)
                 .Select(g => g.Key);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task EnumerableGroupBy_Select_ClientProjection_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public class Order { public int CustomerId { get; set; } public decimal Amount { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(IEnumerable<Order> orders)
+        {
+            var result = orders
+                .GroupBy(o => o.CustomerId)
+                .Select(g => new { Key = g.Key, Items = g.ToList() });
         }
     }
 }";

--- a/tests/LinqContraband.Tests/Analyzers/LC036_DbContextCapturedAcrossThreads/DbContextCapturedAcrossThreadsTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC036_DbContextCapturedAcrossThreads/DbContextCapturedAcrossThreadsTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.EntityFrameworkCore
     public class DbContext
     {
         public int SaveChanges() => 0;
+        public Task<int> SaveChangesAsync() => Task.FromResult(0);
     }
 
     public class DbSet<TEntity> : IQueryable<TEntity> where TEntity : class
@@ -33,6 +34,27 @@ namespace Microsoft.EntityFrameworkCore
         TContext CreateDbContext();
     }
 }
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    using System;
+    using Microsoft.EntityFrameworkCore;
+
+    public interface IServiceScope : IDisposable
+    {
+        IServiceProvider ServiceProvider { get; }
+    }
+
+    public interface IServiceScopeFactory
+    {
+        IServiceScope CreateScope();
+    }
+
+    public static class ServiceProviderServiceExtensions
+    {
+        public static T GetRequiredService<T>(this IServiceProvider provider) => default;
+    }
+}
 ";
 
     [Fact]
@@ -46,13 +68,12 @@ namespace TestApp
     {
         public Task<int> Run(DbContext db)
         {
-            return Task.Run(() => db.SaveChanges());
+            return {|LC036:Task.Run(() => db.SaveChanges())|};
         }
     }
 }";
 
-        var expected = VerifyCS.Diagnostic("LC036").WithSpan(37, 20, 37, 52).WithArguments("db", "Run");
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
@@ -69,13 +90,12 @@ namespace TestApp
     {
         public void Run(DbContext db, IEnumerable<User> users)
         {
-            Parallel.ForEach(users, user => db.SaveChanges());
+            {|LC036:Parallel.ForEach(users, user => db.SaveChanges())|};
         }
     }
 }";
 
-        var expected = VerifyCS.Diagnostic("LC036").WithSpan(40, 13, 40, 62).WithArguments("db", "ForEach");
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
@@ -89,13 +109,109 @@ namespace TestApp
     {
         public void Run(DbContext db)
         {
-            ThreadPool.QueueUserWorkItem(_ => db.SaveChanges());
+            {|LC036:ThreadPool.QueueUserWorkItem(_ => db.SaveChanges())|};
         }
     }
 }";
 
-        var expected = VerifyCS.Diagnostic("LC036").WithSpan(37, 13, 37, 64).WithArguments("db", "QueueUserWorkItem");
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TaskFactoryStartNew_CapturingDbContext_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public Task<int> Run(DbContext db)
+        {
+            return {|LC036:Task.Factory.StartNew(() => db.SaveChanges())|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NewThread_CapturingDbContext_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Threading;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db)
+        {
+            {|LC036:new Thread(() => db.SaveChanges())|}.Start();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TimerCallback_CapturingDbContext_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Threading;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public Timer Run(DbContext db)
+        {
+            return {|LC036:new Timer(_ => db.SaveChanges(), null, 0, 1000)|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TaskRun_AsyncLambdaCapturingDbContext_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public Task<int> Run(DbContext db)
+        {
+            return {|LC036:Task.Run(async () => await db.SaveChangesAsync())|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TaskRun_CapturingDbContextMember_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        private readonly DbContext _db = new DbContext();
+
+        public Task<int> Run()
+        {
+            return {|LC036:Task.Run(() => _db.SaveChanges())|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
@@ -137,6 +253,73 @@ namespace TestApp
                 var db = factory.CreateDbContext();
                 return db.SaveChanges();
             });
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task CreatingScopeInsideTask_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public Task<int> Run(IServiceScopeFactory scopeFactory)
+        {
+            return Task.Run(() =>
+            {
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+                return db.SaveChanges();
+            });
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TaskRun_PassingScalarOnly_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public Task<int> Run(DbContext db)
+        {
+            var count = db.SaveChanges();
+            return Task.Run(() => count);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TaskRun_AfterMaterializationWithoutContextCapture_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Threading.Tasks;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public Task<int> Run(DbContext db)
+        {
+            var saved = db.SaveChanges();
+            var values = new List<int> { saved };
+            return Task.Run(() => values.Count);
         }
     }
 }";


### PR DESCRIPTION
## Summary
- harden LC024 GroupBy projection analysis around EF translation boundaries
- expand LC036 thread-work detection across TaskFactory, Thread, Timer, async lambdas, and captured members
- add safe-pattern coverage for aggregate-only grouping, LINQ-to-Objects grouping, factory/scope context creation, scalar capture, and materialized values
- bump package metadata and changelog for v5.2.4

## Impact
This makes LC024 and LC036 reference-quality candidates: fewer missed high-impact runtime/threading issues while preserving safe boundaries and manual remediation guidance.

## Validation
- `/opt/homebrew/bin/dotnet test LinqContraband.sln --no-restore --framework net10.0` passed with 588 tests
- `git diff --check` clean

Full local multi-target verification remains blocked because this machine only has .NET 10 runtimes installed; CI has .NET 8, 9, and 10 configured.