### PR TITLE
Harden LC023 async finder fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.8] - 2026-04-26
+
+### Changed
+- Hardened the `LC023` fixer so awaited async primary-key lookups with explicit cancellation tokens rewrite to the token-preserving `FindAsync(object[] keyValues, CancellationToken)` overload
+- Suppressed unsafe `LC023` async fixes when the original call is not awaited, avoiding `Task<T>` to `ValueTask<T>` return-shape changes
+- Refreshed `LC023` docs and analyzer-health status to describe the safer fixer contract
+
 ## [5.2.7] - 2026-04-24
 
 ### Changed

--- a/docs/LC023_FindInsteadOfFirstOrDefault.md
+++ b/docs/LC023_FindInsteadOfFirstOrDefault.md
@@ -1,60 +1,47 @@
-# Spec: LC023 - Suggest Find/FindAsync for Primary Key Lookups
+# LC023 - Use Find/FindAsync for Primary Key Lookups
 
 ## Goal
-Detect usage of `FirstOrDefault(x => x.Id == id)` or `SingleOrDefault(x => x.Id == id)` and suggest using `Find(id)` or `FindAsync(id)` instead.
 
-## The Problem
-`FirstOrDefault` always executes a database query. In contrast, `Find` first checks the local change tracker. If the entity is already loaded, `Find` returns it without hitting the database. This can provide a significant performance boost in scenarios where the same entity is requested multiple times in the same context (e.g., in a complex transaction or nested logic).
+Suggest `Find(...)` or `FindAsync(...)` when a query directly looks up a `DbSet` entity by its primary key with `FirstOrDefault`, `SingleOrDefault`, `FirstOrDefaultAsync`, or `SingleOrDefaultAsync`.
 
-### Example Violation
+## Why It Matters
+
+`FirstOrDefault` and `SingleOrDefault` always execute a query. `Find` first checks the EF Core change tracker and can return an already-loaded entity without another database round trip.
+
+## Violation
+
 ```csharp
-// Violation: Always hits the database
-var user = db.Users.FirstOrDefault(u => u.Id == userId);
+var user = db.Users.FirstOrDefault(user => user.Id == userId);
 ```
 
-### The Fix
-Use `Find()` or `FindAsync()`.
+## Preferred
 
 ```csharp
-// Correct: Checks local cache first
 var user = db.Users.Find(userId);
 ```
 
-## Analyzer Logic
+For awaited async lookups, the fixer preserves explicit cancellation tokens by using EF Core's token-aware overload:
 
-### ID: `LC023`
-### Category: `Performance`
-### Severity: `Info`
-
-### Algorithm
-1.  **Target Methods**: Intercept invocations of:
-    -   `FirstOrDefault`, `FirstOrDefaultAsync`
-    -   `SingleOrDefault`, `SingleOrDefaultAsync`
-2.  **Receiver Check**: Ensure it's called directly on a `DbSet`.
-3.  **Predicate Analysis**: 
-    -   Check if the method has a lambda predicate.
-    -   Analyze the predicate to see if it's a simple equality check: `x => x.PrimaryKey == someValue`.
-    -   Use `AnalysisExtensions.TryFindPrimaryKey` to identify the primary key property.
-4.  **Exceptions**:
-    -   If the query has other operators like `Include`, `AsNoTracking`, etc., `Find` cannot be used directly as it returns the tracked entity and doesn't support fluent chaining in the same way.
-    -   *Constraint*: Only suggest if the chain is `db.Entities.FirstOrDefault(...)`.
-
-## Test Cases
-
-### Violations
 ```csharp
-db.Users.FirstOrDefault(x => x.Id == 1);
-db.Users.SingleOrDefaultAsync(x => x.Id == id);
+var user = await db.Users.FindAsync(new object[] { userId }, cancellationToken);
 ```
 
-### Valid
-```csharp
-db.Users.Find(1);
-db.Users.Include(x => x.Profile).FirstOrDefault(x => x.Id == 1); // Complex query, Find not suitable
-db.Users.AsNoTracking().FirstOrDefault(x => x.Id == 1); // Find always tracks
-```
+## Analyzer Behavior
 
