### PR TITLE
Harden LC027 foreign-key fixer and configuration analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.11] - 2026-04-26
+
+### Changed
+- Hardened `LC027` Fluent API configuration analysis so `HasOne(...).WithMany(...).HasForeignKey(...)` suppresses diagnostics for the dependent reference navigation instead of the inverse collection
+- Hardened the `LC027` fixer so optional nullable navigations generate nullable FK properties and non-`int` primary key types are preserved
+- Expanded `LC027` fixer and model-configuration coverage and refreshed docs/analyzer-health status to describe the safer schema guidance
+
 ## [5.2.10] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -959,6 +959,10 @@ public class Order
 }
 ```
 
+**Reliability Notes:**
+- LC027 ignores collection navigations, owned types, `[ForeignKey]` annotations, and relationships configured with `HasForeignKey(...)`.
+- The fixer preserves the principal key type and emits nullable FK properties for optional nullable navigations.
+
 ---
 
 ### LC028: Deep ThenInclude Chain

--- a/docs/LC027_MissingExplicitForeignKey.md
+++ b/docs/LC027_MissingExplicitForeignKey.md
@@ -2,15 +2,21 @@
 
 ## What it flags
 
-Flags relationship types that rely only on navigation properties because explicit foreign-key properties make mappings, updates, and troubleshooting more predictable.
+Flags public reference navigation properties between `DbSet` entity types when the dependent entity does not expose a matching foreign-key property and the relationship is not otherwise configured.
 
 ## Why it matters
 
-LinqContraband reports this rule when the query shape suggests a risky or non-translatable pattern that is better made explicit before it reaches production.
+Shadow foreign keys make it harder to set or inspect relationships without loading the navigation entity. Explicit FK properties are easier to serialize, update, and reason about during schema reviews.
 
 ## Typical fix
 
-Add the concrete foreign-key property and align the relationship configuration so the model exposes the key directly.
+Add the concrete foreign-key property and align the relationship configuration so the model exposes the key directly. The code fix inserts `<NavigationName>Id` above the navigation, uses the principal entity's primary-key type when it can be found, and keeps optional nullable navigations nullable for value-type keys.
+
+## Safe shapes
+
+LC027 does not report collection navigations, owned types configured with `OwnsOne` / `OwnsMany`, relationships configured with `HasForeignKey(...)`, navigations or FK properties annotated with `[ForeignKey]`, or conventional FK properties such as `CustomerId` / `CustomerTypeId`.
+
+When a team intentionally uses a configured shadow FK, keep the Fluent configuration explicit. LC027 treats that as intentional model design and does not offer a fixer.
 
 ## Samples
 
@@ -32,5 +38,15 @@ public sealed class Order
 {
     public int CustomerId { get; set; }
     public Customer Customer { get; set; } = default!;
+}
+```
+
+Optional relationships should keep the FK optional too:
+
+```csharp
+public sealed class Order
+{
+    public int? CustomerId { get; set; }
+    public Customer? Customer { get; set; }
 }
 ```

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -47,7 +47,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC024 | GroupBy with non-translatable projection | Query Shape & Translation | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Reference-quality manual rule with aggregate-only exclusions, helper/string-comparison/object-construction coverage, nested projection tests, and LINQ-to-Objects boundary coverage. |
 | LC025 | AsNoTracking with Update/Remove | Change Tracking & Context Lifetime | Warning | 5 | 5 | 4 | 5 | 5 | 4 | Low | Hardened with order-aware local origin tracking, query-alias and range-call coverage, assignment/foreach fixer tests, and refreshed docs/sample guidance. |
 | LC026 | Missing CancellationToken in async call | Execution & Async | Info | 4 | 4 | 5 | 5 | 4 | 3 | Low | Hardened fixer coverage for omitted, preferred-name, local, default-token, named-default, and `CancellationToken.None` call shapes. |
-| LC027 | Missing explicit foreign key property | Schema & Modeling | Info | 4 | 4 | 3 | 4 | 4 | 3 | Medium | Design guidance is useful; add fixer tests and more model-configuration negative cases. |
+| LC027 | Missing explicit foreign key property | Schema & Modeling | Info | 5 | 5 | 5 | 5 | 5 | 3 | Low | Hardened around Fluent dependent-navigation resolution, optional nullable FK fixes, non-`int` key fixes, and owned/configured relationship boundaries. |
 | LC028 | Deep ThenInclude chain | Loading & Includes | Warning | 3 | 3 | 5 | 3 | 4 | 3 | Medium | Heuristic rule; manual-only is right, but thresholds and false-positive guidance need more tests. |
 | LC029 | Redundant identity Select | Materialization & Projection | Info | 5 | 5 | 5 | 3 | 4 | 2 | Low | Simple, safe cleanup rule; low importance but healthy implementation. |
 | LC030 | DbContext lifetime mismatch | Change Tracking & Context Lifetime | Info | 4 | 4 | 5 | 4 | 5 | 4 | Low | Broadened DI lifetime coverage across generic/type singleton registrations, configured base/interface types, and factory/scope-safe patterns; manual-only rationale is explicit. |
