### PR TITLE
Harden LC028 deep ThenInclude threshold

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -157,6 +157,7 @@ indent_size = 2
 
 # LC028: Deep ThenInclude Chain - ThenInclude depth exceeds 3 levels
 # dotnet_diagnostic.LC028.severity = warning
+# dotnet_code_quality.LC028.max_depth = 3
 
 # LC030: DbContext in Singleton - Potential lifetime mismatch
 # dotnet_diagnostic.LC030.severity = info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.13] - 2026-04-26
+
+### Changed
+- Hardened `LC028` deep `ThenInclude` reporting so each over-threshold chain reports once at the first threshold breach instead of repeating on later links
+- Added `dotnet_code_quality.LC028.max_depth` for teams with reviewed deep eager-loading graphs
+- Expanded `LC028` default, configured-threshold, and non-EF boundary coverage, and refreshed docs/analyzer-health status to describe the manual-only review contract
+
 ## [5.2.12] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -970,6 +970,10 @@ public class Order
 `ThenInclude` chains deeper than 3 levels generate complex SQL with many LEFT JOINs. This is usually a sign of
 over-fetching — loading deeply nested data that should be projected with `Select` instead.
 
+LC028 reports the first `ThenInclude(...)` call that exceeds the configured depth. The default maximum depth is `3`;
+raise `dotnet_code_quality.LC028.max_depth` in `.editorconfig` for reviewed queries where deeper eager loading is
+intentional.
+
 **👶 Explain it like I'm a ten year old:** Imagine asking your friend to bring their mom, who brings their grandma, who
 brings their great-grandma, who brings their great-great-grandma. At some point, the car is full and everyone is
 uncomfortable. It's better to just ask for the specific people you actually need.
