### PR TITLE
Harden LC019 conditional Include paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.12] - 2026-04-26
+
+### Changed
+- Hardened `LC019` conditional Include analysis so ternary and null-coalescing receivers inside longer Include paths are reported
+- Preserved safe filtered Include predicate and non-EF `Include` extension boundaries to avoid broad false positives
+- Expanded `LC019` Include/ThenInclude coverage and refreshed docs/analyzer-health status to describe the manual-only query-shape guidance
+
 ## [5.2.11] - 2026-04-26
 
 ### Changed

--- a/docs/LC019_ConditionalInclude.md
+++ b/docs/LC019_ConditionalInclude.md
@@ -2,15 +2,19 @@
 
 ## What it flags
 
-Flags conditional logic embedded inside Include paths because EF Core include graphs must stay shape-stable to translate reliably and remain predictable.
+Flags conditional logic embedded in EF Core Include paths because include graphs must stay shape-stable to translate reliably and remain predictable. This includes root-level ternary/null-coalescing expressions and conditional receivers inside a longer navigation path.
 
 ## Why it matters
 
-LinqContraband reports this rule when the query shape suggests a risky or non-translatable pattern that is better made explicit before it reaches production.
+EF Core expects Include and ThenInclude lambdas to describe a concrete navigation path. Choosing between alternate navigations inside the lambda can fail at runtime or make the eager-loading shape ambiguous. Split the query shape before the Include call so each branch has a normal navigation path.
+
+## What it does not flag
+
+LC019 is limited to EF Core `Include` and `ThenInclude` calls. It does not report unrelated application extension methods named `Include`, and it does not treat conditionals inside filtered Include predicates as conditional navigation paths.
 
 ## Typical fix
 
-Project a conditional shape outside the Include chain, split the query, or load alternate branches explicitly.
+Project a conditional shape outside the Include chain, split the query, or load alternate branches explicitly. This rule is manual-only because the correct replacement usually depends on whether both branches should run, whether the branches need different filters, and how the query is composed afterward.
 
 ## Samples
 
@@ -23,10 +27,21 @@ var query = db.Orders
     .Include(o => includeCustomer ? o.Customer : o.AlternateCustomer);
 ```
 
+```csharp
+var query = db.Orders
+    .Include(o => (includePrimary ? o.PrimaryCustomer : o.FallbackCustomer).Address);
+```
+
 ## A better shape
 
 ```csharp
 var query = includeCustomer
     ? db.Orders.Include(o => o.Customer)
     : db.Orders.Include(o => o.AlternateCustomer);
