### PR TITLE
Harden LC041 scalar projection fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.9] - 2026-04-26
+
+### Changed
+- Hardened `LC041` so entity property writes and entity escape patterns are not treated as safe single-scalar consumption
+- Narrowed the `LC041` fixer to `First`/`Single` materializers, avoiding unsafe `*OrDefault` rewrites that can change no-row/null behavior
+- Expanded `LC041` analyzer and fixer coverage and refreshed docs/analyzer-health status to describe the safer projection contract
+
 ## [5.2.8] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1408,8 +1408,9 @@ return await db.Users
 ```
 
 **🛡️ Reliability Notes:**
-- LC041 only fixes analyzer-proven single-property usages.
-- The fixer currently targets guarded `var` local patterns and stays silent on escape-heavy or shape-changing cases.
+- LC041 only reports analyzer-proven single-property reads and ignores entity escapes or property writes.
+- The fixer targets guarded `var` local patterns with `First`/`Single` materializers.
+- `*OrDefault` diagnostics stay manual-only because projecting first can change no-row/null behavior.
 
 ---
 

--- a/docs/LC041_SingleEntityScalarProjection.md
+++ b/docs/LC041_SingleEntityScalarProjection.md
@@ -8,18 +8,18 @@ Calling `First*` or `Single*` to fetch a whole row and then reading one property
 
 ### Example Violation
 ```csharp
-var user = db.Users.FirstOrDefault(u => u.IsActive);
+var user = db.Users.First(u => u.IsActive);
 Console.WriteLine(user.Name);
 ```
 
 ### The Fix
-Project the consumed property before materializing.
+Project the consumed property before materializing when the materializer preserves no-row semantics.
 
 ```csharp
 var user = db.Users
     .Where(u => u.IsActive)
     .Select(u => u.Name)