@@ -72,7 +72,6 @@ The next improvement batch should focus on rules that combine high importance wi
 
 | Priority | Rules | Work |
 | --- | --- | --- |
-| Medium | LC027 | Expand existing fixer coverage for schema-sensitive rewrites. |
 | Medium | LC019, LC028, LC031, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
 | Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC023, LC024, LC025, LC026, LC030, LC034, LC035, LC036, LC037, LC041, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
 
@@ -86,6 +85,6 @@ Architecture tests now enforce the rule quality contract for public package meta
 
 `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` currently verifies 43 diagnostic paths.
 
-`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 605 passing tests.
+`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 613 passing tests.
 
 `dotnet --list-runtimes` currently shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyConfigurationAnalysis.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyConfigurationAnalysis.cs
@@ -109,17 +109,23 @@ public sealed partial class MissingExplicitForeignKeyAnalyzer
     private static string? ExtractNavigationNameFromChain(ExpressionSyntax expression)
     {
         var current = expression;
+        string? withOneNavigationName = null;
+
         while (current != null)
         {
             if (current is InvocationExpressionSyntax invocation &&
                 invocation.Expression is MemberAccessExpressionSyntax memberAccess)
             {
                 var methodName = memberAccess.Name.Identifier.Text;
-                if (methodName is "HasOne" or "HasMany" or "WithOne" or "WithMany")
+                if (methodName == "HasOne")
                 {
                     var navName = ExtractNavigationNameFromArgument(invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression);
                     if (navName != null)
                         return navName;
+                }
+                else if (methodName == "WithOne")
+                {
+                    withOneNavigationName ??= ExtractNavigationNameFromArgument(invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression);
                 }
 
                 current = memberAccess.Expression;
@@ -133,7 +139,7 @@ public sealed partial class MissingExplicitForeignKeyAnalyzer
             };
         }
 
-        return null;
+        return withOneNavigationName;
     }
 
     private static string? ExtractNavigationNameFromArgument(ExpressionSyntax? argument)

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyFixer.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyFixer.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Editing;
 
 namespace LinqContraband.Analyzers.LC027_MissingExplicitForeignKey;
 
@@ -50,16 +49,18 @@ public class MissingExplicitForeignKeyFixer : CodeFixProvider
     private static async Task<Document> ApplyFixAsync(Document document, PropertyDeclarationSyntax navProperty,
         CancellationToken cancellationToken)
     {
-        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root == null) return document;
+
         var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
         if (semanticModel == null) return document;
 
         var navSymbol = semanticModel.GetDeclaredSymbol(navProperty, cancellationToken) as IPropertySymbol;
         if (navSymbol == null) return document;
 
-        // Determine the FK type from the navigation entity's PK
         var navType = navSymbol.Type as INamedTypeSymbol;
         var fkTypeName = "int"; // default
+        var nullableForeignKey = false;
 
         if (navType != null)
         {
@@ -68,15 +69,22 @@ public class MissingExplicitForeignKeyFixer : CodeFixProvider
             {
                 var pkProp = navType.GetMembers(pkName).OfType<IPropertySymbol>().FirstOrDefault();
                 if (pkProp != null)
+                {
                     fkTypeName = pkProp.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                    nullableForeignKey = navSymbol.NullableAnnotation == NullableAnnotation.Annotated &&
+                                         pkProp.Type.IsValueType &&
+                                         pkProp.NullableAnnotation != NullableAnnotation.Annotated;
+                }
             }
         }
 
         var fkName = $"{navSymbol.Name}Id";
+        var fkType = SyntaxFactory.ParseTypeName(fkTypeName);
+        if (nullableForeignKey)
+            fkType = SyntaxFactory.NullableType(fkType);
 
-        // Create the FK property declaration
         var fkProperty = SyntaxFactory.PropertyDeclaration(
-                SyntaxFactory.ParseTypeName(fkTypeName),
+                fkType,
                 SyntaxFactory.Identifier(fkName))
             .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
             .AddAccessorListAccessors(
@@ -85,11 +93,28 @@ public class MissingExplicitForeignKeyFixer : CodeFixProvider
                 SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration)
                     .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)))
             .NormalizeWhitespace()
-            .WithLeadingTrivia(navProperty.GetLeadingTrivia())
+            .WithLeadingTrivia(GetIndentationTrivia(navProperty))
             .WithTrailingTrivia(SyntaxFactory.EndOfLine("\n"));
 
-        editor.InsertBefore(navProperty, fkProperty);
+        if (navProperty.Parent is not TypeDeclarationSyntax typeDeclaration)
+            return document;
 
