### PR TITLE
Harden LC005 fixer coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.6] - 2026-04-24
+
+### Changed
+- Hardened the `LC005` fixer so explicit generic `OrderBy<TSource, TKey>(...)` calls keep their type arguments when rewritten to `ThenBy<TSource, TKey>(...)`
+- Added dedicated `LC005` fixer coverage for explicit generic calls and descending sort chains
+- Refreshed `LC005` docs and analyzer-health status to reflect the tighter fixer contract
+
 ## [5.2.5] - 2026-04-24
 
 ### Changed

--- a/docs/LC005_MultipleOrderBy.md
+++ b/docs/LC005_MultipleOrderBy.md
@@ -13,12 +13,14 @@ var users = db.Users.OrderBy(u => u.Name).OrderBy(u => u.Age).ToList();
 ```
 
 ### The Fix
-Use `ThenBy`.
+Use `ThenBy` or `ThenByDescending` for the second and later sort keys.
 
 ```csharp
 // Correct: Sorts by Name, then by Age for ties.
 var users = db.Users.OrderBy(u => u.Name).ThenBy(u => u.Age).ToList();
 ```
+
+The code fix rewrites only the later resetting sort call, preserving the selector and any explicit generic type arguments.
 
 ## Analyzer Logic
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -25,7 +25,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC002 | Premature query continuation after materialization | Materialization & Projection | Warning | 5 | 4 | 5 | 5 | 5 | 5 | Low | Strong analyzer/fixer/test depth; good model for complex performance rules. |
 | LC003 | Prefer Any() over Count() existence checks | Materialization & Projection | Warning | 5 | 5 | 5 | 5 | 4 | 4 | Low | Mature rule with broad edge-case and fixer coverage. |
 | LC004 | IQueryable passed as IEnumerable | Query Shape & Translation | Warning | 5 | 4 | 4 | 4 | 5 | 4 | Low | Strong semantic implementation; keep watching for intentional API-boundary cases. |
-| LC005 | Multiple OrderBy calls | Query Shape & Translation | Warning | 4 | 4 | 3 | 3 | 4 | 3 | Medium | Analyzer is straightforward; add explicit fixer tests to raise confidence. |
+| LC005 | Multiple OrderBy calls | Query Shape & Translation | Warning | 4 | 4 | 4 | 4 | 4 | 3 | Low | Fixer coverage now includes explicit generic calls and descending chained sorts while preserving typed method syntax. |
 | LC006 | Multiple collection Includes | Loading & Includes | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | Useful high-impact EF performance rule; fixer to `AsSplitQuery` is appropriately conservative. |
 | LC007 | Database execution inside loop | Execution & Async | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Excellent rule with clear ignored cases and conservative explicit-loading fixer behavior. |
 | LC008 | Synchronous EF method in async context | Execution & Async | Warning | 5 | 4 | 4 | 5 | 4 | 4 | Low | Strong coverage including edge cases; keep async API mapping current. |
@@ -84,6 +84,6 @@ The next improvement batch should focus on rules that combine high importance wi
 
 `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` currently verifies 43 diagnostic paths.
 
-`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 594 passing tests.
+`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 596 passing tests.
 
 `dotnet --list-runtimes` currently shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC005_MultipleOrderBy/MultipleOrderByFixer.cs
+++ b/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC005_MultipleOrderBy/MultipleOrderByFixer.cs
@@ -53,7 +53,7 @@ public class MultipleOrderByFixer : CodeFixProvider
         var methodName = memberAccess.Name.Identifier.Text;
         var newMethodName = methodName == "OrderBy" ? "ThenBy" : "ThenByDescending";
 
-        var newName = SyntaxFactory.IdentifierName(newMethodName);
+        var newName = CreateReplacementName(memberAccess.Name, newMethodName);
         var newMemberAccess = memberAccess.WithName(newName);
         var newInvocation = invocation.WithExpression(newMemberAccess);
 
@@ -62,5 +62,20 @@ public class MultipleOrderByFixer : CodeFixProvider
 
         var newRoot = root.ReplaceNode(invocation, newInvocation);
         return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static SimpleNameSyntax CreateReplacementName(SimpleNameSyntax originalName, string newMethodName)
+    {
+        var identifier = SyntaxFactory.Identifier(
+            originalName.Identifier.LeadingTrivia,
+            newMethodName,
+            originalName.Identifier.TrailingTrivia);
+
+        return originalName switch
+        {
+            GenericNameSyntax genericName => genericName.WithIdentifier(identifier),
+            IdentifierNameSyntax identifierName => identifierName.WithIdentifier(identifier),
+            _ => SyntaxFactory.IdentifierName(identifier).WithTriviaFrom(originalName)
+        };
     }
 }

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.5</Version>
+        <Version>5.2.6</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC005_MultipleOrderBy/MultipleOrderByFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC005_MultipleOrderBy/MultipleOrderByFixerTests.cs
@@ -1,0 +1,72 @@
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+    LinqContraband.Analyzers.LC005_MultipleOrderBy.MultipleOrderByAnalyzer,
+    LinqContraband.Analyzers.LC005_MultipleOrderBy.MultipleOrderByFixer>;
+
+namespace LinqContraband.Tests.Analyzers.LC005_MultipleOrderBy;
+
+public class MultipleOrderByFixerTests
+{
+    [Fact]
+    public async Task ExplicitGenericOrderBy_PreservesTypeArguments()
+    {
+        var test = @"
+using System.Linq;
+using System.Collections.Generic;
+
+class Test
+{
+    void Method(List<int> list)
+    {
+        var q = list.OrderBy<int, int>(x => x).{|LC005:OrderBy<int, int>|}(x => x);
+    }
+}";
+        var fix = @"
+using System.Linq;
+using System.Collections.Generic;
+
+class Test
+{
+    void Method(List<int> list)
+    {
+        var q = list.OrderBy<int, int>(x => x).ThenBy<int, int>(x => x);
+    }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(test, fix);
+    }
+
+    [Fact]
+    public async Task ThenByDescendingOrderByDescending_RewritesToThenByDescending()
+    {
+        var test = @"
+using System.Linq;
+using System.Collections.Generic;
+
+class Test
+{
+    void Method(List<int> list)
+    {
+        var q = list
+            .OrderBy(x => x)
+            .ThenByDescending(x => x)
+            .{|LC005:OrderByDescending|}(x => x);
+    }
+}";
+        var fix = @"
+using System.Linq;
+using System.Collections.Generic;
+
+class Test
+{
+    void Method(List<int> list)
+    {
+        var q = list
+            .OrderBy(x => x)
+            .ThenByDescending(x => x)
+            .ThenByDescending(x => x);
+    }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(test, fix);
+    }
+}


### PR DESCRIPTION
## Summary
- harden LC005 fixer rewriting so explicit generic OrderBy calls preserve type arguments
- add dedicated LC005 fixer coverage for explicit generic calls and descending sort chains
- update LC005 docs/analyzer-health and bump v5.2.6

## Impact
This improves analyzer precision by keeping the LC005 code fix syntax-preserving for typed LINQ calls while expanding confidence around chained sort rewrites.

## Validation
- `/opt/homebrew/bin/dotnet restore LinqContraband.sln`
- `/opt/homebrew/bin/dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check`
- `PATH="/opt/homebrew/bin:$PATH" /opt/homebrew/bin/dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0`
- `PATH="/opt/homebrew/bin:$PATH" /opt/homebrew/bin/dotnet test LinqContraband.sln --no-restore --framework net10.0` (596 passed)
- `git diff --check`

CI covers full .NET 8/9/10 because local runtimes only include .NET 10.