-    .FirstOrDefault();
+    .First();
 Console.WriteLine(user);
 ```
 
@@ -30,4 +30,6 @@ Console.WriteLine(user);
 ### Severity: `Info`
 
 ### Notes
-The fixer is intentionally guarded. It appears only for `var` locals whose downstream usage is proven to be a single scalar property read.
+The analyzer reports only when a `var` local is consumed through one scalar property read in the same executable scope. It stays silent when the entity escapes, multiple properties are read, or the property is written.
+
+The fixer is intentionally narrower than the analyzer. It appears for `First`, `FirstAsync`, `Single`, and `SingleAsync` because those rewrites preserve no-row behavior. It does not rewrite `FirstOrDefault`, `FirstOrDefaultAsync`, `SingleOrDefault`, or `SingleOrDefaultAsync`; projecting before those calls can turn an entity-null property access into a scalar default/null value instead of preserving the original runtime behavior.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -61,7 +61,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC038 | Excessive eager loading | Loading & Includes | Info | 3 | 3 | 5 | 3 | 4 | 3 | Medium | Heuristic rule; add threshold documentation and more examples of legitimate deep loads. |
 | LC039 | Repeated SaveChanges on same context | Change Tracking & Context Lifetime | Info | 4 | 4 | 5 | 3 | 4 | 4 | Medium | Useful reliability smell; add more transaction, branch, and intentional boundary tests. |
 | LC040 | Mixed tracking and no-tracking modes | Change Tracking & Context Lifetime | Info | 4 | 4 | 5 | 3 | 4 | 4 | Medium | Manual-only is appropriate; add broader context-resolution and split-workflow tests. |
-| LC041 | Single entity over-fetches one consumed property | Materialization & Projection | Info | 4 | 4 | 3 | 3 | 4 | 3 | Medium | Useful but subtle; add explicit fixer tests and more multi-use/side-effect negative cases. |
+| LC041 | Single entity over-fetches one consumed property | Materialization & Projection | Info | 5 | 5 | 4 | 5 | 5 | 3 | Low | Hardened around entity escapes, property writes, and `*OrDefault` no-fix boundaries while keeping the projection fixer narrow. |
 | LC042 | Complex query should be tagged | Loading & Includes | Info | 3 | 3 | 5 | 3 | 4 | 2 | Low | Team-policy rule; low importance unless observability standards require tags. |
 | LC043 | Prefer await foreach over buffering async streams | Execution & Async | Info | 4 | 4 | 4 | 4 | 4 | 3 | Low | Hardened narrow fixer behavior around cancellation-token arguments and reused buffers. |
 | LC044 | AsNoTracking entity mutated then SaveChanges | Change Tracking & Context Lifetime | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Excellent high-impact data-loss rule with strong edge-case coverage and clear manual guidance. |
@@ -72,9 +72,9 @@ The next improvement batch should focus on rules that combine high importance wi
 
 | Priority | Rules | Work |
 | --- | --- | --- |
-| Medium | LC027, LC041 | Expand existing fixer coverage for schema-sensitive and subtle projection/tracking rewrites. |
+| Medium | LC027 | Expand existing fixer coverage for schema-sensitive rewrites. |
 | Medium | LC019, LC028, LC031, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
-| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC023, LC024, LC025, LC026, LC030, LC034, LC035, LC036, LC037, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
+| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC023, LC024, LC025, LC026, LC030, LC034, LC035, LC036, LC037, LC041, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
 
 ## Verification Baseline
 
@@ -84,6 +84,6 @@ The next improvement batch should focus on rules that combine high importance wi
 
 `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` currently verifies 43 diagnostic paths.
 
-`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 601 passing tests.
+`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 605 passing tests.
 
 `dotnet --list-runtimes` currently shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionFixer.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionFixer.cs
@@ -48,6 +48,9 @@ public sealed class SingleEntityScalarProjectionFixer : CodeFixProvider
         if (!TryGetFixContext(invocation, semanticModel, out var fixContext))
             return;
 
+        if (!IsSafeFixMaterializer(invocation))
+            return;
+
         if (!fixContext.IsVarDeclaration)
             return;
 
@@ -57,6 +60,15 @@ public sealed class SingleEntityScalarProjectionFixer : CodeFixProvider
                 c => ApplyFixAsync(context.Document, invocation, fixContext, c),
                 "ProjectConsumedScalar"),
             diagnostic);
+    }
+
+    private static bool IsSafeFixMaterializer(InvocationExpressionSyntax invocation)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return false;
+
+        var methodName = memberAccess.Name.Identifier.Text;
+        return methodName is "First" or "FirstAsync" or "Single" or "SingleAsync";
     }
 
     private static async Task<Document> ApplyFixAsync(

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionUsageAnalysis.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionUsageAnalysis.cs
@@ -59,6 +59,9 @@ public sealed partial class SingleEntityScalarProjectionAnalyzer
             if (!ReferenceEquals(propertyReference.Instance?.UnwrapConversions(), localReference))
                 return false;
 
+            if (!IsReadOnlyPropertyReference(propertyReference))
+                return false;
+
             if (!IsScalarLikeType(propertyReference.Property.Type))
                 return false;
 
@@ -70,6 +73,17 @@ public sealed partial class SingleEntityScalarProjectionAnalyzer
 
         property = properties.First();
         return true;
+    }
+
+    private static bool IsReadOnlyPropertyReference(IPropertyReferenceOperation propertyReference)
+    {
+        return propertyReference.Parent switch
+        {
+            ISimpleAssignmentOperation assignment when ReferenceEquals(assignment.Target, propertyReference) => false,
+            ICompoundAssignmentOperation compoundAssignment when ReferenceEquals(compoundAssignment.Target, propertyReference) => false,
+            IIncrementOrDecrementOperation incrementOrDecrement when ReferenceEquals(incrementOrDecrement.Target, propertyReference) => false,
+            _ => true,
+        };
     }
 
     private static bool IsScalarLikeType(ITypeSymbol? type)

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.8</Version>
+        <Version>5.2.9</Version>
         <Authors>George Wall</Authors>
         <Description>Stop smuggling bad queries into production. LinqContraband is a Roslyn Analyzer that catches EF Core performance killers (client-side evaluation, N+1 queries) at compile time.</Description>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/LinqContraband.Tests/Analyzers/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionTests.cs
@@ -114,7 +114,7 @@ namespace TestApp
     {
         public void Run(DbSet<User> users)
         {
-            var user = {|LC041:users.FirstOrDefault(x => x.IsActive)|};
+            var user = {|LC041:users.First(x => x.IsActive)|};
             System.Console.WriteLine(user.Name);
         }
     }
@@ -134,7 +134,7 @@ namespace TestApp
     {
         public void Run(DbSet<User> users)
         {
-            var user = users.Where(x => x.IsActive).Select(x => x.Name).FirstOrDefault();
+            var user = users.Where(x => x.IsActive).Select(x => x.Name).First();
             System.Console.WriteLine(user);
         }
     }
@@ -161,7 +161,7 @@ namespace TestApp
     {
         public async Task Run(DbSet<User> users)
         {
-            var user = await {|LC041:users.SingleOrDefaultAsync(x => x.IsActive)|};
+            var user = await {|LC041:users.SingleAsync(x => x.IsActive)|};
             System.Console.WriteLine(user.Name.Length);
         }
     }
@@ -182,13 +182,66 @@ namespace TestApp
     {
         public async Task Run(DbSet<User> users)
         {
-            var user = await users.Where(x => x.IsActive).Select(x => x.Name).SingleOrDefaultAsync();
+            var user = await users.Where(x => x.IsActive).Select(x => x.Name).SingleAsync();
             System.Console.WriteLine(user.Length);
         }
     }
 }";
 
         await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task FirstOrDefault_ShouldNotOfferFix()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfCoreMock + @"
+namespace TestApp
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public bool IsActive { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class TestClass
+    {
+        public void Run(DbSet<User> users)
+        {
+            var user = {|LC041:users.FirstOrDefault(x => x.IsActive)|};
+            System.Console.WriteLine(user.Name);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, test);
+    }
+
+    [Fact]
+    public async Task SingleOrDefaultAsync_ShouldNotOfferFix()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;" + EfCoreMock + @"
+namespace TestApp
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public bool IsActive { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class TestClass
+    {
+        public async Task Run(DbSet<User> users)
+        {
+            var user = await {|LC041:users.SingleOrDefaultAsync(x => x.IsActive)|};
+            System.Console.WriteLine(user.Name.Length);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, test);
     }
 
     [Fact]
@@ -238,6 +291,61 @@ namespace TestApp
             System.Console.WriteLine(user.Name);
             System.Console.WriteLine(user.Email);
         }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task PropertyAssignment_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfCoreMock + @"
+namespace TestApp
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public bool IsActive { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class TestClass
+    {
+        public void Run(DbSet<User> users)
+        {
+            var user = users.First(x => x.IsActive);
+            user.Name = ""Updated"";
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task EntityPassedToMethod_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfCoreMock + @"
+namespace TestApp
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public bool IsActive { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class TestClass
+    {
+        public void Run(DbSet<User> users)
+        {
+            var user = users.First(x => x.IsActive);
+            Touch(user);
+            System.Console.WriteLine(user.Name);
+        }
+
+        private static void Touch(User user) { }
     }
 }";
 


### PR DESCRIPTION
## Summary
- harden LC041 usage analysis so property writes and entity escapes do not count as safe scalar-only consumption
- narrow the LC041 fixer to First/Single materializers, leaving *OrDefault diagnostics manual-only to preserve no-row/null behavior
- add LC041 fixer/no-fix coverage, refresh docs/analyzer-health, and bump v5.2.9

## Impact
This improves analyzer precision and prevents the code fix from changing runtime behavior for subtle projection rewrites.

## Validation
- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check`
- `PATH=/opt/homebrew/bin:/usr/local/share/dotnet:$PATH dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter FullyQualifiedName~LC041` passed with 11 tests
- `dotnet test LinqContraband.sln --no-restore --framework net10.0` passed with 605 tests
- `git diff --check`
- CI covers full .NET 8/9/10 because local runtimes currently include only .NET 10