-## Implementation Plan
-1.  Create `LC023_FindInsteadOfFirstOrDefault` directory.
-2.  Implement `FindInsteadOfFirstOrDefaultAnalyzer`.
-3.  Implement tests.
+`LC023` reports only when all of these are true:
+
+- The method is `FirstOrDefault`, `SingleOrDefault`, `FirstOrDefaultAsync`, or `SingleOrDefaultAsync`.
+- The receiver is directly a `DbSet<TEntity>`.
+- The predicate is a simple equality check against the entity primary key convention or `[Key]` property.
+
+The analyzer intentionally stays silent for chained queries such as `AsNoTracking()`, `Include(...)`, `Where(...)`, and other shapes where replacing the materializer with `Find` would change tracking, includes, filters, or return semantics.
+
+## Fixer Behavior
+
+The code fix rewrites simple synchronous lookups to `Find(key)` and awaited async lookups to `FindAsync(key)`.
+
+When the awaited async lookup passes an explicit cancellation token, the fixer rewrites to `FindAsync(new object[] { key }, cancellationToken)` so the token is preserved. The fixer does not rewrite non-awaited async calls because EF Core `FindAsync` returns `ValueTask<TEntity?>`, which can be incompatible with a call site expecting `Task<TEntity?>`.
+
+## Non-Goals
+
+`LC023` does not infer composite keys, Fluent API key configuration, or provider-specific behavior beyond the repository's primary-key helper. Those shapes should be handled manually unless future analyzer metadata can prove the rewrite is safe.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-04-24
+Reviewed: 2026-04-26
 
 This is an actionable health audit for the 44 analyzers in `RuleCatalog`. The current catalog declares 30 rules with code fixes and 14 rules as manual-only with explicit rationale. Scores are 1-5, where `5` is excellent, `3` is usable with gaps, and `1` needs urgent attention.
 
@@ -43,7 +43,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC020 | Untranslatable string comparison overloads | Query Shape & Translation | Warning | 4 | 4 | 3 | 3 | 4 | 4 | Medium | Add explicit fixer tests and provider translation edge cases. |
 | LC021 | IgnoreQueryFilters usage | Raw SQL & Security | Warning | 4 | 3 | 4 | 3 | 4 | 4 | Medium | Intentional bypasses can be valid; consider suppression/allow-list guidance and more negative tests. |
 | LC022 | ToList/ToArray inside Select projection | Materialization & Projection | Warning | 4 | 4 | 3 | 4 | 4 | 4 | Medium | Analyzer coverage is decent; add dedicated fixer tests if fixer behavior is meant to be supported. |
-| LC023 | Prefer Find/FindAsync for primary key lookups | Materialization & Projection | Info | 3 | 3 | 3 | 3 | 4 | 3 | Medium | Useful but schema-sensitive; add fixer tests and more composite-key/provider edge cases. |
+| LC023 | Prefer Find/FindAsync for primary key lookups | Materialization & Projection | Info | 3 | 4 | 4 | 4 | 5 | 3 | Low | Fixer now preserves awaited async cancellation tokens and avoids unsafe non-awaited async rewrites; revisit composite-key metadata only if stronger model analysis is added. |
 | LC024 | GroupBy with non-translatable projection | Query Shape & Translation | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Reference-quality manual rule with aggregate-only exclusions, helper/string-comparison/object-construction coverage, nested projection tests, and LINQ-to-Objects boundary coverage. |
 | LC025 | AsNoTracking with Update/Remove | Change Tracking & Context Lifetime | Warning | 5 | 5 | 4 | 5 | 5 | 4 | Low | Hardened with order-aware local origin tracking, query-alias and range-call coverage, assignment/foreach fixer tests, and refreshed docs/sample guidance. |
 | LC026 | Missing CancellationToken in async call | Execution & Async | Info | 4 | 4 | 5 | 5 | 4 | 3 | Low | Hardened fixer coverage for omitted, preferred-name, local, default-token, named-default, and `CancellationToken.None` call shapes. |
