### PR TITLE
Harden LC025 no-tracking write analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.5] - 2026-04-24
+
+### Changed
+- Hardened `LC025` local-origin analysis so diagnostics follow the nearest previous assignment or declaration instead of treating later no-tracking assignments as write-path evidence
+- Expanded `LC025` coverage for query aliases, `UpdateRange`/`RemoveRange` collection locals, assignment-based fixes, foreach collection fixes, and tracked-reassignment false-positive boundaries
+- Refreshed `LC025` docs/sample guidance and analyzer-health status to reflect the safer analyzer and fixer contract
+
 ## [5.2.4] - 2026-04-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -883,6 +883,10 @@ user.Name = "New Name";
 db.SaveChanges();
 ```
 
+**🛡️ Reliability Notes:**
+- LC025 follows the nearest previous local origin, so a later `AsNoTracking()` assignment does not taint an earlier write.
+- The fixer removes `AsNoTracking()` from direct declarations, simple assignments, and foreach collection expressions when that is the safe local origin.
+
 ---
 
 ### LC026: Missing CancellationToken

--- a/docs/LC025_AsNoTrackingWithUpdate.md
+++ b/docs/LC025_AsNoTrackingWithUpdate.md
@@ -1,62 +1,66 @@
-# Spec: LC025 - Avoid AsNoTracking with Update/Remove
+# LC025 - Avoid AsNoTracking with Update/Remove
 
 ## Goal
-Detect usage of `AsNoTracking()` on queries where the resulting entities are subsequently passed to `DbContext.Update()`, `DbSet.Update()`, `DbContext.Remove()`, or `DbSet.Remove()`.
+Detect entities or materialized entity collections that come from an `AsNoTracking()` query and are later passed to `DbContext.Update`, `DbSet.Update`, `DbContext.Remove`, `DbSet.Remove`, or their `*Range` variants.
 
-## The Problem
-`AsNoTracking()` tells EF Core not to track the entities in the change tracker. This improves performance for read-only queries. However, if you then pass these untracked entities to `Update()` or `Remove()`, EF Core has to re-attach them to the context. 
-1.  **For Update**: EF Core will mark ALL properties as modified because it doesn't know which ones actually changed (since it wasn't tracking the original state). This results in a SQL UPDATE statement that updates every column, which is less efficient and can cause concurrency issues.
-2.  **For Remove**: It works, but it's often a sign of inconsistent intent (marking as read-only, then deleting).
+## Why This Matters
+`AsNoTracking()` is correct for read-only queries because EF Core does not keep original values in the change tracker. Passing those entities back to `Update()` forces EF Core to attach them and mark all properties as modified, which can produce wider SQL updates than intended and can hide concurrency mistakes. Passing untracked entities to `Remove()` is usually a sign that the query was marked read-only even though the result is part of a write path.
 
-### Example Violation
+## Violations
+
 ```csharp
-// Violation: Entity is not tracked, so Update will update all columns
 var user = db.Users.AsNoTracking().FirstOrDefault(u => u.Id == id);
-user.Name = "New Name";
-db.Users.Update(user); 
+if (user is not null)
+{
+    db.Users.Update(user);
+}
 ```
 
-### The Fix
-Remove `AsNoTracking()` if you intend to modify or delete the entity, so EF Core can track changes and generate optimized SQL.
+```csharp
+var users = db.Users.AsNoTracking().Where(u => u.Age > 20).ToList();
+db.Users.UpdateRange(users);
+```
 
 ```csharp
-// Correct: Entity is tracked, Update (or just SaveChanges) will be optimized
+foreach (var user in db.Users.AsNoTracking().Where(u => u.Age > 20).ToList())
+{
+    db.Users.Remove(user);
+}
+```
+
+## Safe Patterns
+
+Use a tracked query when the entity is going through a write path:
+
+```csharp
 var user = db.Users.FirstOrDefault(u => u.Id == id);