-        return editor.GetChangedDocument();
+        var propertyIndex = typeDeclaration.Members.IndexOf(navProperty);
+        if (propertyIndex < 0)
+            return document;
+
+        var updatedType = typeDeclaration.WithMembers(typeDeclaration.Members.Insert(propertyIndex, fkProperty));
+        var updatedRoot = root.ReplaceNode(typeDeclaration, updatedType);
+        return document.WithSyntaxRoot(updatedRoot);
+    }
+
+    private static SyntaxTriviaList GetIndentationTrivia(PropertyDeclarationSyntax property)
+    {
+        var leadingTrivia = property.GetLeadingTrivia();
+        return SyntaxFactory.TriviaList(
+            leadingTrivia
+                .Reverse()
+                .TakeWhile(trivia => !trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                .Reverse());
     }
 }

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.10</Version>
+        <Version>5.2.11</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Add rule quality governance for package metadata, fixer exports, documentation drift, and sample diagnostic expectations.</PackageReleaseNotes>
+        <PackageReleaseNotes>Harden LC027 foreign-key configuration analysis and optional-navigation fixer behavior.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyEdgeCasesTests.cs
@@ -62,6 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         where TRelated : class
     {
         public ReferenceCollectionBuilder<TEntity, TRelated> HasForeignKey<TDependent>(Expression<Func<TDependent, object>> foreignKeyExpression) where TDependent : class => this;
+        public ReferenceCollectionBuilder<TEntity, TRelated> HasForeignKey(params string[] foreignKeyPropertyNames) => this;
     }
 
     public class OwnedNavigationBuilder<TEntity, TOwned>
@@ -169,6 +170,73 @@ namespace TestApp
     {
         public DbSet<Order> Orders { get; set; }
         public DbSet<Customer> Customers { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Navigation_WithShadowForeignKeyConfiguredByString_ShouldNotTrigger()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public Customer Customer { get; set; }
+    }
+
+    public class Customer { public int Id { get; set; } public System.Collections.Generic.List<Order> Orders { get; set; } }
+
+    public class AppDbContext : DbContext
+    {
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<Customer> Customers { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>()
+                .HasOne(o => o.Customer)
+                .WithMany(c => c.Orders)
+                .HasForeignKey(""CustomerShadowId"");
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Navigation_WithOwnedTypeConfiguredByExplicitGeneric_ShouldNotTrigger()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public Address Address { get; set; }
+    }
+
+    public class Address
+    {
+        public string Street { get; set; }
+    }
+
+    public class Customer { public int Id { get; set; } }
+
+    public class AppDbContext : DbContext
+    {
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<Address> Addresses { get; set; }
+        public DbSet<Customer> Customers { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>().OwnsOne<Address>(o => o.Address);
+        }
     }
 }";
 

--- a/tests/LinqContraband.Tests/Analyzers/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyTests.cs
@@ -215,4 +215,103 @@ namespace TestApp
             CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck
         }.RunAsync();
     }
+
+    [Fact]
+    public async Task Fixer_ShouldUsePrimaryKeyType()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public Customer {|LC027:Customer|} { get; set; }
+    }
+
+    public class Customer { public Guid Id { get; set; } }
+
+    public class AppDbContext : DbContext
+    {
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<Customer> Customers { get; set; }
+    }
+}";
+
+        var fixedCode = EFCoreMock + @"
+namespace TestApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public Guid CustomerId { get; set; }
+        public Customer Customer { get; set; }
+    }
+
+    public class Customer { public Guid Id { get; set; } }
+
+    public class AppDbContext : DbContext
+    {
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<Customer> Customers { get; set; }
+    }
+}";
+
+        await new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck
+        }.RunAsync();
+    }
+
+    [Fact]
+    public async Task Fixer_ShouldPreserveOptionalNavigationWithNullableForeignKey()
+    {
+        var test = EFCoreMock + @"
+#nullable enable
+namespace TestApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public Customer? {|LC027:Customer|} { get; set; }
+    }
+
+    public class Customer { public int Id { get; set; } }
+
+    public class AppDbContext : DbContext
+    {
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<Customer> Customers { get; set; }
+    }
+}";
+
+        var fixedCode = EFCoreMock + @"
+#nullable enable
+namespace TestApp
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public int? CustomerId { get; set; }
+        public Customer? Customer { get; set; }
+    }
+
+    public class Customer { public int Id { get; set; } }
+
+    public class AppDbContext : DbContext
+    {
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<Customer> Customers { get; set; }
+    }
+}";
+
+        await new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck
+        }.RunAsync();
+    }
+
 }


### PR DESCRIPTION
## Summary
- harden LC027 Fluent API configuration analysis around dependent reference navigation resolution
- preserve optional nullable navigation intent in the FK fixer and add non-int key coverage
- update LC027 docs, analyzer-health, changelog, and bump v5.2.11

## Impact
This improves analyzer precision for configured relationships and makes the fixer safer for optional relationships while preserving intentional Fluent-configured shadow FK boundaries.

## Validation
- `/opt/homebrew/bin/dotnet restore LinqContraband.sln`
- `/opt/homebrew/bin/dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter "FullyQualifiedName~LC027"` passed with 13 tests
- `PATH="/opt/homebrew/bin:/usr/local/share/dotnet:$PATH" /opt/homebrew/bin/dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` passed with 43 diagnostic paths
- `/opt/homebrew/bin/dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check` passed
- `/opt/homebrew/bin/dotnet test LinqContraband.sln --no-restore --framework net10.0` passed with 613 tests
- `git diff --check` clean
- CI covers full .NET 8/9/10; local runtimes only include .NET 10