@@ -72,9 +72,9 @@ The next improvement batch should focus on rules that combine high importance wi
 
 | Priority | Rules | Work |
 | --- | --- | --- |
-| Medium | LC023, LC027, LC041 | Expand existing fixer coverage for schema-sensitive and subtle projection/tracking rewrites. |
+| Medium | LC027, LC041 | Expand existing fixer coverage for schema-sensitive and subtle projection/tracking rewrites. |
 | Medium | LC019, LC028, LC031, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
-| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC024, LC025, LC026, LC030, LC034, LC035, LC036, LC037, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
+| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC023, LC024, LC025, LC026, LC030, LC034, LC035, LC036, LC037, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
 
 ## Verification Baseline
 
@@ -84,6 +84,6 @@ The next improvement batch should focus on rules that combine high importance wi
 
 `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` currently verifies 43 diagnostic paths.
 
-`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 599 passing tests.
+`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 601 passing tests.
 
 `dotnet --list-runtimes` currently shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultFixer.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultFixer.cs
@@ -3,12 +3,14 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace LinqContraband.Analyzers.LC023_FindInsteadOfFirstOrDefault;
 
@@ -38,22 +40,29 @@ public class FindInsteadOfFirstOrDefaultFixer : CodeFixProvider
         var invocation = token.Parent.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
         if (invocation == null) return;
 
-        if (!await CanApplyFixAsync(context.Document, invocation, context.CancellationToken).ConfigureAwait(false))
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel == null)
+            return;
+
+        if (!TryCreateFixContext(invocation, semanticModel, context.CancellationToken, out var fixContext))
             return;
 
         context.RegisterCodeFix(
             CodeAction.Create(
                 "Use Find/FindAsync",
-                c => ApplyFixAsync(context.Document, invocation, c),
+                c => ApplyFixAsync(context.Document, invocation, fixContext, c),
                 "UseFind"),
             diagnostic);
     }
 
-    private static async Task<bool> CanApplyFixAsync(
-        Document document,
+    private static bool TryCreateFixContext(
         InvocationExpressionSyntax invocation,
-        CancellationToken cancellationToken)
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        out FixContext fixContext)
     {
+        fixContext = null!;
+
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
             return false;
 
@@ -61,65 +70,155 @@ public class FindInsteadOfFirstOrDefaultFixer : CodeFixProvider
         if (methodName is not ("FirstOrDefault" or "SingleOrDefault" or "FirstOrDefaultAsync" or "SingleOrDefaultAsync"))
             return false;
 
-        if (invocation.ArgumentList.Arguments.Count == 0)
+        if (semanticModel.GetOperation(invocation, cancellationToken) is not IInvocationOperation operation)
             return false;
 
-        if (invocation.ArgumentList.Arguments[0].Expression is not LambdaExpressionSyntax lambda)
+        if (!operation.GetInvocationReceiverType().IsDbSet())
             return false;
 
-        if (lambda.Body is not BinaryExpressionSyntax binary || !binary.IsKind(SyntaxKind.EqualsExpression))
+        var isAsync = methodName.EndsWith("Async");
+        if (isAsync && !IsAwaited(invocation))
             return false;
 
-        if (binary.Left is not MemberAccessExpressionSyntax && binary.Right is not MemberAccessExpressionSyntax)
+        var predicateArgument = operation.Arguments
+            .FirstOrDefault(argument => argument.Value.UnwrapConversions() is IAnonymousFunctionOperation);
+        if (predicateArgument == null || predicateArgument.Syntax is not ArgumentSyntax predicateSyntax)
             return false;
 
-        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-        if (semanticModel == null)
-            return false;
-
-        return semanticModel.GetTypeInfo(memberAccess.Expression, cancellationToken).Type?.Name == "DbSet";
-    }
-
-    private async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
-    {
-        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-
-        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-            invocation.ArgumentList.Arguments.Count > 0)
+        if (predicateSyntax.Expression is not LambdaExpressionSyntax lambda ||
+            lambda.Body is not BinaryExpressionSyntax binary ||
+            !binary.IsKind(SyntaxKind.EqualsExpression))
         {
-            var firstArg = invocation.ArgumentList.Arguments[0].Expression;
-            if (firstArg is LambdaExpressionSyntax lambda)
-            {
-                ExpressionSyntax? valueExpression = null;
-                if (lambda.Body is BinaryExpressionSyntax binary && binary.IsKind(SyntaxKind.EqualsExpression))
-                {
-                    // Basic logic: if left is property access, right is the value (or vice versa)
-                    // The analyzer already verified it's a PK equality.
-                    if (binary.Left is MemberAccessExpressionSyntax)
-                        valueExpression = binary.Right;
-                    else
-                        valueExpression = binary.Left;
-                }
-
-                if (valueExpression != null)
-                {
-                    var methodName = memberAccess.Name.Identifier.Text;
-                    var isAsync = methodName.EndsWith("Async");
-                    var newMethodName = isAsync ? "FindAsync" : "Find";
-
-                    var newMemberAccess = memberAccess.WithName(SyntaxFactory.IdentifierName(newMethodName));
-                    var newArguments = SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(valueExpression)));
-
-                    var newInvocation = SyntaxFactory.InvocationExpression(newMemberAccess, newArguments)
-                        .WithLeadingTrivia(invocation.GetLeadingTrivia())
-                        .WithTrailingTrivia(invocation.GetTrailingTrivia());
-
-                    editor.ReplaceNode(invocation, newInvocation);
-                }
-            }
+            return false;
         }
 