-user.Name = "New Name";
-db.SaveChanges(); // No need for Update() if tracked
+if (user is not null)
+{
+    user.Name = "Updated";
+    db.SaveChanges();
+}
 ```
 
-## Analyzer Logic
+Keep `AsNoTracking()` for read-only projections or materialized values that are not passed back into EF write APIs:
 
-### ID: `LC025`
-### Category: `Reliability` (or `Performance`)
-### Severity: `Warning`
-
-### Algorithm
-1.  **Detection**: This is a cross-statement analysis, which is harder with Roslyn `IOperation` but possible within a method scope.
-2.  **Step 1**: Find calls to `AsNoTracking()`.
-3.  **Step 2**: Track the resulting variable (data flow analysis).
-4.  **Step 3**: Check if that variable (or items from the collection) is passed to `Update` or `Remove`.
-
-*Simplification for MVP*: 
--   Focus on local variables assigned from a query ending in `AsNoTracking()`.
--   Check if that local variable is used as an argument to `Update`/`Remove` in the same method.
-
-## Test Cases
-
-### Violations
 ```csharp
-var user = db.Users.AsNoTracking().First(x => x.Id == 1);
-db.Users.Update(user);
+var names = db.Users.AsNoTracking()
+    .Where(u => u.Age > 20)
+    .Select(u => u.Name)
+    .ToList();
 ```
 
-### Valid
-```csharp
-var user = db.Users.First(x => x.Id == 1);
-db.Users.Update(user);
-```
+## Analyzer Behavior
+LC025 tracks local variables within the current method, lambda, or local function. It reports when the nearest previous origin for the local is an `AsNoTracking()` query, including:
 
-## Implementation Plan
-1.  Create `LC025_AsNoTrackingWithUpdate` directory.
-2.  Implement `AsNoTrackingWithUpdateAnalyzer`.
-3.  Implement tests.
+- direct entity locals materialized from a no-tracking query;
+- collection locals materialized from a no-tracking query and passed to `UpdateRange` or `RemoveRange`;
+- foreach iteration variables over no-tracking collections;
+- entities materialized from local query aliases that were built from `AsNoTracking()`.
+
+The rule is order-aware. It does not report when a local is reassigned from a tracked query before the write API call, and it does not look ahead to no-tracking assignments that occur after the write.
+
+## Code Fix
+The fixer removes the `AsNoTracking()` call from direct local declarations, simple assignments, and foreach collection expressions when that is the origin of the diagnostic.
+
+It intentionally does not rewrite broader architecture choices. If the query was intentionally read-only, change the write path instead of applying the fix blindly.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -45,7 +45,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC022 | ToList/ToArray inside Select projection | Materialization & Projection | Warning | 4 | 4 | 3 | 4 | 4 | 4 | Medium | Analyzer coverage is decent; add dedicated fixer tests if fixer behavior is meant to be supported. |
 | LC023 | Prefer Find/FindAsync for primary key lookups | Materialization & Projection | Info | 3 | 3 | 3 | 3 | 4 | 3 | Medium | Useful but schema-sensitive; add fixer tests and more composite-key/provider edge cases. |
 | LC024 | GroupBy with non-translatable projection | Query Shape & Translation | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Reference-quality manual rule with aggregate-only exclusions, helper/string-comparison/object-construction coverage, nested projection tests, and LINQ-to-Objects boundary coverage. |
-| LC025 | AsNoTracking with Update/Remove | Change Tracking & Context Lifetime | Warning | 4 | 4 | 3 | 3 | 4 | 4 | Medium | Reliability value is clear; add fixer tests or narrow catalog confidence if fixer coverage is intentionally absent. |
+| LC025 | AsNoTracking with Update/Remove | Change Tracking & Context Lifetime | Warning | 5 | 5 | 4 | 5 | 5 | 4 | Low | Hardened with order-aware local origin tracking, query-alias and range-call coverage, assignment/foreach fixer tests, and refreshed docs/sample guidance. |
 | LC026 | Missing CancellationToken in async call | Execution & Async | Info | 4 | 4 | 3 | 4 | 4 | 3 | Medium | Good analyzer scope; add fixer tests across method parameters, locals, and default token cases. |
 | LC027 | Missing explicit foreign key property | Schema & Modeling | Info | 4 | 4 | 3 | 4 | 4 | 3 | Medium | Design guidance is useful; add fixer tests and more model-configuration negative cases. |
 | LC028 | Deep ThenInclude chain | Loading & Includes | Warning | 3 | 3 | 5 | 3 | 4 | 3 | Medium | Heuristic rule; manual-only is right, but thresholds and false-positive guidance need more tests. |
@@ -72,14 +72,18 @@ The next improvement batch should focus on rules that combine high importance wi
 
 | Priority | Rules | Work |
 | --- | --- | --- |
-| Medium | LC023, LC025, LC026, LC027, LC041 | Expand existing fixer coverage for schema-sensitive and subtle projection/tracking rewrites. |
+| Medium | LC023, LC026, LC027, LC041 | Expand existing fixer coverage for schema-sensitive and subtle projection/tracking rewrites. |
 | Medium | LC019, LC028, LC031, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
-| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC024, LC030, LC034, LC035, LC036, LC037, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
+| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC024, LC025, LC030, LC034, LC035, LC036, LC037, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
 
 ## Verification Baseline
 
 `dotnet restore LinqContraband.sln` completed successfully.
 
-`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 588 passing tests.
+`dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check` currently reports `docs/rule-catalog.md` is up to date.
+
+`dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` currently verifies 43 diagnostic paths.
+
+`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 594 passing tests.
 
 `dotnet --list-runtimes` currently shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/samples/LinqContraband.Sample/Samples/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateSample.cs
+++ b/samples/LinqContraband.Sample/Samples/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateSample.cs
@@ -12,7 +12,7 @@ public class AsNoTrackingWithUpdateSample
         var userId = Guid.NewGuid();
 
         // VIOLATION: Entity is not tracked, so Update will mark all columns as modified
-        var user1 = db.Users.FirstOrDefault(u => u.Id == userId);
+        var user1 = db.Users.AsNoTracking().FirstOrDefault(u => u.Id == userId);
         if (user1 != null)
         {
             user1.Name = "Updated";

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateAnalyzer.cs
@@ -68,16 +68,29 @@ public sealed class AsNoTrackingWithUpdateAnalyzer : DiagnosticAnalyzer
 
     private bool IsFromNoTrackingQuery(ILocalSymbol local, IOperation currentOperation)
     {
+        return IsFromNoTrackingQuery(local, currentOperation, new HashSet<ISymbol>(SymbolEqualityComparer.Default));
+    }
+
+    private bool IsFromNoTrackingQuery(ILocalSymbol local, IOperation currentOperation, ISet<ISymbol> visited)
+    {
+        if (!visited.Add(local)) return false;
+
         var root = currentOperation.FindOwningExecutableRoot() ?? currentOperation;
+        var currentStart = currentOperation.Syntax.SpanStart;
+        var bestOriginPosition = -1;
+        var bestOriginIsNoTracking = false;
 
         foreach (var op in EnumerateOperations(root))
         {
             // 1. Standard Assignments
             if (op is ISimpleAssignmentOperation assignment &&
                 assignment.Target is ILocalReferenceOperation targetLocal &&
-                SymbolEqualityComparer.Default.Equals(targetLocal.Local, local))
+                SymbolEqualityComparer.Default.Equals(targetLocal.Local, local) &&
+                assignment.Syntax.SpanStart < currentStart &&
+                assignment.Syntax.SpanStart >= bestOriginPosition)
             {
-                if (IsAsNoTrackingQuery(assignment.Value)) return true;
+                bestOriginPosition = assignment.Syntax.SpanStart;
+                bestOriginIsNoTracking = IsNoTrackingSource(assignment.Value, assignment, visited);
             }
 
             // 2. Variable Declarations
@@ -87,9 +100,11 @@ public sealed class AsNoTrackingWithUpdateAnalyzer : DiagnosticAnalyzer
                 {
                     if (SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) &&
                         declarator.Initializer != null &&
-                        IsAsNoTrackingQuery(declarator.Initializer.Value))
+                        declarator.Syntax.SpanStart < currentStart &&
+                        declarator.Syntax.SpanStart >= bestOriginPosition)
                     {
-                        return true;
+                        bestOriginPosition = declarator.Syntax.SpanStart;
+                        bestOriginIsNoTracking = IsNoTrackingSource(declarator.Initializer.Value, declarator.Initializer.Value, visited);
                     }
                 }
             }
@@ -98,21 +113,40 @@ public sealed class AsNoTrackingWithUpdateAnalyzer : DiagnosticAnalyzer
             if (op is IForEachLoopOperation forEach)
             {
                 // Check if our target 'local' is one of the locals defined by the loop
-                if (forEach.Locals.Any(l => SymbolEqualityComparer.Default.Equals(l, local)))
+                if (forEach.Locals.Any(l => SymbolEqualityComparer.Default.Equals(l, local)) &&
+                    forEach.Syntax.Span.Contains(currentStart) &&
+                    forEach.Collection.Syntax.SpanStart < currentStart &&
+                    forEach.Collection.Syntax.SpanStart >= bestOriginPosition)
                 {
-                    var collection = forEach.Collection.UnwrapConversions();
-                    if (IsAsNoTrackingQuery(collection)) return true;
-
-                    if (collection is ILocalReferenceOperation collRef)
-                    {
-                        // Check if collection variable itself is from a no-tracking query
-                        if (IsFromNoTrackingQuery(collRef.Local, forEach)) return true;
-                    }
+                    bestOriginPosition = forEach.Collection.Syntax.SpanStart;
+                    bestOriginIsNoTracking = IsNoTrackingSource(forEach.Collection, forEach.Collection, visited);
                 }
             }
         }
 
-        return false;
+        return bestOriginIsNoTracking;
+    }
+
+    private bool IsNoTrackingSource(IOperation source, IOperation boundaryOperation, ISet<ISymbol> visited)
+    {
+        var unwrapped = source.UnwrapConversions();
+        if (IsAsNoTrackingQuery(unwrapped)) return true;
+
+        if (unwrapped is IInvocationOperation invocation &&
+            invocation.TargetMethod.Name.IsMaterializerMethod() &&
+            invocation.GetInvocationReceiver() is ILocalReferenceOperation receiverLocal)
+        {
+            return IsFromNoTrackingQuery(
+                receiverLocal.Local,
+                boundaryOperation,
+                new HashSet<ISymbol>(visited, SymbolEqualityComparer.Default));
+        }
+
+        return unwrapped is ILocalReferenceOperation localRef &&
+               IsFromNoTrackingQuery(
+                   localRef.Local,
+                   boundaryOperation,
+                   new HashSet<ISymbol>(visited, SymbolEqualityComparer.Default));
     }
 
     private static IEnumerable<IOperation> EnumerateOperations(IOperation root)
@@ -132,13 +166,9 @@ public sealed class AsNoTrackingWithUpdateAnalyzer : DiagnosticAnalyzer
 
         if (current is IInvocationOperation invocation)
         {
-            if (invocation.TargetMethod.Name.IsMaterializerMethod())
-            {
-                var receiver = invocation.GetInvocationReceiver();
-                if (receiver != null) return HasAsNoTrackingInChain(receiver);
-            }
-
             if (invocation.TargetMethod.Name == "AsNoTracking") return true;
+
+            return HasAsNoTrackingInChain(invocation);
         }
 
         return false;

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateFixer.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateFixer.cs
@@ -3,12 +3,14 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace LinqContraband.Analyzers.LC025_AsNoTrackingWithUpdate;
 
@@ -38,6 +40,14 @@ public class AsNoTrackingWithUpdateFixer : CodeFixProvider
         var argument = token.Parent.AncestorsAndSelf().OfType<ArgumentSyntax>().FirstOrDefault();
         if (argument == null) return;
 
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel == null) return;
+
+        var local = GetLocalArgumentSymbol(semanticModel, argument, context.CancellationToken);
+        if (local == null) return;
+
+        if (FindAsNoTrackingOrigin(root, semanticModel, local, argument.SpanStart, context.CancellationToken) == null) return;
+
         context.RegisterCodeFix(
             CodeAction.Create(
                 "Remove AsNoTracking from query",
@@ -50,37 +60,93 @@ public class AsNoTrackingWithUpdateFixer : CodeFixProvider
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel == null) return document;
 
-        // 1. Identify the variable being passed
-        var symbol = semanticModel.GetSymbolInfo(argument.Expression, cancellationToken).Symbol as ILocalSymbol;
-        if (symbol == null) return document;
-
-        // 2. Find the assignment to this variable
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         if (root == null) return document;
 
-        var assignment = root.DescendantNodes()
-            .OfType<VariableDeclaratorSyntax>()
-            .FirstOrDefault(d => d.Identifier.Text == symbol.Name && d.Initializer != null);
+        var local = GetLocalArgumentSymbol(semanticModel, argument, cancellationToken);
+        if (local == null) return document;
 
-        if (assignment?.Initializer?.Value is InvocationExpressionSyntax queryExpression)
+        var asNoTrackingInvocation = FindAsNoTrackingOrigin(root, semanticModel, local, argument.SpanStart, cancellationToken);
+        if (asNoTrackingInvocation?.Expression is not MemberAccessExpressionSyntax asNoTrackingAccess) return document;
+
+        if (asNoTrackingAccess.Expression is ExpressionSyntax source)
         {
-            // 3. Find .AsNoTracking() in the chain
-            var asNoTrackingCall = queryExpression.DescendantNodesAndSelf()
-                .OfType<MemberAccessExpressionSyntax>()
-                .FirstOrDefault(m => m.Name.Identifier.Text == "AsNoTracking");
-
-            if (asNoTrackingCall?.Parent is InvocationExpressionSyntax invocation)
-            {
-                // Remove the call from the chain: query.AsNoTracking().ToList() -> query.ToList()
-                if (asNoTrackingCall.Expression is ExpressionSyntax source)
-                {
-                    // If it's a chained call, we need to replace the AsNoTracking invocation with its source
-                    editor.ReplaceNode(invocation, source.WithTriviaFrom(invocation));
-                }
-            }
+            editor.ReplaceNode(asNoTrackingInvocation, source.WithTriviaFrom(asNoTrackingInvocation));
         }
 
         return editor.GetChangedDocument();
+    }
+
+    private static ILocalSymbol? GetLocalArgumentSymbol(SemanticModel semanticModel, ArgumentSyntax argument, CancellationToken cancellationToken)
+    {
+        var operation = semanticModel.GetOperation(argument.Expression, cancellationToken)?.UnwrapConversions();
+        if (operation is ILocalReferenceOperation localReference)
+            return localReference.Local;
+
+        return semanticModel.GetSymbolInfo(argument.Expression, cancellationToken).Symbol as ILocalSymbol;
+    }
+
+    private static InvocationExpressionSyntax? FindAsNoTrackingOrigin(
+        SyntaxNode root,
+        SemanticModel semanticModel,
+        ILocalSymbol local,
+        int boundary,
+        CancellationToken cancellationToken)
+    {
+        var bestPosition = -1;
+        InvocationExpressionSyntax? bestInvocation = null;
+
+        foreach (var declarator in root.DescendantNodes().OfType<VariableDeclaratorSyntax>())
+        {
+            if (declarator.Initializer == null || declarator.SpanStart >= boundary) continue;
+            if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetDeclaredSymbol(declarator, cancellationToken), local)) continue;
+
+            UpdateBest(declarator.Initializer.Value, declarator.SpanStart);
+        }
+
+        foreach (var assignment in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (!assignment.IsKind(SyntaxKind.SimpleAssignmentExpression) || assignment.SpanStart >= boundary) continue;
+
+            var target = semanticModel.GetOperation(assignment.Left, cancellationToken)?.UnwrapConversions();
+            if (target is not ILocalReferenceOperation localReference ||
+                !SymbolEqualityComparer.Default.Equals(localReference.Local, local))
+            {
+                continue;
+            }
+
+            UpdateBest(assignment.Right, assignment.SpanStart);
+        }
+
+        foreach (var forEach in root.DescendantNodes().OfType<ForEachStatementSyntax>())
+        {
+            if (!forEach.Span.Contains(boundary) || forEach.Expression.SpanStart >= boundary) continue;
+            if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetDeclaredSymbol(forEach, cancellationToken), local)) continue;
+
+            UpdateBest(forEach.Expression, forEach.Expression.SpanStart);
+        }
+
+        return bestInvocation;
+
+        void UpdateBest(ExpressionSyntax expression, int position)
+        {
+            if (position < bestPosition) return;
+
+            var invocation = FindAsNoTrackingInvocation(expression);
+            bestPosition = position;
+            bestInvocation = invocation;
+        }
+    }
+
+    private static InvocationExpressionSyntax? FindAsNoTrackingInvocation(ExpressionSyntax expression)
+    {
+        return expression.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>()
+            .FirstOrDefault(invocation =>
+                invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Name.Identifier.ValueText == "AsNoTracking" &&
+                invocation.ArgumentList.Arguments.Count == 0);
     }
 }

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.4</Version>
+        <Version>5.2.5</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateTests.cs
@@ -17,12 +17,16 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class DbContext { 
         public void Update(object entity) { }
+        public void UpdateRange(IEnumerable<object> entities) { }
         public void Remove(object entity) { }
+        public void RemoveRange(IEnumerable<object> entities) { }
     }
     public class DbSet<TEntity> : IQueryable<TEntity> where TEntity : class
     {
         public void Update(TEntity entity) { }
+        public void UpdateRange(IEnumerable<TEntity> entities) { }
         public void Remove(TEntity entity) { }
+        public void RemoveRange(IEnumerable<TEntity> entities) { }
         public Type ElementType => typeof(TEntity);
         public System.Linq.Expressions.Expression Expression => null;
         public IQueryProvider Provider => null;
@@ -103,6 +107,84 @@ namespace LinqContraband.Test
     }
 
     [Fact]
+    public async Task Fixer_ShouldRemoveAsNoTrackingFromAssignment()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            User user;
+            user = users.AsNoTracking().FirstOrDefault(x => x.Id == 1);
+            users.Update({|LC025:user|});
+        }
+    }
+}";
+
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            User user;
+            user = users.FirstOrDefault(x => x.Id == 1);
+            users.Update(user);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldRemoveAsNoTrackingFromForeachCollection()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            foreach (var user in users.AsNoTracking().Where(x => x.Id > 0).ToList())
+            {
+                users.Remove({|LC025:user|});
+            }
+        }
+    }
+}";
+
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            foreach (var user in users.Where(x => x.Id > 0).ToList())
+            {
+                users.Remove(user);
+            }
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
     public async Task AsNoTracking_ThenRemove_ShouldTriggerLC025()
     {
         var test = @"using Microsoft.EntityFrameworkCore;
@@ -116,6 +198,93 @@ namespace LinqContraband.Test
         {
             var user = users.AsNoTracking().First();
             users.Remove({|LC025:user|});
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsNoTrackingCollection_ThenUpdateRange_ShouldTriggerLC025()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            var batch = users.AsNoTracking().Where(x => x.Id > 0).ToList();
+            users.UpdateRange({|LC025:batch|});
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NoTrackingAssignmentAfterUpdate_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            var user = users.FirstOrDefault(x => x.Id == 1);
+            users.Update(user);
+            user = users.AsNoTracking().FirstOrDefault(x => x.Id == 2);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ReassignedToTrackedQueryBeforeUpdate_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            var user = users.AsNoTracking().FirstOrDefault(x => x.Id == 1);
+            user = users.FirstOrDefault(x => x.Id == 2);
+            users.Update(user);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task MaterializedFromNoTrackingQueryAlias_ShouldTriggerLC025()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            var query = users.AsNoTracking().Where(x => x.Id > 0);
+            var user = query.FirstOrDefault();
+            users.Update({|LC025:user|});
         }
     }
 }";


### PR DESCRIPTION
## Summary
- harden LC025 order-aware local-origin analysis for no-tracking write paths
- add query-alias, range-call, reassignment, assignment-fixer, and foreach-fixer coverage
- update LC025 docs/sample, analyzer-health, changelog, and bump v5.2.5

## Impact
This improves analyzer precision by catching high-impact no-tracking write cases while avoiding false positives from later or superseded assignments.

## Validation
- focused LC025 net10 test slice passed with 14 tests
- catalog doc check passed
- sample diagnostics verifier passed for net10.0 with 43 diagnostic paths
- local net10 test run passed with 594 tests
- git diff --check clean
- CI covers full .NET 8/9/10 when local runtimes are unavailable