### PR TITLE
Harden LC011 primary-key modeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.16] - 2026-04-27
+
+### Changed
+- Hardened `LC011` primary-key detection so fake same-name attributes no longer suppress diagnostics, ignored `Id` properties are not treated as mapped keys, and unapplied `IEntityTypeConfiguration<T>` classes no longer leak across contexts
+- Expanded `LC011` Fluent API coverage for scoped builder variables, chained builder calls, local applied configuration instances, current-assembly configuration scanning, and inferred `OwnsOne`/`OwnsMany` owned types
+- Restricted the `LC011` fixer so it does not generate duplicate `Id` members when an invalid `Id` already exists
+
 ## [5.2.15] - 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -405,7 +405,8 @@ public class Product
 
 **✅ The Fix:**
 
-Define a primary key using the `Id` convention, `[Key]` attribute, or Fluent API.
+Define a primary key using the `Id` convention, `[Key]`/`[PrimaryKey]` attributes, or Fluent API. If the type is
+intentionally query-only or owned, mark it with `[Keyless]`, `HasNoKey()`, `[Owned]`, or `OwnsOne`/`OwnsMany`.
 
 ```csharp
 // 1. Convention: Id or {ClassName}Id
@@ -427,6 +428,8 @@ public class Product
 modelBuilder.Entity<Product>().HasKey(p => p.ProductCode);
 
 // 4. Separate Configuration (IEntityTypeConfiguration<T>)
+modelBuilder.ApplyConfiguration(new ProductConfiguration());
+
 public class ProductConfiguration : IEntityTypeConfiguration<Product>
 {
     public void Configure(EntityTypeBuilder<Product> builder)

--- a/docs/LC011_EntityMissingPrimaryKey.md
+++ b/docs/LC011_EntityMissingPrimaryKey.md
@@ -1,25 +1,46 @@
 # Spec: LC011 - Entity Missing Primary Key
 
 ## Goal
-Detect entity classes that do not have a primary key defined.
+
+Detect `DbSet<TEntity>` entity types that EF Core would treat as regular tracked entities but that have no primary key definition.
 
 ## The Problem
-Entity Framework Core requires a primary key to track entity identity and perform updates/deletes. If an entity is missing a key, EF Core will throw a runtime error or prevent certain database operations.
 
-### Example Violation
+EF Core needs a primary key for tracked entities so it can identify rows, perform updates/deletes, resolve relationships, and maintain identity in the change tracker. A missing key usually fails model validation at startup or leaves the entity usable only as a keyless query type when that was not intended.
+
+## Example Violation
+
 ```csharp
-// Violation: No ID or Key defined
+public class AppDbContext : DbContext
+{
+    public DbSet<Product> Products { get; set; }
+}
+
 public class Product
 {
     public string Name { get; set; }
 }
 ```
 
-### The Fix
-Define a primary key using the `Id` convention or the `[Key]` attribute.
+## Supported Safe Shapes
+
+LC011 treats these as valid primary-key or intentional opt-out patterns:
+
+- Convention keys: public mapped `Id` or `{EntityName}Id` properties.
+- Data annotations: public mapped properties with `System.ComponentModel.DataAnnotations.KeyAttribute`.
+- EF Core composite keys: class-level `Microsoft.EntityFrameworkCore.PrimaryKeyAttribute` where all referenced properties exist, are public, mapped, and key-compatible.
+- Fluent API keys in `OnModelCreating`: `modelBuilder.Entity<TEntity>().HasKey(...)`, scoped local builder variables, and chained builder calls such as `entity.ToTable("Products").HasKey(...)`.
+- Applied configurations: inline or local `modelBuilder.ApplyConfiguration(...)` calls, and `ApplyConfigurationsFromAssembly(typeof(LocalType).Assembly)` when the marker type belongs to the current source assembly and the configuration's `Configure` method calls `HasKey(...)` or `HasNoKey()` for its own `EntityTypeBuilder<TEntity>`.
+- Intentional keyless types: `Microsoft.EntityFrameworkCore.KeylessAttribute` or `HasNoKey()`.
+- Owned types: `Microsoft.EntityFrameworkCore.OwnedAttribute`, generic ownership such as `OwnsOne<Address>(...)`, and inferred ownership such as `OwnsOne(e => e.Address)` / `OwnsMany(e => e.Items)`.
+
+Attributes are namespace-checked. A custom class named `KeyAttribute`, `PrimaryKeyAttribute`, or `KeylessAttribute` does not suppress LC011.
+
+## Fixes
+
+Preferred fixes are domain-specific:
 
 ```csharp