+        if (!TryGetKeyValueExpression(binary, semanticModel, cancellationToken, out var valueExpression))
+            return false;
+
+        var cancellationTokenArgument = operation.Arguments
+            .FirstOrDefault(argument => IsCancellationTokenParameter(argument.Parameter));
+
+        var tokenSyntax = cancellationTokenArgument?.Syntax as ArgumentSyntax;
+        fixContext = new FixContext(methodName, valueExpression, tokenSyntax);
+        return true;
+    }
+
+    private async Task<Document> ApplyFixAsync(
+        Document document,
+        InvocationExpressionSyntax invocation,
+        FixContext fixContext,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return document;
+
+        var newMethodName = fixContext.IsAsync ? "FindAsync" : "Find";
+        var newMemberAccess = memberAccess.WithName(SyntaxFactory.IdentifierName(newMethodName));
+        var newArguments = CreateFindArgumentList(fixContext);
+
+        var newInvocation = SyntaxFactory.InvocationExpression(newMemberAccess, newArguments)
+            .WithLeadingTrivia(invocation.GetLeadingTrivia())
+            .WithTrailingTrivia(invocation.GetTrailingTrivia());
+
+        editor.ReplaceNode(invocation, newInvocation);
         return editor.GetChangedDocument();
+    }
+
+    private static bool TryGetKeyValueExpression(
+        BinaryExpressionSyntax binary,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        out ExpressionSyntax valueExpression)
+    {
+        if (IsPrimaryKeyAccess(binary.Left, semanticModel, cancellationToken))
+        {
+            valueExpression = binary.Right.WithoutTrivia();
+            return true;
+        }
+
+        if (IsPrimaryKeyAccess(binary.Right, semanticModel, cancellationToken))
+        {
+            valueExpression = binary.Left.WithoutTrivia();
+            return true;
+        }
+
+        valueExpression = null!;
+        return false;
+    }
+
+    private static bool IsPrimaryKeyAccess(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        var operation = semanticModel.GetOperation(expression, cancellationToken)?.UnwrapConversions();
+        if (operation is not IPropertyReferenceOperation propertyReference)
+            return false;
+
+        return propertyReference.Instance?.UnwrapConversions() is IParameterReferenceOperation &&
+               propertyReference.Property.ContainingType.TryFindPrimaryKey() == propertyReference.Property.Name;
+    }
+
+    private static ArgumentListSyntax CreateFindArgumentList(FixContext fixContext)
+    {
+        if (!fixContext.IsAsync || fixContext.CancellationTokenArgument == null)
+        {
+            return SyntaxFactory.ArgumentList(
+                SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(fixContext.KeyValueExpression)));
+        }
+
+        var keyArray = SyntaxFactory.ArrayCreationExpression(
+            SyntaxFactory.ArrayType(
+                SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword)),
+                SyntaxFactory.SingletonList(
+                    SyntaxFactory.ArrayRankSpecifier(
+                        SyntaxFactory.SingletonSeparatedList<ExpressionSyntax>(
+                            SyntaxFactory.OmittedArraySizeExpression())))),
+            SyntaxFactory.InitializerExpression(
+                SyntaxKind.ArrayInitializerExpression,
+                SyntaxFactory.SingletonSeparatedList(fixContext.KeyValueExpression)));
+
+        return SyntaxFactory.ArgumentList(
+            SyntaxFactory.SeparatedList(new[]
+            {
+                SyntaxFactory.Argument(keyArray),
+                fixContext.CancellationTokenArgument.WithoutTrivia()
+            }));
+    }
+
+    private static bool IsAwaited(SyntaxNode node)
+    {
+        for (var current = node.Parent; current != null; current = current.Parent)
+        {
+            if (current is AwaitExpressionSyntax)
+                return true;
+
+            if (current is ParenthesizedExpressionSyntax)
+                continue;
+
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool IsCancellationTokenParameter(IParameterSymbol? parameter)
+    {
+        return parameter?.Type.Name == nameof(CancellationToken) &&
+               parameter.Type.ContainingNamespace?.ToString() == "System.Threading";
+    }
+
+    private sealed class FixContext
+    {
+        public FixContext(string methodName, ExpressionSyntax keyValueExpression, ArgumentSyntax? cancellationTokenArgument)
+        {
+            IsAsync = methodName.EndsWith("Async");
+            KeyValueExpression = keyValueExpression;
+            CancellationTokenArgument = cancellationTokenArgument;
+        }
+
+        public bool IsAsync { get; }
+
+        public ExpressionSyntax KeyValueExpression { get; }
+
+        public ArgumentSyntax? CancellationTokenArgument { get; }
     }
 }

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.7</Version>
+        <Version>5.2.8</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore
     {
         public TEntity Find(params object[] keyValues) => null;
         public ValueTask<TEntity> FindAsync(params object[] keyValues) => default;
+        public ValueTask<TEntity> FindAsync(object[] keyValues, CancellationToken cancellationToken) => default;
 
         public Type ElementType => typeof(TEntity);
         public Expression Expression => null;
@@ -147,6 +148,66 @@ namespace LinqContraband.Test
 }";
 
         await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldPreserveCancellationTokenWhenReplacingAwaitedAsyncLookup()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public async Task TestMethod(DbSet<User> users, int userId, CancellationToken cancellationToken)
+        {
+            var result = await {|LC023:users.FirstOrDefaultAsync(x => x.Id == userId, cancellationToken)|};
+        }
+    }
+}";
+
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public async Task TestMethod(DbSet<User> users, int userId, CancellationToken cancellationToken)
+        {
+            var result = await users.FindAsync(new object[] { userId }, cancellationToken);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldNotRewriteAsyncLookupWhenCallIsNotAwaited()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public Task<User> TestMethod(DbSet<User> users, int userId, CancellationToken cancellationToken)
+        {
+            return {|LC023:users.SingleOrDefaultAsync(x => x.Id == userId, cancellationToken)|};
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, test);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- harden LC023 async fixer behavior around awaited `FindAsync` rewrites
- preserve explicit cancellation tokens with the token-aware `FindAsync(object[] keyValues, CancellationToken)` overload
- update LC023 tests/docs/analyzer-health and bump v5.2.8

## Impact
This improves fixer precision by avoiding cancellation-token loss and suppressing async fixes that would change an unawaited `Task<T>` call shape to `ValueTask<T>`.

## Validation
- local net10 focused LC023 test run passed with 9 tests
- local net10 full test run passed with 601 tests
- rule catalog docs check passed
- sample diagnostics verifier passed for net10.0
- git diff --check clean
- CI covers full .NET 8/9/10 when local runtimes are unavailable