+```
+
+```csharp
+var query = includePrimary
+    ? db.Orders.Include(o => o.PrimaryCustomer.Address)
+    : db.Orders.Include(o => o.FallbackCustomer.Address);
 ```

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -39,7 +39,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC016 | Avoid DateTime.Now/UtcNow in queries | Query Shape & Translation | Warning | 5 | 5 | 4 | 5 | 4 | 3 | Low | Well-tested rule; importance is moderate because impact is usually cacheability/testability. |
 | LC017 | Whole entity projection | Materialization & Projection | Info | 5 | 5 | 5 | 5 | 4 | 4 | Low | Very strong edge-case coverage for a heuristic Info rule. |
 | LC018 | FromSqlRaw with interpolated strings | Raw SQL & Security | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Brought closer to LC034 parity with named SQL argument handling, nested concatenation coverage, alias boundary tests, and narrow fixer guardrails. |
-| LC019 | Conditional Include expression | Loading & Includes | Warning | 4 | 4 | 5 | 3 | 4 | 5 | Medium | Manual-only rationale is sound; add more Include/ThenInclude shape and non-EF negative tests. |
+| LC019 | Conditional Include expression | Loading & Includes | Warning | 5 | 5 | 5 | 5 | 5 | 5 | Low | Hardened path analysis now catches conditional receivers in longer Include chains while preserving filtered Include predicate and non-EF Include boundaries. |
 | LC020 | Untranslatable string comparison overloads | Query Shape & Translation | Warning | 4 | 4 | 3 | 3 | 4 | 4 | Medium | Add explicit fixer tests and provider translation edge cases. |
 | LC021 | IgnoreQueryFilters usage | Raw SQL & Security | Warning | 4 | 3 | 4 | 3 | 4 | 4 | Medium | Intentional bypasses can be valid; consider suppression/allow-list guidance and more negative tests. |
 | LC022 | ToList/ToArray inside Select projection | Materialization & Projection | Warning | 4 | 4 | 3 | 4 | 4 | 4 | Medium | Analyzer coverage is decent; add dedicated fixer tests if fixer behavior is meant to be supported. |
@@ -72,7 +72,7 @@ The next improvement batch should focus on rules that combine high importance wi
 
 | Priority | Rules | Work |
 | --- | --- | --- |
-| Medium | LC019, LC028, LC031, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
+| Medium | LC028, LC031, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
 | Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC023, LC024, LC025, LC026, LC030, LC034, LC035, LC036, LC037, LC041, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
 
 ## Verification Baseline
@@ -85,6 +85,6 @@ Architecture tests now enforce the rule quality contract for public package meta
 
 `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` currently verifies 43 diagnostic paths.
 
-`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 613 passing tests.
+`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 618 passing tests.
 
 `dotnet --list-runtimes` currently shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC019_ConditionalInclude/ConditionalIncludeAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC019_ConditionalInclude/ConditionalIncludeAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -52,12 +53,9 @@ public sealed class ConditionalIncludeAnalyzer : DiagnosticAnalyzer
         // Find the lambda argument
         foreach (var arg in invocation.Arguments)
         {
-            var value = arg.Value;
-            // Unwrap conversions
-            while (value is IConversionOperation conv)
-                value = conv.Operand;
+            var value = arg.Value.UnwrapConversions();
             while (value is IDelegateCreationOperation del)
-                value = del.Target;
+                value = del.Target.UnwrapConversions();
 
             if (value is not IAnonymousFunctionOperation lambda) continue;
 
@@ -70,7 +68,7 @@ public sealed class ConditionalIncludeAnalyzer : DiagnosticAnalyzer
                 {
                     if (op is IReturnOperation ret && ret.ReturnedValue != null)
                     {
-                        if (IsConditionalExpression(ret.ReturnedValue))
+                        if (HasConditionalIncludePath(ret.ReturnedValue))
                         {
                             context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation()));
                             return;
@@ -78,7 +76,7 @@ public sealed class ConditionalIncludeAnalyzer : DiagnosticAnalyzer
                     }
                 }
             }
-            else if (IsConditionalExpression(body))
+            else if (HasConditionalIncludePath(body))
             {
                 // Non-block lambda body (expression lambda directly)
                 context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation()));
@@ -87,12 +85,25 @@ public sealed class ConditionalIncludeAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool IsConditionalExpression(IOperation operation)
+    private static bool HasConditionalIncludePath(IOperation operation)
     {
-        var current = operation;
-        while (current is IConversionOperation conv)
-            current = conv.Operand;
+        var current = operation.UnwrapConversions();
 
-        return current is IConditionalOperation or ICoalesceOperation;
+        return current switch
+        {
+            IConditionalOperation or ICoalesceOperation => true,
+            IPropertyReferenceOperation property => property.Instance != null &&
+                                                    HasConditionalIncludePath(property.Instance),
+            IFieldReferenceOperation field => field.Instance != null &&
+                                              HasConditionalIncludePath(field.Instance),
+            IInvocationOperation invocation => HasConditionalIncludeInvocationSource(invocation),
+            _ => false
+        };
+    }
+
+    private static bool HasConditionalIncludeInvocationSource(IInvocationOperation invocation)
+    {
+        var receiver = invocation.GetInvocationReceiver();
+        return receiver != null && HasConditionalIncludePath(receiver);
     }
 }

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.11</Version>
+        <Version>5.2.12</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Harden LC027 foreign-key configuration analysis and optional-navigation fixer behavior.</PackageReleaseNotes>
+        <PackageReleaseNotes>Harden LC019 conditional Include path analysis and filtered Include boundaries.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC019_ConditionalInclude/ConditionalIncludeTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC019_ConditionalInclude/ConditionalIncludeTests.cs
@@ -39,6 +39,10 @@ namespace Microsoft.EntityFrameworkCore
         public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
             this IIncludableQueryable<TEntity, TPreviousProperty> source,
             Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath) where TEntity : class => null;
+
+        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this IIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>> source,
+            Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath) where TEntity : class => null;
     }
 }
 ";
@@ -79,6 +83,50 @@ namespace TestApp
         public void TestMethod(DbSet<Order> orders)
         {
             var result = {|LC019:orders.Include(o => o.Customer ?? o.FallbackCustomer)|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Include_WithConditionalReceiverInPath_ShouldTriggerLC019()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    public class Order { public int Id { get; set; } public Customer PrimaryCustomer { get; set; } public Customer FallbackCustomer { get; set; } }
+    public class Customer { public int Id { get; set; } public Address Address { get; set; } }
+    public class Address { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(DbSet<Order> orders, bool usePrimary)
+        {
+            var result = {|LC019:orders.Include(o => (usePrimary ? o.PrimaryCustomer : o.FallbackCustomer).Address)|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Include_WithCoalescedReceiverInPath_ShouldTriggerLC019()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    public class Order { public int Id { get; set; } public Customer PrimaryCustomer { get; set; } public Customer FallbackCustomer { get; set; } }
+    public class Customer { public int Id { get; set; } public Address Address { get; set; } }
+    public class Address { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(DbSet<Order> orders)
+        {
+            var result = {|LC019:orders.Include(o => (o.PrimaryCustomer ?? o.FallbackCustomer).Address)|};
         }
     }
 }";
@@ -130,6 +178,28 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task CollectionThenInclude_WithTernary_ShouldTriggerLC019()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    public class Order { public int Id { get; set; } public ICollection<OrderLine> Lines { get; set; } }
+    public class OrderLine { public int Id { get; set; } public Product PrimaryProduct { get; set; } public Product FallbackProduct { get; set; } }
+    public class Product { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(DbSet<Order> orders, bool usePrimary)
+        {
+            var result = {|LC019:orders.Include(o => o.Lines).ThenInclude(l => usePrimary ? l.PrimaryProduct : l.FallbackProduct)|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task ThenInclude_Normal_ShouldNotTrigger()
     {
         var test = EFCoreMock + @"
@@ -144,6 +214,56 @@ namespace TestApp
         public void TestMethod(DbSet<Order> orders)
         {
             var result = orders.Include(o => o.Customer).ThenInclude(c => c.Address);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task FilteredInclude_WithConditionalPredicate_ShouldNotTrigger()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    public class Order { public int Id { get; set; } public ICollection<OrderLine> Lines { get; set; } }
+    public class OrderLine { public int Id { get; set; } public bool IsPriority { get; set; } public bool IsBackordered { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(DbSet<Order> orders, bool priorityOnly)
+        {
+            var result = orders.Include(o => o.Lines.Where(l => priorityOnly ? l.IsPriority : l.IsBackordered));
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NonEfInclude_WithTernary_ShouldNotTrigger()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    using System;
+    using System.Collections.Generic;
+
+    public static class IncludeExtensions
+    {
+        public static IEnumerable<T> Include<T, TProperty>(this IEnumerable<T> source, Func<T, TProperty> selector) => source;
+    }
+
+    public class Order { public int Id { get; set; } public Customer Customer { get; set; } public Customer FallbackCustomer { get; set; } }
+    public class Customer { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(IEnumerable<Order> orders, bool usePrimary)
+        {
+            var result = orders.Include(o => usePrimary ? o.Customer : o.FallbackCustomer);
         }
     }
 }";


### PR DESCRIPTION
## Summary
- harden LC019 to catch ternary/null-coalescing receivers inside longer Include paths
- add Include/ThenInclude coverage plus filtered Include predicate and non-EF Include negative tests
- update docs/analyzer-health and bump v5.2.12

## Impact
This improves analyzer precision for high-impact conditional Include crashes while preserving safe boundaries for filtered Include predicates and unrelated Include-like APIs.

## Validation
- `/opt/homebrew/bin/dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter FullyQualifiedName~LC019_ConditionalInclude` passed with 10 tests
- `/opt/homebrew/bin/dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check` passed
- `/opt/homebrew/bin/dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` passed
- `/opt/homebrew/bin/dotnet test LinqContraband.sln --no-restore --framework net10.0` passed with 618 tests
- `git diff --check` clean
- CI covers full .NET 8/9/10 because local runtimes only include .NET 10