-// Correct
 public class Product
 {
     public int Id { get; set; }
@@ -27,8 +48,28 @@ public class Product
 }
 ```
 
+```csharp
+modelBuilder.Entity<Product>().HasKey(p => p.ProductCode);
+```
+
+```csharp
+modelBuilder.ApplyConfiguration(new ProductConfiguration());
+
+public sealed class ProductConfiguration : IEntityTypeConfiguration<Product>
+{
+    public void Configure(EntityTypeBuilder<Product> builder)
+    {
+        builder.HasKey(p => p.ProductCode);
+    }
+}
+```
+
+The code fix offers `public int Id { get; set; }` only when the entity is source-editable and has no existing `Id` member. It intentionally avoids generating a duplicate `Id` when the current member is private, ignored, or a navigation property; choose the correct domain key manually in those cases.
+
 ## Analyzer Logic
 
 ### ID: `LC011`
-### Category: `Reliability`
+### Category: `Design`
 ### Severity: `Warning`
+
+LC011 starts from `DbSet<TEntity>` members on source `DbContext` types, checks the entity's inheritance chain for valid mapped key properties, then folds in keyless/owned/fluent configuration discovered from the analyzed context. Standalone `IEntityTypeConfiguration<TEntity>` classes are not trusted unless the context applies them, preventing one context's configuration from suppressing diagnostics in another context.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-04-26
+Reviewed: 2026-04-27
 
 This is a deliberately harsh health audit for the 44 analyzers in `RuleCatalog`. The catalog currently declares 29 rules with code fixes and 15 manual-only rules with explicit rationale. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
@@ -38,7 +38,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC008 | Synchronous EF method in async context | Execution & Async | Warning | 4 | 4 | 3 | 4 | 3 | 4 | Low | Good coverage for common sync-over-async shapes; fixer confidence depends on keeping API mappings current. |
 | LC009 | Missing AsNoTracking in read-only path | Change Tracking & Context Lifetime | Info | 4 | 4 | 3 | 4 | 3 | 3 | Low | Good write-detection coverage for a tuning rule; fixer/docs need clearer identity-resolution and intentional tracking guidance. |
 | LC010 | SaveChanges inside loop | Change Tracking & Context Lifetime | Warning | 3 | 3 | 3 | 3 | 3 | 5 | Medium | Very important rule, but current health is more basic than the impact justifies; add branch, loop, async, and unit-of-work negatives. |
-| LC011 | Entity missing primary key | Schema & Modeling | Warning | 4 | 4 | 3 | 4 | 3 | 4 | Low | Solid convention/configuration handling; fixer safety and non-standard key modeling keep it below reference quality. |
+| LC011 | Entity missing primary key | Schema & Modeling | Warning | 4 | 5 | 4 | 5 | 5 | 4 | Low | Hardened around namespace-validated attributes, mapped key checks, context-specific applied configurations, current-assembly config scanning, inferred owned types, scoped/chained builder Fluent API, and duplicate-safe fixes; remaining risk is mostly exotic/dynamic EF model construction. |
 | LC012 | Use ExecuteDelete instead of RemoveRange | Bulk Operations & Set-Based Writes | Warning | 3 | 3 | 3 | 2 | 3 | 4 | Medium | Useful but risky rewrite space; needs more source-shape, provider/version, and fixer safety tests. |
 | LC013 | Disposed context query | Change Tracking & Context Lifetime | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong manual-only reliability rule; keep expanding lifetime-alias and ownership boundary coverage. |
 | LC014 | Avoid string case conversion in queries | Query Shape & Translation | Warning | 3 | 3 | 3 | 3 | 3 | 4 | Medium | Correct basic smell, but provider/collation nuance is under-modeled and should be documented more clearly. |
@@ -92,9 +92,9 @@ This audit was recalibrated against the current `RuleCatalog`, analyzer/fixer so
 
 Current local verification:
 
-- `/opt/homebrew/bin/dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check` reported `docs/rule-catalog.md` is up to date.
-- `/opt/homebrew/bin/dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter FullyQualifiedName~LC020` passed with 12 tests.
-- `PATH="/opt/homebrew/bin:$PATH" /opt/homebrew/bin/dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` passed for 43 diagnostic paths.
-- `/opt/homebrew/bin/dotnet test LinqContraband.sln --no-restore --framework net10.0` passed with 628 tests.
+- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check` reported `docs/rule-catalog.md` is up to date.
+- `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0` passed for 43 diagnostic paths.
+- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --filter FullyQualifiedName~LC011` passed with 45 tests.
+- `dotnet test LinqContraband.sln --framework net10.0` passed with 671 tests.
 - `git diff --check` passed.
-- `/opt/homebrew/bin/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.
+- `dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/samples/LinqContraband.Sample/Data/AppDbContext.cs
+++ b/samples/LinqContraband.Sample/Data/AppDbContext.cs
@@ -24,7 +24,7 @@ public class AppDbContext : DbContext
         // Configure Fluent API Key for ValidFluentEntity
         modelBuilder.Entity<ValidFluentEntity>().HasKey(e => e.CodeKey);
 
-        // Apply separate configuration
+        // Apply separate configuration so LC011 can verify the configured key belongs to this context.
         modelBuilder.ApplyConfiguration(new ConfigurationEntityConfiguration());
     }
 
@@ -81,7 +81,7 @@ public class AppDbContext : DbContext
     public DbSet<ValidFluentEntity> ValidFluents { get; set; } = null!;
 
     /// <summary>
-    ///     VALID: Primary Key defined in IEntityTypeConfiguration.
+    ///     VALID: Primary Key defined in an applied IEntityTypeConfiguration.
     /// </summary>
     public DbSet<ConfigurationEntity> ConfigurationEntities { get; set; } = null!;
 

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs
@@ -62,17 +62,15 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer : DiagnosticAnalyzer
 
         var keylessEntities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
         var ownedEntities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-        ScanOnModelCreating(namedType, keylessEntities, ownedEntities, context.Compilation);
-
         var configuredEntities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-        ScanEntityTypeConfigurations(context.Compilation, configuredEntities, keylessEntities);
+        ScanOnModelCreating(namedType, configuredEntities, keylessEntities, ownedEntities, context.Compilation);
 
         foreach (var member in namedType.GetMembers())
         {
             if (!TryGetDbSetMember(member, out var entityType, out var location))
                 continue;
 
-            if (IsMissingPrimaryKey(entityType!, namedType, configuredEntities, keylessEntities, ownedEntities, context.Compilation))
+            if (IsMissingPrimaryKey(entityType!, configuredEntities, keylessEntities, ownedEntities))
             {
                 context.ReportDiagnostic(
                     Diagnostic.Create(Rule, location!, entityType!.Name));

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyConfigurationScan.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyConfigurationScan.cs
@@ -9,6 +9,7 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
 {
     private static void ScanOnModelCreating(
         INamedTypeSymbol dbContextType,
+        HashSet<INamedTypeSymbol> configuredEntities,
         HashSet<INamedTypeSymbol> keylessEntities,
         HashSet<INamedTypeSymbol> ownedEntities,
         Compilation compilation)
@@ -20,6 +21,7 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
         foreach (var syntaxRef in onModelCreating.DeclaringSyntaxReferences)
         {
             var syntax = syntaxRef.GetSyntax();
+            var builderVariables = new Dictionary<string, INamedTypeSymbol>();
 
             foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
             {
@@ -27,10 +29,30 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
                     continue;
 
                 var methodName = memberAccess.Name.Identifier.Text;
-                if (methodName == "HasNoKey")
-                    TryAddResolvedType(ExtractEntityTypeNameFromChain(memberAccess.Expression), compilation, keylessEntities);
-                else if (methodName is "OwnsOne" or "OwnsMany")
-                    TryAddResolvedType(ExtractOwnedTypeName(invocation), compilation, ownedEntities);
+                if (methodName == "HasKey" &&
+                    TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilation, out var configuredEntity))
+                {
+                    configuredEntities.Add(configuredEntity);
+                }
+                else if (methodName == "HasNoKey" &&
+                         TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilation, out var keylessEntity))
+                {
+                    keylessEntities.Add(keylessEntity);
+                }
+                else if (methodName is "OwnsOne" or "OwnsMany" &&
+                         TryGetOwnedEntityType(invocation, memberAccess, builderVariables, compilation, out var ownedEntity))
+                {
+                    ownedEntities.Add(ownedEntity);
+                }
+                else if (methodName == "ApplyConfiguration")
+                {
+                    ScanAppliedConfiguration(invocation, dbContextType, compilation, configuredEntities, keylessEntities);
+                }
+                else if (methodName == "ApplyConfigurationsFromAssembly" &&
+                         ShouldScanCurrentAssemblyConfigurations(invocation, compilation))
+                {
+                    ScanEntityTypeConfigurations(compilation, configuredEntities, keylessEntities);
+                }
             }
         }
     }
@@ -57,7 +79,7 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
                 if (iface.TypeArguments.Length > 0 &&
                     iface.TypeArguments[0] is INamedTypeSymbol entityType)
                 {
-                    var (hasKey, hasNoKey) = CheckConfigureMethod(type);
+                    var (hasKey, hasNoKey) = CheckConfigureMethod(type, entityType, compilation);
 
                     if (hasKey)
                         configuredEntities.Add(entityType);
@@ -69,7 +91,171 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
         }
     }
 
-    private static (bool hasKey, bool hasNoKey) CheckConfigureMethod(INamedTypeSymbol configClass)
+    private static void ScanAppliedConfiguration(
+        InvocationExpressionSyntax invocation,
+        INamedTypeSymbol dbContextType,
+        Compilation compilation,
+        HashSet<INamedTypeSymbol> configuredEntities,
+        HashSet<INamedTypeSymbol> keylessEntities)
+    {
+        var configurationExpression = invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression;
+        var configType = configurationExpression == null
+            ? null
+            : ResolveConfigurationType(configurationExpression, dbContextType, compilation);
+        if (configType == null)
+            return;
+
+        if (!TryGetConfiguredEntityType(configType, out var entityType))
+            return;
+
+        var (hasKey, hasNoKey) = CheckConfigureMethod(configType, entityType, compilation);
+
+        if (hasKey)
+            configuredEntities.Add(entityType);
+
+        if (hasNoKey)
+            keylessEntities.Add(entityType);
+    }
+
+    private static bool ShouldScanCurrentAssemblyConfigurations(InvocationExpressionSyntax invocation, Compilation compilation)
+    {
+        if (invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression is not MemberAccessExpressionSyntax memberAccess ||
+            memberAccess.Name.Identifier.ValueText != "Assembly" ||
+            memberAccess.Expression is not TypeOfExpressionSyntax typeOfExpression)
+        {
+            return false;
+        }
+
+        var assemblyMarkerType = FindTypeByName(compilation, typeOfExpression.Type.ToString());
+        return assemblyMarkerType != null &&
+               SymbolEqualityComparer.Default.Equals(assemblyMarkerType.ContainingAssembly, compilation.Assembly);
+    }
+
+    private static INamedTypeSymbol? ResolveConfigurationType(
+        ExpressionSyntax expression,
+        INamedTypeSymbol dbContextType,
+        Compilation compilation)
+    {
+        if (expression is ObjectCreationExpressionSyntax objectCreation)
+            return FindTypeByName(compilation, objectCreation.Type.ToString());
+
+        if (expression is ImplicitObjectCreationExpressionSyntax implicitObjectCreation)
+            return ResolveImplicitObjectCreationType(implicitObjectCreation, dbContextType, compilation);
+
+        if (expression is ParenthesizedExpressionSyntax parenthesized)
+            return ResolveConfigurationType(parenthesized.Expression, dbContextType, compilation);
+
+        if (expression is IdentifierNameSyntax identifier)
+        {
+            if (TryResolveLocalConfiguration(identifier, dbContextType, compilation, out var localConfigType))
+                return localConfigType;
+
+            return TryGetConfigurationTypeFromMember(dbContextType, identifier.Identifier.ValueText, out var memberConfigType)
+                ? memberConfigType
+                : null;
+        }
+
+        if (expression is MemberAccessExpressionSyntax memberAccess &&
+            memberAccess.Expression is ThisExpressionSyntax &&
+            TryGetConfigurationTypeFromMember(dbContextType, memberAccess.Name.Identifier.ValueText, out var thisMemberConfigType))
+        {
+            return thisMemberConfigType;
+        }
+
+        return null;
+    }
+
+    private static INamedTypeSymbol? ResolveImplicitObjectCreationType(
+        ImplicitObjectCreationExpressionSyntax implicitObjectCreation,
+        INamedTypeSymbol dbContextType,
+        Compilation compilation)
+    {
+        var variable = implicitObjectCreation.Ancestors().OfType<VariableDeclaratorSyntax>().FirstOrDefault();
+        var localDeclaration = variable?.Parent?.Parent as LocalDeclarationStatementSyntax;
+        if (localDeclaration != null)
+            return FindTypeByName(compilation, localDeclaration.Declaration.Type.ToString());
+
+        var fieldDeclaration = variable?.Parent?.Parent as FieldDeclarationSyntax;
+        if (fieldDeclaration != null)
+            return FindTypeByName(compilation, fieldDeclaration.Declaration.Type.ToString());
+
+        var propertyDeclaration = implicitObjectCreation.Ancestors().OfType<PropertyDeclarationSyntax>().FirstOrDefault();
+        if (propertyDeclaration != null)
+            return FindTypeByName(compilation, propertyDeclaration.Type.ToString());
+
+        return null;
+    }
+
+    private static bool TryResolveLocalConfiguration(
+        IdentifierNameSyntax identifier,
+        INamedTypeSymbol dbContextType,
+        Compilation compilation,
+        out INamedTypeSymbol configType)
+    {
+        configType = null!;
+        var identifierName = identifier.Identifier.ValueText;
+        var position = identifier.SpanStart;
+
+        foreach (var block in identifier.Ancestors().OfType<BlockSyntax>())
+        {
+            foreach (var statement in block.Statements)
+            {
+                if (statement.SpanStart >= position)
+                    break;
+
+                if (statement is not LocalDeclarationStatementSyntax localDeclaration)
+                    continue;
+
+                foreach (var variable in localDeclaration.Declaration.Variables)
+                {
+                    if (variable.Identifier.ValueText != identifierName || variable.Initializer?.Value == null)
+                        continue;
+
+                    var resolvedConfigType = ResolveConfigurationType(variable.Initializer.Value, dbContextType, compilation);
+                    if (resolvedConfigType == null && variable.Initializer.Value is ImplicitObjectCreationExpressionSyntax)
+                        resolvedConfigType = FindTypeByName(compilation, localDeclaration.Declaration.Type.ToString());
+
+                    if (resolvedConfigType != null)
+                    {
+                        configType = resolvedConfigType;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetConfigurationTypeFromMember(
+        INamedTypeSymbol dbContextType,
+        string memberName,
+        out INamedTypeSymbol configType)
+    {
+        configType = null!;
+        foreach (var member in dbContextType.GetMembers(memberName))
+        {
+            var memberType = member switch
+            {
+                IFieldSymbol field => field.Type,
+                IPropertySymbol property => property.Type,
+                _ => null
+            };
+
+            if (memberType is INamedTypeSymbol namedType)
+            {
+                configType = namedType;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static (bool hasKey, bool hasNoKey) CheckConfigureMethod(
+        INamedTypeSymbol configClass,
+        INamedTypeSymbol entityType,
+        Compilation compilation)
     {
         var configureMethod = configClass.GetMembers("Configure").FirstOrDefault() as IMethodSymbol;
         if (configureMethod == null)
@@ -81,12 +267,19 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
         foreach (var syntaxRef in configureMethod.DeclaringSyntaxReferences)
         {
             var syntax = syntaxRef.GetSyntax();
+            var builderVariables = CollectConfigureBuilderParameters(configureMethod);
             var invocations = syntax.DescendantNodes().OfType<InvocationExpressionSyntax>();
 
             foreach (var invocation in invocations)
             {
                 if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
                     continue;
+
+                if (!TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilation, out var configuredEntity) ||
+                    !SymbolEqualityComparer.Default.Equals(configuredEntity, entityType))
+                {
+                    continue;
+                }
 
                 var methodName = memberAccess.Name.Identifier.Text;
                 if (methodName == "HasKey")
@@ -99,33 +292,204 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
         return (hasKey, hasNoKey);
     }
 
-    private bool HasFluentKeyConfiguration(INamedTypeSymbol dbContextType, INamedTypeSymbol entityType, Compilation compilation)
+    private static bool TryGetConfiguredEntityType(INamedTypeSymbol configType, out INamedTypeSymbol entityType)
     {
-        var methods = dbContextType.GetMembers("OnModelCreating");
-        if (methods.IsEmpty || methods[0] is not IMethodSymbol onModelCreating)
-            return false;
+        entityType = null!;
 
-        foreach (var syntaxRef in onModelCreating.DeclaringSyntaxReferences)
+        foreach (var iface in configType.AllInterfaces)
         {
-            var syntax = syntaxRef.GetSyntax();
-
-            foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            if (iface.Name != "IEntityTypeConfiguration" ||
+                iface.ContainingNamespace?.ToString() != "Microsoft.EntityFrameworkCore" ||
+                iface.TypeArguments.Length == 0 ||
+                iface.TypeArguments[0] is not INamedTypeSymbol configuredEntity)
             {
-                if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
-                    continue;
-                if (memberAccess.Name.Identifier.Text != "HasKey")
-                    continue;
+                continue;
+            }
 
-                var entityTypeName = ExtractEntityTypeNameFromChain(memberAccess.Expression);
-                if (entityTypeName == null)
-                    continue;
+            entityType = configuredEntity;
+            return true;
+        }
 
-                var matchedType = FindTypeByName(compilation, entityTypeName);
-                if (matchedType != null && SymbolEqualityComparer.Default.Equals(matchedType, entityType))
-                    return true;
+        return false;
+    }
+
+    private static Dictionary<string, INamedTypeSymbol> CollectConfigureBuilderParameters(IMethodSymbol configureMethod)
+    {
+        var builderVariables = new Dictionary<string, INamedTypeSymbol>();
+        foreach (var parameter in configureMethod.Parameters)
+        {
+            if (TryGetEntityTypeBuilderEntity(parameter.Type, out var entityType))
+                builderVariables[parameter.Name] = entityType;
+        }
+
+        return builderVariables;
+    }
+
+    private static bool TryResolveEntityTypeFromBuilderExpression(
+        ExpressionSyntax expression,
+        Dictionary<string, INamedTypeSymbol> builderVariables,
+        Compilation compilation,
+        out INamedTypeSymbol entityType)
+    {
+        entityType = null!;
+
+        if (ExtractEntityTypeNameFromChain(expression) is { } entityTypeName)
+        {
+            var resolvedEntityType = FindTypeByName(compilation, entityTypeName);
+            if (resolvedEntityType != null)
+            {
+                entityType = resolvedEntityType;
+                return true;
+            }
+        }
+
+        if (expression is InvocationExpressionSyntax invocation &&
+            invocation.Expression is MemberAccessExpressionSyntax chainedMemberAccess &&
+            TryResolveEntityTypeFromBuilderExpression(chainedMemberAccess.Expression, builderVariables, compilation, out var chainedEntityType))
+        {
+            entityType = chainedEntityType;
+            return true;
+        }
+
+        if (expression is ParenthesizedExpressionSyntax parenthesized &&
+            TryResolveEntityTypeFromBuilderExpression(parenthesized.Expression, builderVariables, compilation, out var parenthesizedEntityType))
+        {
+            entityType = parenthesizedEntityType;
+            return true;
+        }
+
+        if (expression is IdentifierNameSyntax identifier)
+        {
+            if (TryResolveLocalBuilder(identifier, builderVariables, compilation, out var localEntityType))
+            {
+                entityType = localEntityType;
+                return true;
+            }
+
+            if (builderVariables.TryGetValue(identifier.Identifier.ValueText, out var parameterEntityType))
+            {
+                entityType = parameterEntityType;
+                return true;
             }
         }
 
         return false;
+    }
+
+    private static bool TryResolveLocalBuilder(
+        IdentifierNameSyntax identifier,
+        Dictionary<string, INamedTypeSymbol> builderVariables,
+        Compilation compilation,
+        out INamedTypeSymbol entityType)
+    {
+        entityType = null!;
+        var identifierName = identifier.Identifier.ValueText;
+        var position = identifier.SpanStart;
+
+        foreach (var block in identifier.Ancestors().OfType<BlockSyntax>())
+        {
+            foreach (var statement in block.Statements)
+            {
+                if (statement.SpanStart >= position)
+                    break;
+
+                if (statement is not LocalDeclarationStatementSyntax localDeclaration)
+                    continue;
+
+                foreach (var variable in localDeclaration.Declaration.Variables)
+                {
+                    if (variable.Identifier.ValueText != identifierName || variable.Initializer?.Value == null)
+                        continue;
+
+                    if (TryResolveEntityTypeFromBuilderExpression(variable.Initializer.Value, builderVariables, compilation, out var localEntityType))
+                    {
+                        entityType = localEntityType;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetEntityTypeBuilderEntity(ITypeSymbol? type, out INamedTypeSymbol entityType)
+    {
+        entityType = null!;
+
+        if (type is not INamedTypeSymbol namedType ||
+            namedType.Name != "EntityTypeBuilder" ||
+            namedType.TypeArguments.Length == 0)
+        {
+            return false;
+        }
+
+        var namespaceName = namedType.ContainingNamespace?.ToString();
+        if (namespaceName is not ("Microsoft.EntityFrameworkCore" or "Microsoft.EntityFrameworkCore.Metadata.Builders"))
+            return false;
+
+        if (namedType.TypeArguments[0] is not INamedTypeSymbol builderEntity)
+            return false;
+
+        entityType = builderEntity;
+        return true;
+    }
+
+    private static bool TryGetOwnedEntityType(
+        InvocationExpressionSyntax invocation,
+        MemberAccessExpressionSyntax memberAccess,
+        Dictionary<string, INamedTypeSymbol> builderVariables,
+        Compilation compilation,
+        out INamedTypeSymbol ownedEntity)
+    {
+        ownedEntity = null!;
+
+        if (memberAccess.Name is GenericNameSyntax genericName)
+        {
+            var typeArg = genericName.TypeArgumentList.Arguments.FirstOrDefault();
+            if (typeArg != null)
+            {
+                var resolvedOwnedType = FindTypeByName(compilation, typeArg.ToString());
+                if (resolvedOwnedType != null)
+                {
+                    ownedEntity = resolvedOwnedType;
+                    return true;
+                }
+            }
+        }
+
+        if (!TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilation, out var ownerEntity))
+            return false;
+
+        var lambda = invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression as LambdaExpressionSyntax;
+        if (lambda?.Body is not MemberAccessExpressionSyntax navigationAccess)
+            return false;
+
+        var navigationName = navigationAccess.Name.Identifier.ValueText;
+        var navigation = ownerEntity.GetMembers(navigationName).OfType<IPropertySymbol>().FirstOrDefault();
+        if (navigation?.Type is not INamedTypeSymbol navigationType)
+            return false;
+
+        ownedEntity = TryGetCollectionElementType(navigationType) ?? navigationType;
+        return true;
+    }
+
+    private static INamedTypeSymbol? TryGetCollectionElementType(INamedTypeSymbol navigationType)
+    {
+        if (navigationType.SpecialType == SpecialType.System_String)
+            return null;
+
+        foreach (var iface in navigationType.AllInterfaces)
+        {
+            if (iface.Name == "IEnumerable" &&
+                iface.ContainingNamespace?.ToString() == "System.Collections.Generic" &&
+                iface.TypeArguments.Length == 1 &&
+                iface.TypeArguments[0] is INamedTypeSymbol elementType)
+            {
+                return elementType;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyFixer.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyFixer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -39,6 +40,9 @@ public class EntityMissingPrimaryKeyFixer : CodeFixProvider
         var propertyDecl = token.Parent.AncestorsAndSelf().OfType<PropertyDeclarationSyntax>().FirstOrDefault();
         if (propertyDecl == null) return;
 
+        if (!await CanAddIdPropertyAsync(context.Document, propertyDecl, context.CancellationToken).ConfigureAwait(false))
+            return;
+
         context.RegisterCodeFix(
             CodeAction.Create(
                 "Add 'Id' property to entity",
@@ -47,21 +51,33 @@ public class EntityMissingPrimaryKeyFixer : CodeFixProvider
             diagnostic);
     }
 
+    private static async Task<bool> CanAddIdPropertyAsync(
+        Document document,
+        PropertyDeclarationSyntax propertyDecl,
+        CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var propertySymbol = semanticModel?.GetDeclaredSymbol(propertyDecl, cancellationToken) as IPropertySymbol;
+        if (!TryGetEntityType(propertySymbol, out var entityType))
+            return false;
+
+        if (HasIdMember(entityType))
+            return false;
+
+        return entityType.DeclaringSyntaxReferences.FirstOrDefault() != null;
+    }
+
     private async Task<Document> ApplyFixAsync(Document document, PropertyDeclarationSyntax propertyDecl, CancellationToken cancellationToken)
     {
         var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-        var propertySymbol = semanticModel.GetDeclaredSymbol(propertyDecl, cancellationToken) as IPropertySymbol;
-        if (propertySymbol == null) return document;
+        var propertySymbol = semanticModel?.GetDeclaredSymbol(propertyDecl, cancellationToken) as IPropertySymbol;
+        if (!TryGetEntityType(propertySymbol, out var entityType)) return document;
+        if (HasIdMember(entityType)) return document;
 
-        // Get the TEntity from DbSet<TEntity>
-        var dbSetType = propertySymbol.Type as INamedTypeSymbol;
-        if (dbSetType == null || dbSetType.TypeArguments.Length == 0) return document;
-
-        var entityType = dbSetType.TypeArguments[0];
         var entitySyntaxRef = entityType.DeclaringSyntaxReferences.FirstOrDefault();
         if (entitySyntaxRef == null) return document;
 
-        var entitySyntax = await entitySyntaxRef.GetSyntaxAsync(cancellationToken).ConfigureAwait(false) as ClassDeclarationSyntax;
+        var entitySyntax = await entitySyntaxRef.GetSyntaxAsync(cancellationToken).ConfigureAwait(false) as TypeDeclarationSyntax;
         if (entitySyntax == null) return document;
 
         // We need to get the document containing the entity
@@ -82,5 +98,30 @@ public class EntityMissingPrimaryKeyFixer : CodeFixProvider
         editor.InsertMembers(entitySyntax, 0, new[] { idProperty });
 
         return editor.GetChangedDocument();
+    }
+
+    private static bool TryGetEntityType(IPropertySymbol? propertySymbol, out ITypeSymbol entityType)
+    {
+        entityType = null!;
+
+        if (propertySymbol?.Type is not INamedTypeSymbol dbSetType || dbSetType.TypeArguments.Length == 0)
+            return false;
+
+        entityType = dbSetType.TypeArguments[0];
+        return true;
+    }
+
+    private static bool HasIdMember(ITypeSymbol entityType)
+    {
+        var current = entityType;
+        while (current != null && current.SpecialType != SpecialType.System_Object)
+        {
+            if (current.GetMembers().Any(member => member.Name.Equals("Id", StringComparison.OrdinalIgnoreCase)))
+                return true;
+
+            current = current.BaseType;
+        }
+
+        return false;
     }
 }

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyKeyRules.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyKeyRules.cs
@@ -8,27 +8,24 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
 {
     private bool IsMissingPrimaryKey(
         INamedTypeSymbol entityType,
-        INamedTypeSymbol dbContextType,
         HashSet<INamedTypeSymbol> configuredEntities,
         HashSet<INamedTypeSymbol> keylessEntities,
-        HashSet<INamedTypeSymbol> ownedEntities,
-        Compilation compilation)
+        HashSet<INamedTypeSymbol> ownedEntities)
     {
-        if (HasAttribute(entityType, "KeylessAttribute") || HasAttribute(entityType, "Keyless"))
+        if (HasAttribute(entityType, "KeylessAttribute", "Microsoft.EntityFrameworkCore"))
             return false;
         if (keylessEntities.Contains(entityType))
             return false;
 
+        if (HasAttribute(entityType, "OwnedAttribute", "Microsoft.EntityFrameworkCore"))
+            return false;
         if (ownedEntities.Contains(entityType))
             return false;
 
-        if (HasAttribute(entityType, "PrimaryKeyAttribute") || HasAttribute(entityType, "PrimaryKey"))
+        if (HasValidPrimaryKeyAttribute(entityType))
             return false;
 
         if (HasValidKeyProperty(entityType))
-            return false;
-
-        if (HasFluentKeyConfiguration(dbContextType, entityType, compilation))
             return false;
 
         if (configuredEntities.Contains(entityType))
@@ -37,20 +34,78 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
         return true;
     }
 
-    private bool HasAttribute(ISymbol symbol, string attributeName)
+    private static bool HasAttribute(ISymbol symbol, string attributeName, string namespaceName)
     {
+        var shortName = attributeName.EndsWith("Attribute", StringComparison.Ordinal)
+            ? attributeName.Substring(0, attributeName.Length - 9)
+            : attributeName;
+
         foreach (var attr in symbol.GetAttributes())
         {
             if (attr.AttributeClass == null)
                 continue;
-            if (attr.AttributeClass.Name == attributeName)
-                return true;
-            if (attributeName.EndsWith("Attribute", StringComparison.Ordinal) &&
-                attr.AttributeClass.Name == attributeName.Substring(0, attributeName.Length - 9))
+
+            if (attr.AttributeClass.ContainingNamespace?.ToString() != namespaceName)
+                continue;
+
+            if (attr.AttributeClass.Name == attributeName || attr.AttributeClass.Name == shortName)
                 return true;
         }
 
         return false;
+    }
+
+    private bool HasValidPrimaryKeyAttribute(INamedTypeSymbol entityType)
+    {
+        foreach (var attr in entityType.GetAttributes())
+        {
+            if (attr.AttributeClass == null ||
+                attr.AttributeClass.ContainingNamespace?.ToString() != "Microsoft.EntityFrameworkCore" ||
+                attr.AttributeClass.Name is not ("PrimaryKeyAttribute" or "PrimaryKey"))
+            {
+                continue;
+            }
+
+            var propertyNames = GetPrimaryKeyPropertyNames(attr);
+            if (propertyNames.Count == 0)
+                return false;
+
+            var allPropertiesValid = true;
+            foreach (var propertyName in propertyNames)
+            {
+                if (!TryFindProperty(entityType, propertyName, out var prop) ||
+                    !IsUsableKeyProperty(prop))
+                {
+                    allPropertiesValid = false;
+                    break;
+                }
+            }
+
+            if (allPropertiesValid)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static List<string> GetPrimaryKeyPropertyNames(AttributeData attr)
+    {
+        var propertyNames = new List<string>();
+        foreach (var argument in attr.ConstructorArguments)
+        {
+            if (argument.Kind == TypedConstantKind.Array)
+            {
+                foreach (var value in argument.Values)
+                    if (value.Value is string propertyName)
+                        propertyNames.Add(propertyName);
+            }
+            else if (argument.Value is string propertyName)
+            {
+                propertyNames.Add(propertyName);
+            }
+        }
+
+        return propertyNames;
     }
 
     private bool HasValidKeyProperty(INamedTypeSymbol entityType)
@@ -63,17 +118,15 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
                 if (member is not IPropertySymbol prop)
                     continue;
 
-                if ((HasAttribute(prop, "KeyAttribute") || HasAttribute(prop, "Key")) &&
-                    IsPublicProperty(prop) &&
-                    IsValidKeyType(prop.Type))
+                if (HasAttribute(prop, "KeyAttribute", "System.ComponentModel.DataAnnotations") &&
+                    IsUsableKeyProperty(prop))
                 {
                     return true;
                 }
 
                 if ((prop.Name.Equals("Id", StringComparison.OrdinalIgnoreCase) ||
-                     prop.Name.Equals($"{entityType.Name}Id", StringComparison.OrdinalIgnoreCase)) &&
-                    IsPublicProperty(prop) &&
-                    IsValidKeyType(prop.Type))
+                      prop.Name.Equals($"{entityType.Name}Id", StringComparison.OrdinalIgnoreCase)) &&
+                    IsUsableKeyProperty(prop))
                 {
                     return true;
                 }
@@ -85,6 +138,34 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
         return false;
     }
 
+    private static bool TryFindProperty(INamedTypeSymbol entityType, string propertyName, out IPropertySymbol property)
+    {
+        var current = entityType;
+        while (current != null && current.SpecialType != SpecialType.System_Object)
+        {
+            foreach (var member in current.GetMembers(propertyName))
+            {
+                if (member is IPropertySymbol prop)
+                {
+                    property = prop;
+                    return true;
+                }
+            }
+
+            current = current.BaseType;
+        }
+
+        property = null!;
+        return false;
+    }
+
+    private static bool IsUsableKeyProperty(IPropertySymbol prop)
+    {
+        return IsPublicProperty(prop) &&
+               !HasAttribute(prop, "NotMappedAttribute", "System.ComponentModel.DataAnnotations.Schema") &&
+               IsValidKeyType(prop.Type);
+    }
+
     private static bool IsPublicProperty(IPropertySymbol prop)
     {
         return prop.DeclaredAccessibility == Accessibility.Public &&
@@ -93,6 +174,9 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
 
     private static bool IsValidKeyType(ITypeSymbol type)
     {
+        if (type.SpecialType == SpecialType.System_Object)
+            return false;
+
         if (type.SpecialType != SpecialType.None)
             return true;
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.15</Version>
+        <Version>5.2.16</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Hardens LC010, LC012, LC014, LC015, LC016, LC018, LC020, LC021, LC022, LC023, LC024, LC031, LC034, LC037, LC039, and LC040 analyzer/fixer safety to reduce false positives, false negatives, and unsafe automated rewrites.</PackageReleaseNotes>
+        <PackageReleaseNotes>Hardens LC011 primary-key detection around applied configurations, owned/keyless modeling, namespace-validated attributes, mapped keys, and duplicate-safe fixes.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyEdgeCasesTests.cs
@@ -62,6 +62,60 @@ namespace TestNamespace
     }
 }";
 
+    private const string SemanticMockAttributes = @"
+namespace System.ComponentModel.DataAnnotations
+{
+    public class KeyAttribute : Attribute {}
+}
+namespace System.ComponentModel.DataAnnotations.Schema
+{
+    public class NotMappedAttribute : Attribute {}
+}
+namespace Microsoft.EntityFrameworkCore
+{
+    public class KeylessAttribute : Attribute {}
+    public class PrimaryKeyAttribute : Attribute
+    {
+        public PrimaryKeyAttribute(params string[] propertyNames) {}
+    }
+    public class DbContext : IDisposable
+    {
+        public void Dispose() {}
+        protected virtual void OnModelCreating(ModelBuilder modelBuilder) {}
+    }
+    public class DbSet<T> where T : class {}
+
+    public interface IEntityTypeConfiguration<T> where T : class
+    {
+        void Configure(EntityTypeBuilder<T> builder);
+    }
+
+    public class ModelBuilder
+    {
+        public EntityTypeBuilder<T> Entity<T>() where T : class => new EntityTypeBuilder<T>();
+        public void ApplyConfiguration<T>(IEntityTypeConfiguration<T> configuration) where T : class {}
+        public void ApplyConfigurationsFromAssembly(System.Reflection.Assembly assembly) {}
+    }
+
+    public class EntityTypeBuilder<T> where T : class
+    {
+        public EntityTypeBuilder<T> HasKey(params string[] propertyNames) => this;
+        public EntityTypeBuilder<T> HasKey(System.Linq.Expressions.Expression<Func<T, object>> keyExpression) => this;
+        public EntityTypeBuilder<T> HasNoKey() => this;
+        public EntityTypeBuilder<T> ToTable(string name) => this;
+        public OwnedNavigationBuilder<T, TOwned> OwnsOne<TOwned>(System.Linq.Expressions.Expression<Func<T, TOwned>> navigationExpression) where TOwned : class => new OwnedNavigationBuilder<T, TOwned>();
+        public OwnedNavigationBuilder<T, TOwned> OwnsMany<TOwned>(System.Linq.Expressions.Expression<Func<T, System.Collections.Generic.IEnumerable<TOwned>>> navigationExpression) where TOwned : class => new OwnedNavigationBuilder<T, TOwned>();
+    }
+
+    public class OwnedNavigationBuilder<T, TOwned> where T : class where TOwned : class {}
+}
+
+namespace TestNamespace
+{
+    public class MyDbContext : Microsoft.EntityFrameworkCore.DbContext
+    {
+";
+
     [Fact]
     public async Task TestInnocent_EntityInheritsIdFromBaseClass_ShouldNotTrigger()
     {
@@ -303,6 +357,332 @@ namespace TestNamespace
     {
         public string Value { get; set; }
         public int Count { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_FakeAttributeNames_ShouldNotSuppressDiagnostic()
+    {
+        var test = @"
+using System;
+using FakeAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace FakeAnnotations
+{
+    public class KeyAttribute : Attribute {}
+    public class KeylessAttribute : Attribute {}
+    public class PrimaryKeyAttribute : Attribute
+    {
+        public PrimaryKeyAttribute(params string[] propertyNames) {}
+    }
+}
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class DbContext : IDisposable
+    {
+        public void Dispose() {}
+    }
+
+    public class DbSet<T> where T : class {}
+}
+
+namespace TestNamespace
+{
+    public class MyDbContext : Microsoft.EntityFrameworkCore.DbContext
+    {
+        public DbSet<FakeKeyEntity> {|LC011:FakeKeys|} { get; set; }
+        public DbSet<FakeKeylessEntity> {|LC011:FakeKeyless|} { get; set; }
+        public DbSet<FakePrimaryKeyEntity> {|LC011:FakePrimaryKeys|} { get; set; }
+    }
+
+    public class FakeKeyEntity
+    {
+        [Key]
+        public int Code { get; set; }
+    }
+
+    [Keyless]
+    public class FakeKeylessEntity
+    {
+        public string Name { get; set; }
+    }
+
+    [PrimaryKey(nameof(Code))]
+    public class FakePrimaryKeyEntity
+    {
+        public int Code { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_NotMappedId_ShouldTrigger()
+    {
+        var test = Usings + SemanticMockAttributes + @"
+        public DbSet<IgnoredIdEntity> {|LC011:IgnoredIds|} { get; set; }
+    }
+
+    public class IgnoredIdEntity
+    {
+        [NotMapped]
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_UnappliedEntityTypeConfiguration_ShouldTrigger()
+    {
+        var test = Usings + SemanticMockAttributes + @"
+        public DbSet<ConfiguredElsewhereEntity> {|LC011:ConfiguredElsewhere|} { get; set; }
+    }
+
+    public class ConfiguredElsewhereEntity
+    {
+        public int Code { get; set; }
+    }
+
+    public class ConfiguredElsewhereEntityConfiguration : IEntityTypeConfiguration<ConfiguredElsewhereEntity>
+    {
+        public void Configure(EntityTypeBuilder<ConfiguredElsewhereEntity> builder)
+        {
+            builder.HasKey(e => e.Code);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_AppliedEntityTypeConfiguration_ShouldNotTrigger()
+    {
+        var test = Usings + SemanticMockAttributes + @"
+        public DbSet<AppliedConfigEntity> AppliedConfigs { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfiguration(new AppliedConfigEntityConfiguration());
+        }
+    }
+
+    public class AppliedConfigEntity
+    {
+        public int Code { get; set; }
+    }
+
+    public class AppliedConfigEntityConfiguration : IEntityTypeConfiguration<AppliedConfigEntity>
+    {
+        public void Configure(EntityTypeBuilder<AppliedConfigEntity> builder)
+        {
+            builder.HasKey(e => e.Code);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_BuilderVariableHasKey_ShouldNotTrigger()
+    {
+        var test = Usings + SemanticMockAttributes + @"
+        public DbSet<VariableConfiguredEntity> VariableConfiguredEntities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var entity = modelBuilder.Entity<VariableConfiguredEntity>();
+            entity.HasKey(e => e.Code);
+        }
+    }
+
+    public class VariableConfiguredEntity
+    {
+        public int Code { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ChainedBuilderVariableHasKey_ShouldNotTrigger()
+    {
+        var test = Usings + SemanticMockAttributes + @"
+        public DbSet<ChainedConfiguredEntity> ChainedConfiguredEntities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var entity = modelBuilder.Entity<ChainedConfiguredEntity>();
+            entity.ToTable(""ChainedConfiguredEntities"").HasKey(e => e.Code);
+        }
+    }
+
+    public class ChainedConfiguredEntity
+    {
+        public int Code { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_AppliedConfigurationChainedBuilderHasKey_ShouldNotTrigger()
+    {
+        var test = Usings + SemanticMockAttributes + @"
+        public DbSet<ChainedConfigEntity> ChainedConfigEntities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfiguration(new ChainedConfigEntityConfiguration());
+        }
+    }
+
+    public class ChainedConfigEntity
+    {
+        public int Code { get; set; }
+    }
+
+    public class ChainedConfigEntityConfiguration : IEntityTypeConfiguration<ChainedConfigEntity>
+    {
+        public void Configure(EntityTypeBuilder<ChainedConfigEntity> builder)
+        {
+            builder.ToTable(""ChainedConfigEntities"").HasKey(e => e.Code);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_LocalVariableAppliedConfiguration_ShouldNotTrigger()
+    {
+        var test = Usings + SemanticMockAttributes + @"
+        public DbSet<VariableAppliedConfigEntity> VariableAppliedConfigEntities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var config = new VariableAppliedConfigEntityConfiguration();
+            modelBuilder.ApplyConfiguration(config);
+        }
+    }
+
+    public class VariableAppliedConfigEntity
+    {
+        public int Code { get; set; }
+    }
+
+    public class VariableAppliedConfigEntityConfiguration : IEntityTypeConfiguration<VariableAppliedConfigEntity>
+    {
+        public void Configure(EntityTypeBuilder<VariableAppliedConfigEntity> builder)
+        {
+            builder.HasKey(e => e.Code);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_ExternalApplyConfigurationsFromAssembly_ShouldNotApplyLocalConfig()
+    {
+        var test = Usings + SemanticMockAttributes + @"
+        public DbSet<ExternalAssemblyConfigEntity> {|LC011:ExternalAssemblyConfigs|} { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfigurationsFromAssembly(typeof(string).Assembly);
+        }
+    }
+
+    public class ExternalAssemblyConfigEntity
+    {
+        public int Code { get; set; }
+    }
+
+    public class ExternalAssemblyConfigEntityConfiguration : IEntityTypeConfiguration<ExternalAssemblyConfigEntity>
+    {
+        public void Configure(EntityTypeBuilder<ExternalAssemblyConfigEntity> builder)
+        {
+            builder.HasKey(e => e.Code);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ScopedBuilderVariableReuse_ShouldNotTrigger()
+    {
+        var test = Usings + SemanticMockAttributes + @"
+        public DbSet<ScopedOrder> ScopedOrders { get; set; }
+        public DbSet<ScopedCustomer> ScopedCustomers { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            {
+                var entity = modelBuilder.Entity<ScopedOrder>();
+                entity.HasKey(e => e.Code);
+            }
+
+            {
+                var entity = modelBuilder.Entity<ScopedCustomer>();
+                entity.HasKey(e => e.Code);
+            }
+        }
+    }
+
+    public class ScopedOrder
+    {
+        public int Code { get; set; }
+    }
+
+    public class ScopedCustomer
+    {
+        public int Code { get; set; }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_NonGenericOwnsOne_ShouldNotTriggerForOwnedDbSetType()
+    {
+        var test = Usings + SemanticMockAttributes + @"
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<ShippingAddress> ShippingAddresses { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>().OwnsOne(o => o.ShippingAddress);
+        }
+    }
+
+    public class Order
+    {
+        public int Id { get; set; }
+        public ShippingAddress ShippingAddress { get; set; }
+    }
+
+    public class ShippingAddress
+    {
+        public string Street { get; set; }
+        public string City { get; set; }
     }
 }";
 

--- a/tests/LinqContraband.Tests/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyFixerTests.cs
@@ -44,4 +44,28 @@ namespace Microsoft.EntityFrameworkCore { public class DbContext { } public clas
 
         await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
     }
+
+    [Fact]
+    public async Task Fixer_ShouldNotAddDuplicateId_WhenPrivateIdAlreadyExists()
+    {
+        var test = @"
+using Microsoft.EntityFrameworkCore;
+namespace LinqContraband.Test
+{
+    public class AppDbContext : DbContext
+    {
+        public DbSet<Product> {|LC011:Products|} { get; set; }
+    }
+
+    public class Product
+    {
+        private int Id { get; set; }
+        public string Name { get; set; }
+    }
+}
+namespace Microsoft.EntityFrameworkCore { public class DbContext { } public class DbSet<T> { } }
+";
+
+        await VerifyFix.VerifyCodeFixAsync(test, test);
+    }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyTests.cs
@@ -21,7 +21,7 @@ namespace System.ComponentModel.DataAnnotations
 namespace Microsoft.EntityFrameworkCore
 {
     public class KeylessAttribute : Attribute {}
-    public class PrimaryKeyAttribute : Attribute 
+    public class PrimaryKeyAttribute : Attribute
     {
         public PrimaryKeyAttribute(params string[] propertyNames) {}
     }
@@ -31,13 +31,13 @@ namespace Microsoft.EntityFrameworkCore
         protected virtual void OnModelCreating(ModelBuilder modelBuilder) {}
     }
     public class DbSet<T> where T : class {}
-    
+
     public interface IEntityTypeConfiguration<T> where T : class
     {
         void Configure(EntityTypeBuilder<T> builder);
     }
 
-    public class ModelBuilder 
+    public class ModelBuilder
     {
         public EntityTypeBuilder<T> Entity<T>() where T : class => new EntityTypeBuilder<T>();
     }
@@ -212,8 +212,53 @@ namespace TestNamespace
     [Fact]
     public async Task TestInnocent_EntityWithEntityTypeConfiguration_ShouldNotTrigger()
     {
-        var test = Usings + MockAttributes + @"
+        var test = Usings + @"
+namespace System.ComponentModel.DataAnnotations
+{
+    public class KeyAttribute : Attribute {}
+}
+namespace Microsoft.EntityFrameworkCore
+{
+    public class KeylessAttribute : Attribute {}
+    public class PrimaryKeyAttribute : Attribute
+    {
+        public PrimaryKeyAttribute(params string[] propertyNames) {}
+    }
+    public class DbContext : IDisposable
+    {
+        public void Dispose() {}
+        protected virtual void OnModelCreating(ModelBuilder modelBuilder) {}
+    }
+    public class DbSet<T> where T : class {}
+
+    public interface IEntityTypeConfiguration<T> where T : class
+    {
+        void Configure(EntityTypeBuilder<T> builder);
+    }
+
+    public class ModelBuilder
+    {
+        public EntityTypeBuilder<T> Entity<T>() where T : class => new EntityTypeBuilder<T>();
+        public void ApplyConfiguration<T>(IEntityTypeConfiguration<T> configuration) where T : class {}
+    }
+
+    public class EntityTypeBuilder<T> where T : class
+    {
+        public EntityTypeBuilder<T> HasKey(params string[] propertyNames) => this;
+        public EntityTypeBuilder<T> HasKey(System.Linq.Expressions.Expression<Func<T, object>> keyExpression) => this;
+    }
+}
+
+namespace TestNamespace
+{
+    public class MyDbContext : Microsoft.EntityFrameworkCore.DbContext
+    {
         public DbSet<ConfigEntity> ConfigEntities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfiguration(new ConfigEntityConfiguration());
+        }
     }
 
     public class ConfigEntity


### PR DESCRIPTION
## Summary
- harden LC011 primary-key detection for namespace-validated attributes, mapped keys, keyless/owned opt-outs, and context-specific applied configurations
- add regression coverage for scoped/chained builder variables, local config instances, external assembly config boundaries, non-generic ownership, ignored keys, and duplicate-safe fixes
- update LC011 docs, analyzer-health, samples, changelog, and package metadata for v5.2.16

## Impact
This improves LC011 precision by reducing false positives for valid EF Core key/ownership configuration and false negatives from fake attributes or ignored key properties, while keeping the automatic fixer conservative.

## Validation
- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check`
- `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --filter FullyQualifiedName~LC011` passed with 45 tests
- `dotnet test LinqContraband.sln --framework net10.0` passed with 671 tests
- `git diff --check`
- `codex review --uncommitted`
- CI covers net8.0/net9.0 because local runtimes only include .NET 10