@@ -988,7 +992,8 @@ var orders = db.Orders
 ```
 
 **✅ The Fix:**
-Use `Select` projection to load only the needed nested data.
+Use `Select` projection to load only the needed nested data, split the query, or suppress the diagnostic with a local
+justification when the deep graph is intentional.
 
 ```csharp
 var orders = db.Orders.Select(o => new {

--- a/docs/LC028_DeepThenInclude.md
+++ b/docs/LC028_DeepThenInclude.md
@@ -2,15 +2,28 @@
 
 ## What it flags
 
-Flags very deep eager-loading chains because they often signal over-fetching, brittle query shapes, and poor separation between read models and entity graphs.
+Flags EF Core `ThenInclude(...)` chains once they exceed the configured maximum depth. By default, LC028 allows three consecutive `ThenInclude(...)` calls after an `Include(...)` and reports the fourth call as the point where the query should be reviewed.
 
 ## Why it matters
 
-LinqContraband reports this rule when the query shape suggests a risky or non-translatable pattern that is better made explicit before it reaches production.
+Very deep eager-loading chains often signal over-fetching, brittle query shapes, and poor separation between read models and entity graphs. They can also generate wide SQL with many joins and duplicated row data.
+
+LC028 is intentionally heuristic: a deep Include graph can be valid for small reference data, aggregate snapshots, or carefully profiled queries. The diagnostic asks for a manual review rather than prescribing a universal rewrite.
+
+## Safe and intentional shapes
+
+LC028 does not report the first three `ThenInclude(...)` calls by default. If a project has a known, reviewed deep graph, either suppress the specific diagnostic with a justification or raise the threshold for that scope:
+
+```editorconfig
+[*.cs]
+dotnet_code_quality.LC028.max_depth = 4
+```
+
+The threshold must be a positive integer. Invalid values keep the default of `3`.
 
 ## Typical fix
 
-Prefer focused projections, split queries, or targeted follow-up loads for the specific data the caller actually consumes.
+Prefer focused projections, split queries, or targeted follow-up loads for the specific data the caller actually consumes. There is no automatic fix because removing eager-loading depth requires a domain-specific decision about result shape, tracking behavior, and query ownership.
 
 ## Samples
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -48,7 +48,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC025 | AsNoTracking with Update/Remove | Change Tracking & Context Lifetime | Warning | 5 | 5 | 4 | 5 | 5 | 4 | Low | Hardened with order-aware local origin tracking, query-alias and range-call coverage, assignment/foreach fixer tests, and refreshed docs/sample guidance. |
 | LC026 | Missing CancellationToken in async call | Execution & Async | Info | 4 | 4 | 5 | 5 | 4 | 3 | Low | Hardened fixer coverage for omitted, preferred-name, local, default-token, named-default, and `CancellationToken.None` call shapes. |
 | LC027 | Missing explicit foreign key property | Schema & Modeling | Info | 5 | 5 | 5 | 5 | 5 | 3 | Low | Hardened around Fluent dependent-navigation resolution, optional nullable FK fixes, non-`int` key fixes, and owned/configured relationship boundaries. |
-| LC028 | Deep ThenInclude chain | Loading & Includes | Warning | 3 | 3 | 5 | 3 | 4 | 3 | Medium | Heuristic rule; manual-only is right, but thresholds and false-positive guidance need more tests. |
+| LC028 | Deep ThenInclude chain | Loading & Includes | Warning | 4 | 4 | 5 | 5 | 5 | 3 | Low | Hardened manual-only heuristic with one diagnostic per over-threshold chain, configurable max depth, non-EF boundary coverage, and explicit intentional-use guidance. |
 | LC029 | Redundant identity Select | Materialization & Projection | Info | 5 | 5 | 5 | 3 | 4 | 2 | Low | Simple, safe cleanup rule; low importance but healthy implementation. |
 | LC030 | DbContext lifetime mismatch | Change Tracking & Context Lifetime | Info | 4 | 4 | 5 | 4 | 5 | 4 | Low | Broadened DI lifetime coverage across generic/type singleton registrations, configured base/interface types, and factory/scope-safe patterns; manual-only rationale is explicit. |
 | LC031 | Unbounded query materialization | Materialization & Projection | Info | 3 | 3 | 5 | 3 | 4 | 4 | Medium | Valuable but heuristic; expand safe opt-out, Take/Where ordering, and intentional full-scan coverage. |
@@ -72,8 +72,8 @@ The next improvement batch should focus on rules that combine high importance wi
 
 | Priority | Rules | Work |
 | --- | --- | --- |
-| Medium | LC028, LC031, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
-| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC023, LC024, LC025, LC026, LC030, LC034, LC035, LC036, LC037, LC041, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
+| Medium | LC031, LC038, LC039, LC040 | Expand negative tests and documented intentional-use guidance for manual-only heuristics. |
+| Low | LC002, LC003, LC007, LC012, LC013, LC015, LC017, LC018, LC023, LC024, LC025, LC026, LC028, LC030, LC034, LC035, LC036, LC037, LC041, LC043, LC044 | Treat as reference-quality or recently hardened examples for future analyzer work. |
 
 ## Verification Baseline
 
@@ -85,6 +85,6 @@ Architecture tests now enforce the rule quality contract for public package meta
 
 `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` currently verifies 43 diagnostic paths.
 
-`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 618 passing tests.
+`dotnet test LinqContraband.sln --no-restore --framework net10.0` currently builds and runs successfully with 622 passing tests.
 
 `dotnet --list-runtimes` currently shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC028_DeepThenInclude/DeepThenIncludeAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC028_DeepThenInclude/DeepThenIncludeAnalyzer.cs
@@ -1,9 +1,11 @@
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
 
 namespace LinqContraband.Analyzers.LC028_DeepThenInclude;
 
@@ -15,8 +17,10 @@ namespace LinqContraband.Analyzers.LC028_DeepThenInclude;
 public sealed class DeepThenIncludeAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC028";
+    internal const string MaxDepthOptionKey = "dotnet_code_quality.LC028.max_depth";
+
     private const string Category = "Performance";
-    private const int MaxDepth = 3;
+    private const int DefaultMaxDepth = 3;
     private static readonly LocalizableString Title = "Deep ThenInclude Chain";
 
     private static readonly LocalizableString MessageFormat =
@@ -40,10 +44,16 @@ public sealed class DeepThenIncludeAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(InitializeCompilation);
     }
 
-    private void AnalyzeInvocation(OperationAnalysisContext context)
+    private static void InitializeCompilation(CompilationStartAnalysisContext context)
+    {
+        var maxDepthCache = new ConditionalWeakTable<SyntaxTree, StrongBox<int>>();
+        context.RegisterOperationAction(operationContext => AnalyzeInvocation(operationContext, maxDepthCache), OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context, ConditionalWeakTable<SyntaxTree, StrongBox<int>> maxDepthCache)
     {
         var invocation = (IInvocationOperation)context.Operation;
         var method = invocation.TargetMethod;
@@ -70,7 +80,8 @@ public sealed class DeepThenIncludeAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        if (depth > MaxDepth)
+        var maxDepth = GetMaxDepth(context, maxDepthCache);
+        if (depth == maxDepth + 1)
         {
             // Narrow the diagnostic to just the ".ThenInclude(...)" portion, excluding the receiver
             var location = invocation.Syntax.GetLocation();
@@ -79,12 +90,32 @@ public sealed class DeepThenIncludeAnalyzer : DiagnosticAnalyzer
                 // Span from the dot before ThenInclude through the closing paren
                 var start = memberAccess.OperatorToken.SpanStart;
                 var end = invocation.Syntax.Span.End;
-                var textSpan = Microsoft.CodeAnalysis.Text.TextSpan.FromBounds(start, end);
+                var textSpan = TextSpan.FromBounds(start, end);
                 location = Location.Create(invocation.Syntax.SyntaxTree, textSpan);
             }
 
-            context.ReportDiagnostic(Diagnostic.Create(Rule, location, depth, MaxDepth));
+            context.ReportDiagnostic(Diagnostic.Create(Rule, location, depth, maxDepth));
         }
+    }
+
+    private static int GetMaxDepth(OperationAnalysisContext context, ConditionalWeakTable<SyntaxTree, StrongBox<int>> maxDepthCache)
+    {
+        var syntaxTree = context.Operation.Syntax.SyntaxTree;
+        if (maxDepthCache.TryGetValue(syntaxTree, out var cached))
+            return cached.Value;
+
+        var options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
+        var maxDepth = DefaultMaxDepth;
+
+        if (options.TryGetValue(MaxDepthOptionKey, out var value) &&
+            int.TryParse(value, out var configuredMaxDepth) &&
+            configuredMaxDepth > 0)
+        {
+            maxDepth = configuredMaxDepth;
+        }
+
+        maxDepthCache.Add(syntaxTree, new StrongBox<int>(maxDepth));
+        return maxDepth;
     }
 
     private static bool IsEfCoreMethod(IMethodSymbol method)

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.12</Version>
+        <Version>5.2.13</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Harden LC019 conditional Include path analysis and filtered Include boundaries.</PackageReleaseNotes>
+        <PackageReleaseNotes>Harden LC028 deep ThenInclude reporting with a configurable max depth and single diagnostic per chain.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC028_DeepThenInclude/DeepThenIncludeTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC028_DeepThenInclude/DeepThenIncludeTests.cs
@@ -56,7 +56,23 @@ namespace TestApp
     public class Address { public int Id { get; set; } public Country Country { get; set; } }
     public class Country { public int Id { get; set; } public Region Region { get; set; } }
     public class Region { public int Id { get; set; } public Continent Continent { get; set; } }
-    public class Continent { public int Id { get; set; } }
+    public class Continent { public int Id { get; set; } public Planet Planet { get; set; } }
+    public class Planet { public int Id { get; set; } public Moon Moon { get; set; } }
+    public class Moon { public int Id { get; set; } }
+}
+
+namespace MyCompany
+{
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    public static class QueryableExtensions
+    {
+        public static IQueryable<TEntity> ThenInclude<TEntity, TProperty>(
+            this IQueryable<TEntity> source,
+            Expression<Func<TEntity, TProperty>> nav) => source;
+    }
 }
 ";
 
@@ -76,6 +92,30 @@ namespace TestApp
                 .ThenInclude(a => a.Country)
                 .ThenInclude(c => c.Region)
                 {|LC028:.ThenInclude(r => r.Continent)|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ThenInclude_Depth5_ShouldTriggerOnceAtFirstThresholdBreach()
+    {
+        var test = Preamble + @"
+namespace TestApp
+{
+    public class TestClass
+    {
+        public void TestMethod(DbSet<Order> orders)
+        {
+            var result = orders
+                .Include(o => o.Customer)
+                .ThenInclude(c => c.Address)
+                .ThenInclude(a => a.Country)
+                .ThenInclude(c => c.Region)
+                {|LC028:.ThenInclude(r => r.Continent)|}
+                .ThenInclude(c => c.Planet);
         }
     }
 }";
@@ -136,6 +176,99 @@ namespace TestApp
         {
             var result = orders
                 .Include(o => o.Customer);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ThenInclude_ConfiguredMaxDepth4_ShouldNotTriggerAtDepth4()
+    {
+        var test = new Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<
+            LinqContraband.Analyzers.LC028_DeepThenInclude.DeepThenIncludeAnalyzer,
+            Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>
+        {
+            TestCode = Preamble + @"
+namespace TestApp
+{
+    public class TestClass
+    {
+        public void TestMethod(DbSet<Order> orders)
+        {
+            var result = orders
+                .Include(o => o.Customer)
+                .ThenInclude(c => c.Address)
+                .ThenInclude(a => a.Country)
+                .ThenInclude(c => c.Region)
+                .ThenInclude(r => r.Continent);
+        }
+    }
+}"
+        };
+
+        test.TestState.AnalyzerConfigFiles.Add(("/0/.editorconfig", """
+root = true
+
+[*.cs]
+dotnet_code_quality.LC028.max_depth = 4
+"""));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ThenInclude_ConfiguredMaxDepth2_ShouldTriggerAtDepth3()
+    {
+        var test = new Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<
+            LinqContraband.Analyzers.LC028_DeepThenInclude.DeepThenIncludeAnalyzer,
+            Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>
+        {
+            TestCode = Preamble + @"
+namespace TestApp
+{
+    public class TestClass
+    {
+        public void TestMethod(DbSet<Order> orders)
+        {
+            var result = orders
+                .Include(o => o.Customer)
+                .ThenInclude(c => c.Address)
+                .ThenInclude(a => a.Country)
+                {|LC028:.ThenInclude(c => c.Region)|};
+        }
+    }
+}"
+        };
+
+        test.TestState.AnalyzerConfigFiles.Add(("/0/.editorconfig", """
+root = true
+
+[*.cs]
+dotnet_code_quality.LC028.max_depth = 2
+"""));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task NonEfCoreThenInclude_ShouldNotTrigger()
+    {
+        var test = Preamble + @"
+namespace TestApp
+{
+    using MyCompany;
+
+    public class TestClass
+    {
+        public void TestMethod(DbSet<Order> orders)
+        {
+            var result = orders
+                .ThenInclude(o => o.Customer)
+                .ThenInclude(o => o.Customer)
+                .ThenInclude(o => o.Customer)
+                .ThenInclude(o => o.Customer);
         }
     }
 }";


### PR DESCRIPTION
## Summary
- harden LC028 to report once at the first over-threshold ThenInclude link
- add configurable `dotnet_code_quality.LC028.max_depth` and non-EF boundary coverage
- update LC028 docs, analyzer-health, changelog, and bump v5.2.13

## Impact
This improves analyzer precision for a heuristic Warning rule by reducing repeated diagnostics and giving teams a documented threshold escape hatch for reviewed deep eager-loading graphs.

## Validation
- `/opt/homebrew/bin/dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter DeepThenIncludeTests` passed with 8 tests
- `/opt/homebrew/bin/dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check` passed
- `/opt/homebrew/bin/dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` passed, verifying 43 diagnostic paths
- `/opt/homebrew/bin/dotnet test LinqContraband.sln --no-restore --framework net10.0` passed with 622 tests
- `git diff --check` clean
- CI covers full .NET 8/9/10 when local runtimes are unavailable