### PR TITLE
fix: cache analyzer scans to prevent build hangs

### DIFF
--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC028_DeepThenInclude/DeepThenIncludeAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC028_DeepThenInclude/DeepThenIncludeAnalyzer.cs
@@ -101,10 +101,14 @@ public sealed class DeepThenIncludeAnalyzer : DiagnosticAnalyzer
     private static int GetMaxDepth(OperationAnalysisContext context, ConditionalWeakTable<SyntaxTree, StrongBox<int>> maxDepthCache)
     {
         var syntaxTree = context.Operation.Syntax.SyntaxTree;
-        if (maxDepthCache.TryGetValue(syntaxTree, out var cached))
-            return cached.Value;
+        return maxDepthCache.GetValue(
+            syntaxTree,
+            tree => new StrongBox<int>(ReadMaxDepth(context.Options.AnalyzerConfigOptionsProvider, tree))).Value;
+    }
 
-        var options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
+    private static int ReadMaxDepth(AnalyzerConfigOptionsProvider optionsProvider, SyntaxTree syntaxTree)
+    {
+        var options = optionsProvider.GetOptions(syntaxTree);
         var maxDepth = DefaultMaxDepth;
 
         if (options.TryGetValue(MaxDepthOptionKey, out var value) &&
@@ -114,7 +118,6 @@ public sealed class DeepThenIncludeAnalyzer : DiagnosticAnalyzer
             maxDepth = configuredMaxDepth;
         }
 
-        maxDepthCache.Add(syntaxTree, new StrongBox<int>(maxDepth));
         return maxDepth;
     }
 

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingThresholds.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingThresholds.cs
@@ -10,10 +10,14 @@ public sealed partial class ExcessiveEagerLoadingAnalyzer
     private static int GetThreshold(OperationAnalysisContext context, ConditionalWeakTable<SyntaxTree, StrongBox<int>> thresholdCache)
     {
         var syntaxTree = context.Operation.Syntax.SyntaxTree;
-        if (thresholdCache.TryGetValue(syntaxTree, out var cached))
-            return cached.Value;
+        return thresholdCache.GetValue(
+            syntaxTree,
+            tree => new StrongBox<int>(ReadThreshold(context.Options.AnalyzerConfigOptionsProvider, tree))).Value;
+    }
 
-        var options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
+    private static int ReadThreshold(AnalyzerConfigOptionsProvider optionsProvider, SyntaxTree syntaxTree)
+    {
+        var options = optionsProvider.GetOptions(syntaxTree);
         var threshold = DefaultThreshold;
 
         if (options.TryGetValue(ThresholdOptionKey, out var value) &&
@@ -23,7 +27,6 @@ public sealed partial class ExcessiveEagerLoadingAnalyzer
             threshold = configuredThreshold;
         }
 
-        thresholdCache.Add(syntaxTree, new StrongBox<int>(threshold));
         return threshold;
     }
 }

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultAnalyzer.cs
@@ -37,10 +37,20 @@ public sealed class FindInsteadOfFirstOrDefaultAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(InitializeCompilation);
     }
 
-    private void AnalyzeInvocation(OperationAnalysisContext context)
+    private static void InitializeCompilation(CompilationStartAnalysisContext context)
+    {
+        var primaryKeyCache = FindInsteadOfFirstOrDefaultKeyAnalysis.CreateCache(context.Compilation);
+        context.RegisterOperationAction(
+            operationContext => AnalyzeInvocation(operationContext, primaryKeyCache),
+            OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(
+        OperationAnalysisContext context,
+        FindInsteadOfFirstOrDefaultKeyAnalysis.PrimaryKeyCache primaryKeyCache)
     {
         var invocation = (IInvocationOperation)context.Operation;
         var method = invocation.TargetMethod;
@@ -59,15 +69,15 @@ public sealed class FindInsteadOfFirstOrDefaultAnalyzer : DiagnosticAnalyzer
         if (lambda == null) return;
 
         // Analyze predicate body for x.Id == id
-        if (IsPrimaryKeyEquality(lambda, context.Compilation, context.CancellationToken, out var pkName))
+        if (IsPrimaryKeyEquality(lambda, primaryKeyCache, context.CancellationToken, out var pkName))
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), method.Name));
         }
     }
 
-    private bool IsPrimaryKeyEquality(
+    private static bool IsPrimaryKeyEquality(
         IAnonymousFunctionOperation lambda,
-        Compilation compilation,
+        FindInsteadOfFirstOrDefaultKeyAnalysis.PrimaryKeyCache primaryKeyCache,
         System.Threading.CancellationToken cancellationToken,
         out string? pkName)
     {
@@ -81,17 +91,17 @@ public sealed class FindInsteadOfFirstOrDefaultAnalyzer : DiagnosticAnalyzer
         if (body is IBinaryOperation binary && binary.OperatorKind == BinaryOperatorKind.Equals)
         {
             // Check left or right for primary key property
-            if (IsPrimaryKeyProperty(binary.LeftOperand, lambda, compilation, cancellationToken, out pkName)) return true;
-            if (IsPrimaryKeyProperty(binary.RightOperand, lambda, compilation, cancellationToken, out pkName)) return true;
+            if (IsPrimaryKeyProperty(binary.LeftOperand, lambda, primaryKeyCache, cancellationToken, out pkName)) return true;
+            if (IsPrimaryKeyProperty(binary.RightOperand, lambda, primaryKeyCache, cancellationToken, out pkName)) return true;
         }
 
         return false;
     }
 
-    private bool IsPrimaryKeyProperty(
+    private static bool IsPrimaryKeyProperty(
         IOperation operation,
         IAnonymousFunctionOperation lambda,
-        Compilation compilation,
+        FindInsteadOfFirstOrDefaultKeyAnalysis.PrimaryKeyCache primaryKeyCache,
         System.Threading.CancellationToken cancellationToken,
         out string? pkName)
     {
@@ -105,9 +115,8 @@ public sealed class FindInsteadOfFirstOrDefaultAnalyzer : DiagnosticAnalyzer
             if (receiver is IParameterReferenceOperation paramRef &&
                 SymbolEqualityComparer.Default.Equals(paramRef.Parameter, lambda.Symbol.Parameters.FirstOrDefault()))
             {
-                var pk = FindInsteadOfFirstOrDefaultKeyAnalysis.TryFindSafePrimaryKey(
+                var pk = primaryKeyCache.TryFindSafePrimaryKey(
                     propRef.Property.ContainingType,
-                    compilation,
                     cancellationToken);
                 if (pk != null && propRef.Property.Name == pk)
                 {

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultKeyAnalysis.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultKeyAnalysis.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using LinqContraband.Extensions;
@@ -9,30 +10,71 @@ namespace LinqContraband.Analyzers.LC023_FindInsteadOfFirstOrDefault;
 
 internal static class FindInsteadOfFirstOrDefaultKeyAnalysis
 {
+    public static PrimaryKeyCache CreateCache(Compilation compilation)
+    {
+        return new PrimaryKeyCache(compilation);
+    }
+
     public static string? TryFindSafePrimaryKey(
         ITypeSymbol entityType,
         Compilation compilation,
         CancellationToken cancellationToken)
     {
-        var configuredKey = TryFindConfiguredPrimaryKey(entityType, compilation, cancellationToken);
-        if (configuredKey.IsConfigured)
-            return configuredKey.PropertyName;
-
-        return entityType.TryFindPrimaryKey();
+        return CreateCache(compilation).TryFindSafePrimaryKey(entityType, cancellationToken);
     }
 
-    private static ConfiguredPrimaryKey TryFindConfiguredPrimaryKey(
-        ITypeSymbol entityType,
+    internal sealed class PrimaryKeyCache
+    {
+        private readonly object syncRoot = new();
+        private readonly Compilation compilation;
+        private Dictionary<ITypeSymbol, ConfiguredPrimaryKey>? configuredPrimaryKeys;
+
+        internal PrimaryKeyCache(Compilation compilation)
+        {
+            this.compilation = compilation;
+        }
+
+        public string? TryFindSafePrimaryKey(ITypeSymbol entityType, CancellationToken cancellationToken)
+        {
+            var configuredKey = GetConfiguredPrimaryKeys(cancellationToken).TryGetValue(entityType, out var primaryKey)
+                ? primaryKey
+                : ConfiguredPrimaryKey.NotConfigured;
+
+            if (configuredKey.IsConfigured)
+                return configuredKey.PropertyName;
+
+            return entityType.TryFindPrimaryKey();
+        }
+
+        private Dictionary<ITypeSymbol, ConfiguredPrimaryKey> GetConfiguredPrimaryKeys(CancellationToken cancellationToken)
+        {
+            if (configuredPrimaryKeys != null)
+                return configuredPrimaryKeys;
+
+            lock (syncRoot)
+            {
+                configuredPrimaryKeys ??= BuildConfiguredPrimaryKeys(compilation, cancellationToken);
+                return configuredPrimaryKeys;
+            }
+        }
+    }
+
+    private static Dictionary<ITypeSymbol, ConfiguredPrimaryKey> BuildConfiguredPrimaryKeys(
         Compilation compilation,
         CancellationToken cancellationToken)
     {
+        var configuredPrimaryKeys = new Dictionary<ITypeSymbol, ConfiguredPrimaryKey>(SymbolEqualityComparer.Default);
+
         foreach (var tree in compilation.SyntaxTrees)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var root = tree.GetRoot(cancellationToken);
             var semanticModel = compilation.GetSemanticModel(tree);
 
             foreach (var invocationSyntax in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (invocationSyntax.Expression is not MemberAccessExpressionSyntax memberAccess ||
                     memberAccess.Name.Identifier.ValueText != "HasKey")
                 {
@@ -41,25 +83,35 @@ internal static class FindInsteadOfFirstOrDefaultKeyAnalysis
 
                 if (semanticModel.GetOperation(invocationSyntax, cancellationToken) is not IInvocationOperation invocation ||
                     invocation.TargetMethod.Name != "HasKey" ||
-                    !ReceiverTargetsEntity(invocation.GetInvocationReceiverType(), entityType))
+                    !TryGetEntityTypeBuilderEntity(invocation.GetInvocationReceiverType(), out var entityType) ||
+                    configuredPrimaryKeys.ContainsKey(entityType))
                 {
                     continue;
                 }
 
-                return AnalyzeKeyArgument(invocation.Arguments.FirstOrDefault()?.Value);
+                configuredPrimaryKeys.Add(
+                    entityType,
+                    AnalyzeKeyArgument(invocation.Arguments.FirstOrDefault()?.Value));
             }
         }
 
-        return ConfiguredPrimaryKey.NotConfigured;
+        return configuredPrimaryKeys;
     }
 
-    private static bool ReceiverTargetsEntity(ITypeSymbol? receiverType, ITypeSymbol entityType)
+    private static bool TryGetEntityTypeBuilderEntity(ITypeSymbol? receiverType, out ITypeSymbol entityType)
     {
-        return receiverType is INamedTypeSymbol namedType &&
-               namedType.IsGenericType &&
-               namedType.TypeArguments.Length == 1 &&
-               IsEntityTypeBuilder(namedType) &&
-               SymbolEqualityComparer.Default.Equals(namedType.TypeArguments[0], entityType);
+        entityType = null!;
+
+        if (receiverType is not INamedTypeSymbol namedType ||
+            !namedType.IsGenericType ||
+            namedType.TypeArguments.Length != 1 ||
+            !IsEntityTypeBuilder(namedType))
+        {
+            return false;
+        }
+
+        entityType = namedType.TypeArguments[0];
+        return true;
     }
 
     private static bool IsEntityTypeBuilder(INamedTypeSymbol namedType)

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyAnalyzer.cs
@@ -47,11 +47,20 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterSymbolAction(AnalyzeDbContext, SymbolKind.NamedType);
+        context.RegisterCompilationStartAction(InitializeCompilation);
     }
 
-    private void AnalyzeDbContext(SymbolAnalysisContext context)
+    private void InitializeCompilation(CompilationStartAnalysisContext context)
     {
+        var compilationModel = new CompilationModel(context.Compilation);
+        context.RegisterSymbolAction(
+            symbolContext => AnalyzeDbContext(symbolContext, compilationModel),
+            SymbolKind.NamedType);
+    }
+
+    private void AnalyzeDbContext(SymbolAnalysisContext context, CompilationModel compilationModel)
+    {
+        context.CancellationToken.ThrowIfCancellationRequested();
         var namedType = (INamedTypeSymbol)context.Symbol;
 
         if (!namedType.IsDbContext())
@@ -63,10 +72,17 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer : DiagnosticAnalyzer
         var keylessEntities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
         var ownedEntities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
         var configuredEntities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-        ScanOnModelCreating(namedType, configuredEntities, keylessEntities, ownedEntities, context.Compilation);
+        ScanOnModelCreating(
+            namedType,
+            configuredEntities,
+            keylessEntities,
+            ownedEntities,
+            compilationModel,
+            context.CancellationToken);
 
         foreach (var member in namedType.GetMembers())
         {
+            context.CancellationToken.ThrowIfCancellationRequested();
             if (!TryGetDbSetMember(member, out var entityType, out var location))
                 continue;
 

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyConfigurationScan.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyConfigurationScan.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -12,7 +13,8 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
         HashSet<INamedTypeSymbol> configuredEntities,
         HashSet<INamedTypeSymbol> keylessEntities,
         HashSet<INamedTypeSymbol> ownedEntities,
-        Compilation compilation)
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken)
     {
         var methods = dbContextType.GetMembers("OnModelCreating");
         if (methods.IsEmpty || methods[0] is not IMethodSymbol onModelCreating)
@@ -20,95 +22,117 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
 
         foreach (var syntaxRef in onModelCreating.DeclaringSyntaxReferences)
         {
-            var syntax = syntaxRef.GetSyntax();
+            cancellationToken.ThrowIfCancellationRequested();
+            var syntax = syntaxRef.GetSyntax(cancellationToken);
             var builderVariables = new Dictionary<string, INamedTypeSymbol>();
 
             foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
                     continue;
 
                 var methodName = memberAccess.Name.Identifier.Text;
                 if (methodName == "HasKey" &&
-                    TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilation, out var configuredEntity))
+                    TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilationModel, cancellationToken, out var configuredEntity))
                 {
                     configuredEntities.Add(configuredEntity);
                 }
                 else if (methodName == "HasNoKey" &&
-                         TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilation, out var keylessEntity))
+                         TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilationModel, cancellationToken, out var keylessEntity))
                 {
                     keylessEntities.Add(keylessEntity);
                 }
                 else if (methodName is "OwnsOne" or "OwnsMany" &&
-                         TryGetOwnedEntityType(invocation, memberAccess, builderVariables, compilation, out var ownedEntity))
+                         TryGetOwnedEntityType(invocation, memberAccess, builderVariables, compilationModel, cancellationToken, out var ownedEntity))
                 {
                     ownedEntities.Add(ownedEntity);
                 }
                 else if (methodName == "ApplyConfiguration")
                 {
-                    ScanAppliedConfiguration(invocation, dbContextType, compilation, configuredEntities, keylessEntities);
+                    ScanAppliedConfiguration(invocation, dbContextType, compilationModel, configuredEntities, keylessEntities, cancellationToken);
                 }
                 else if (methodName == "ApplyConfigurationsFromAssembly" &&
-                         ShouldScanCurrentAssemblyConfigurations(invocation, compilation))
+                         ShouldScanCurrentAssemblyConfigurations(invocation, compilationModel, cancellationToken))
                 {
-                    ScanEntityTypeConfigurations(compilation, configuredEntities, keylessEntities);
+                    ScanEntityTypeConfigurations(compilationModel, configuredEntities, keylessEntities, cancellationToken);
                 }
             }
         }
     }
 
     private static void ScanEntityTypeConfigurations(
-        Compilation compilation,
+        CompilationModel compilationModel,
         HashSet<INamedTypeSymbol> configuredEntities,
-        HashSet<INamedTypeSymbol> keylessEntities)
+        HashSet<INamedTypeSymbol> keylessEntities,
+        CancellationToken cancellationToken)
     {
+        var scan = compilationModel.GetEntityTypeConfigurationScan(cancellationToken);
+        configuredEntities.UnionWith(scan.ConfiguredEntities);
+        keylessEntities.UnionWith(scan.KeylessEntities);
+    }
+
+    private static EntityTypeConfigurationScan BuildEntityTypeConfigurationScan(
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken)
+    {
+        var scan = new EntityTypeConfigurationScan();
+        var compilation = compilationModel.Compilation;
         var configInterface = compilation.GetTypeByMetadataName("Microsoft.EntityFrameworkCore.IEntityTypeConfiguration`1");
         if (configInterface == null)
-            return;
+            return scan;
 
-        foreach (var type in GetAllTypes(compilation.Assembly.GlobalNamespace))
+        foreach (var type in compilationModel.GetAllTypes(cancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (type.AllInterfaces.IsEmpty)
                 continue;
 
             foreach (var iface in type.AllInterfaces)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (!SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, configInterface))
                     continue;
 
                 if (iface.TypeArguments.Length > 0 &&
                     iface.TypeArguments[0] is INamedTypeSymbol entityType)
                 {
-                    var (hasKey, hasNoKey) = CheckConfigureMethod(type, entityType, compilation);
+                    var (hasKey, hasNoKey) = CheckConfigureMethod(type, entityType, compilationModel, cancellationToken);
 
                     if (hasKey)
-                        configuredEntities.Add(entityType);
+                        scan.ConfiguredEntities.Add(entityType);
 
                     if (hasNoKey)
-                        keylessEntities.Add(entityType);
+                        scan.KeylessEntities.Add(entityType);
                 }
             }
         }
+
+        return scan;
     }
 
     private static void ScanAppliedConfiguration(
         InvocationExpressionSyntax invocation,
         INamedTypeSymbol dbContextType,
-        Compilation compilation,
+        CompilationModel compilationModel,
         HashSet<INamedTypeSymbol> configuredEntities,
-        HashSet<INamedTypeSymbol> keylessEntities)
+        HashSet<INamedTypeSymbol> keylessEntities,
+        CancellationToken cancellationToken)
     {
         var configurationExpression = invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression;
         var configType = configurationExpression == null
             ? null
-            : ResolveConfigurationType(configurationExpression, dbContextType, compilation);
+            : ResolveConfigurationType(configurationExpression, dbContextType, compilationModel, cancellationToken);
         if (configType == null)
             return;
 
         if (!TryGetConfiguredEntityType(configType, out var entityType))
             return;
 
-        var (hasKey, hasNoKey) = CheckConfigureMethod(configType, entityType, compilation);
+        var (hasKey, hasNoKey) = CheckConfigureMethod(configType, entityType, compilationModel, cancellationToken);
 
         if (hasKey)
             configuredEntities.Add(entityType);
@@ -117,7 +141,10 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
             keylessEntities.Add(entityType);
     }
 
-    private static bool ShouldScanCurrentAssemblyConfigurations(InvocationExpressionSyntax invocation, Compilation compilation)
+    private static bool ShouldScanCurrentAssemblyConfigurations(
+        InvocationExpressionSyntax invocation,
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken)
     {
         if (invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression is not MemberAccessExpressionSyntax memberAccess ||
             memberAccess.Name.Identifier.ValueText != "Assembly" ||
@@ -126,28 +153,31 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
             return false;
         }
 
-        var assemblyMarkerType = FindTypeByName(compilation, typeOfExpression.Type.ToString());
+        var assemblyMarkerType = compilationModel.FindTypeByName(typeOfExpression.Type.ToString(), cancellationToken);
         return assemblyMarkerType != null &&
-               SymbolEqualityComparer.Default.Equals(assemblyMarkerType.ContainingAssembly, compilation.Assembly);
+               SymbolEqualityComparer.Default.Equals(assemblyMarkerType.ContainingAssembly, compilationModel.Compilation.Assembly);
     }
 
     private static INamedTypeSymbol? ResolveConfigurationType(
         ExpressionSyntax expression,
         INamedTypeSymbol dbContextType,
-        Compilation compilation)
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (expression is ObjectCreationExpressionSyntax objectCreation)
-            return FindTypeByName(compilation, objectCreation.Type.ToString());
+            return compilationModel.FindTypeByName(objectCreation.Type.ToString(), cancellationToken);
 
         if (expression is ImplicitObjectCreationExpressionSyntax implicitObjectCreation)
-            return ResolveImplicitObjectCreationType(implicitObjectCreation, dbContextType, compilation);
+            return ResolveImplicitObjectCreationType(implicitObjectCreation, dbContextType, compilationModel, cancellationToken);
 
         if (expression is ParenthesizedExpressionSyntax parenthesized)
-            return ResolveConfigurationType(parenthesized.Expression, dbContextType, compilation);
+            return ResolveConfigurationType(parenthesized.Expression, dbContextType, compilationModel, cancellationToken);
 
         if (expression is IdentifierNameSyntax identifier)
         {
-            if (TryResolveLocalConfiguration(identifier, dbContextType, compilation, out var localConfigType))
+            if (TryResolveLocalConfiguration(identifier, dbContextType, compilationModel, cancellationToken, out var localConfigType))
                 return localConfigType;
 
             return TryGetConfigurationTypeFromMember(dbContextType, identifier.Identifier.ValueText, out var memberConfigType)
@@ -168,20 +198,21 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
     private static INamedTypeSymbol? ResolveImplicitObjectCreationType(
         ImplicitObjectCreationExpressionSyntax implicitObjectCreation,
         INamedTypeSymbol dbContextType,
-        Compilation compilation)
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken)
     {
         var variable = implicitObjectCreation.Ancestors().OfType<VariableDeclaratorSyntax>().FirstOrDefault();
         var localDeclaration = variable?.Parent?.Parent as LocalDeclarationStatementSyntax;
         if (localDeclaration != null)
-            return FindTypeByName(compilation, localDeclaration.Declaration.Type.ToString());
+            return compilationModel.FindTypeByName(localDeclaration.Declaration.Type.ToString(), cancellationToken);
 
         var fieldDeclaration = variable?.Parent?.Parent as FieldDeclarationSyntax;
         if (fieldDeclaration != null)
-            return FindTypeByName(compilation, fieldDeclaration.Declaration.Type.ToString());
+            return compilationModel.FindTypeByName(fieldDeclaration.Declaration.Type.ToString(), cancellationToken);
 
         var propertyDeclaration = implicitObjectCreation.Ancestors().OfType<PropertyDeclarationSyntax>().FirstOrDefault();
         if (propertyDeclaration != null)
-            return FindTypeByName(compilation, propertyDeclaration.Type.ToString());
+            return compilationModel.FindTypeByName(propertyDeclaration.Type.ToString(), cancellationToken);
 
         return null;
     }
@@ -189,7 +220,8 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
     private static bool TryResolveLocalConfiguration(
         IdentifierNameSyntax identifier,
         INamedTypeSymbol dbContextType,
-        Compilation compilation,
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken,
         out INamedTypeSymbol configType)
     {
         configType = null!;
@@ -198,8 +230,12 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
 
         foreach (var block in identifier.Ancestors().OfType<BlockSyntax>())
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             foreach (var statement in block.Statements)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (statement.SpanStart >= position)
                     break;
 
@@ -211,9 +247,9 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
                     if (variable.Identifier.ValueText != identifierName || variable.Initializer?.Value == null)
                         continue;
 
-                    var resolvedConfigType = ResolveConfigurationType(variable.Initializer.Value, dbContextType, compilation);
+                    var resolvedConfigType = ResolveConfigurationType(variable.Initializer.Value, dbContextType, compilationModel, cancellationToken);
                     if (resolvedConfigType == null && variable.Initializer.Value is ImplicitObjectCreationExpressionSyntax)
-                        resolvedConfigType = FindTypeByName(compilation, localDeclaration.Declaration.Type.ToString());
+                        resolvedConfigType = compilationModel.FindTypeByName(localDeclaration.Declaration.Type.ToString(), cancellationToken);
 
                     if (resolvedConfigType != null)
                     {
@@ -255,7 +291,8 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
     private static (bool hasKey, bool hasNoKey) CheckConfigureMethod(
         INamedTypeSymbol configClass,
         INamedTypeSymbol entityType,
-        Compilation compilation)
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken)
     {
         var configureMethod = configClass.GetMembers("Configure").FirstOrDefault() as IMethodSymbol;
         if (configureMethod == null)
@@ -266,16 +303,19 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
 
         foreach (var syntaxRef in configureMethod.DeclaringSyntaxReferences)
         {
-            var syntax = syntaxRef.GetSyntax();
+            cancellationToken.ThrowIfCancellationRequested();
+            var syntax = syntaxRef.GetSyntax(cancellationToken);
             var builderVariables = CollectConfigureBuilderParameters(configureMethod);
             var invocations = syntax.DescendantNodes().OfType<InvocationExpressionSyntax>();
 
             foreach (var invocation in invocations)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
                     continue;
 
-                if (!TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilation, out var configuredEntity) ||
+                if (!TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilationModel, cancellationToken, out var configuredEntity) ||
                     !SymbolEqualityComparer.Default.Equals(configuredEntity, entityType))
                 {
                     continue;
@@ -328,14 +368,16 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
     private static bool TryResolveEntityTypeFromBuilderExpression(
         ExpressionSyntax expression,
         Dictionary<string, INamedTypeSymbol> builderVariables,
-        Compilation compilation,
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken,
         out INamedTypeSymbol entityType)
     {
         entityType = null!;
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (ExtractEntityTypeNameFromChain(expression) is { } entityTypeName)
         {
-            var resolvedEntityType = FindTypeByName(compilation, entityTypeName);
+            var resolvedEntityType = compilationModel.FindTypeByName(entityTypeName, cancellationToken);
             if (resolvedEntityType != null)
             {
                 entityType = resolvedEntityType;
@@ -345,14 +387,14 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
 
         if (expression is InvocationExpressionSyntax invocation &&
             invocation.Expression is MemberAccessExpressionSyntax chainedMemberAccess &&
-            TryResolveEntityTypeFromBuilderExpression(chainedMemberAccess.Expression, builderVariables, compilation, out var chainedEntityType))
+            TryResolveEntityTypeFromBuilderExpression(chainedMemberAccess.Expression, builderVariables, compilationModel, cancellationToken, out var chainedEntityType))
         {
             entityType = chainedEntityType;
             return true;
         }
 
         if (expression is ParenthesizedExpressionSyntax parenthesized &&
-            TryResolveEntityTypeFromBuilderExpression(parenthesized.Expression, builderVariables, compilation, out var parenthesizedEntityType))
+            TryResolveEntityTypeFromBuilderExpression(parenthesized.Expression, builderVariables, compilationModel, cancellationToken, out var parenthesizedEntityType))
         {
             entityType = parenthesizedEntityType;
             return true;
@@ -360,7 +402,7 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
 
         if (expression is IdentifierNameSyntax identifier)
         {
-            if (TryResolveLocalBuilder(identifier, builderVariables, compilation, out var localEntityType))
+            if (TryResolveLocalBuilder(identifier, builderVariables, compilationModel, cancellationToken, out var localEntityType))
             {
                 entityType = localEntityType;
                 return true;
@@ -379,7 +421,8 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
     private static bool TryResolveLocalBuilder(
         IdentifierNameSyntax identifier,
         Dictionary<string, INamedTypeSymbol> builderVariables,
-        Compilation compilation,
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken,
         out INamedTypeSymbol entityType)
     {
         entityType = null!;
@@ -388,8 +431,12 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
 
         foreach (var block in identifier.Ancestors().OfType<BlockSyntax>())
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             foreach (var statement in block.Statements)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (statement.SpanStart >= position)
                     break;
 
@@ -401,7 +448,7 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
                     if (variable.Identifier.ValueText != identifierName || variable.Initializer?.Value == null)
                         continue;
 
-                    if (TryResolveEntityTypeFromBuilderExpression(variable.Initializer.Value, builderVariables, compilation, out var localEntityType))
+                    if (TryResolveEntityTypeFromBuilderExpression(variable.Initializer.Value, builderVariables, compilationModel, cancellationToken, out var localEntityType))
                     {
                         entityType = localEntityType;
                         return true;
@@ -439,7 +486,8 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
         InvocationExpressionSyntax invocation,
         MemberAccessExpressionSyntax memberAccess,
         Dictionary<string, INamedTypeSymbol> builderVariables,
-        Compilation compilation,
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken,
         out INamedTypeSymbol ownedEntity)
     {
         ownedEntity = null!;
@@ -449,7 +497,7 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
             var typeArg = genericName.TypeArgumentList.Arguments.FirstOrDefault();
             if (typeArg != null)
             {
-                var resolvedOwnedType = FindTypeByName(compilation, typeArg.ToString());
+                var resolvedOwnedType = compilationModel.FindTypeByName(typeArg.ToString(), cancellationToken);
                 if (resolvedOwnedType != null)
                 {
                     ownedEntity = resolvedOwnedType;
@@ -458,7 +506,7 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
             }
         }
 
-        if (!TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilation, out var ownerEntity))
+        if (!TryResolveEntityTypeFromBuilderExpression(memberAccess.Expression, builderVariables, compilationModel, cancellationToken, out var ownerEntity))
             return false;
 
         var lambda = invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression as LambdaExpressionSyntax;

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyTypeLookup.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyTypeLookup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -8,29 +9,111 @@ namespace LinqContraband.Analyzers.LC011_EntityMissingPrimaryKey;
 
 public sealed partial class EntityMissingPrimaryKeyAnalyzer
 {
-    private static void TryAddResolvedType(string? typeName, Compilation compilation, HashSet<INamedTypeSymbol> targetSet)
+    private sealed class CompilationModel
     {
-        if (typeName == null)
-            return;
-        var resolved = FindTypeByName(compilation, typeName);
-        if (resolved != null)
-            targetSet.Add(resolved);
+        private readonly object syncRoot = new();
+        private readonly Compilation compilation;
+        private readonly Dictionary<string, INamedTypeSymbol?> typeLookupCache = new(StringComparer.Ordinal);
+        private List<INamedTypeSymbol>? allTypes;
+        private EntityTypeConfigurationScan? entityTypeConfigurationScan;
+
+        public CompilationModel(Compilation compilation)
+        {
+            this.compilation = compilation;
+        }
+
+        public Compilation Compilation => compilation;
+
+        public IReadOnlyList<INamedTypeSymbol> GetAllTypes(CancellationToken cancellationToken)
+        {
+            if (allTypes != null)
+                return allTypes;
+
+            lock (syncRoot)
+            {
+                allTypes ??= BuildAllTypes(cancellationToken);
+                return allTypes;
+            }
+        }
+
+        public INamedTypeSymbol? FindTypeByName(string typeName, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            lock (syncRoot)
+            {
+                if (!typeLookupCache.TryGetValue(typeName, out var cachedType))
+                {
+                    cachedType = FindTypeByNameCore(typeName, cancellationToken);
+                    typeLookupCache[typeName] = cachedType;
+                }
+
+                return cachedType;
+            }
+        }
+
+        public EntityTypeConfigurationScan GetEntityTypeConfigurationScan(CancellationToken cancellationToken)
+        {
+            if (entityTypeConfigurationScan != null)
+                return entityTypeConfigurationScan;
+
+            lock (syncRoot)
+            {
+                entityTypeConfigurationScan ??= BuildEntityTypeConfigurationScan(this, cancellationToken);
+                return entityTypeConfigurationScan;
+            }
+        }
+
+        private List<INamedTypeSymbol> BuildAllTypes(CancellationToken cancellationToken)
+        {
+            var result = new List<INamedTypeSymbol>();
+            AddNamespaceTypes(compilation.Assembly.GlobalNamespace, result, cancellationToken);
+            return result;
+        }
+
+        private INamedTypeSymbol? FindTypeByNameCore(string typeName, CancellationToken cancellationToken)
+        {
+            var type = compilation.GetTypeByMetadataName(typeName);
+            if (type != null)
+                return type;
+
+            var simpleName = typeName.Contains(".", StringComparison.Ordinal)
+                ? typeName.Substring(typeName.LastIndexOf(".", StringComparison.Ordinal) + 1)
+                : typeName;
+
+            foreach (var candidate in GetAllTypes(cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (candidate.Name != simpleName)
+                    continue;
+
+                if (!typeName.Contains(".", StringComparison.Ordinal))
+                    return candidate;
+
+                var fullName = candidate.ToDisplayString();
+                if (fullName.Equals(typeName, StringComparison.Ordinal))
+                    return candidate;
+
+                if (fullName.EndsWith(typeName, StringComparison.Ordinal))
+                {
+                    var prefixLength = fullName.Length - typeName.Length;
+                    if (prefixLength == 0 || fullName[prefixLength - 1] == '.')
+                        return candidate;
+                }
+            }
+
+            return null;
+        }
     }
 
-    private static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol ns)
+    private sealed class EntityTypeConfigurationScan
     {
-        foreach (var type in ns.GetTypeMembers())
-        {
-            yield return type;
-            foreach (var nested in type.GetTypeMembers())
-                yield return nested;
-        }
+        public HashSet<INamedTypeSymbol> ConfiguredEntities { get; } =
+            new(SymbolEqualityComparer.Default);
 
-        foreach (var childNs in ns.GetNamespaceMembers())
-        {
-            foreach (var type in GetAllTypes(childNs))
-                yield return type;
-        }
+        public HashSet<INamedTypeSymbol> KeylessEntities { get; } =
+            new(SymbolEqualityComparer.Default);
     }
 
     private static string? ExtractEntityTypeNameFromChain(ExpressionSyntax expression)
@@ -60,81 +143,35 @@ public sealed partial class EntityMissingPrimaryKeyAnalyzer
         return null;
     }
 
-    private static string? ExtractOwnedTypeName(InvocationExpressionSyntax invocation)
+    private static void AddNamespaceTypes(
+        INamespaceSymbol ns,
+        List<INamedTypeSymbol> result,
+        CancellationToken cancellationToken)
     {
-        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-            memberAccess.Name is GenericNameSyntax genericName)
-        {
-            var typeArg = genericName.TypeArgumentList.Arguments.FirstOrDefault();
-            if (typeArg != null)
-                return typeArg.ToString();
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
-        return null;
-    }
-
-    private static INamedTypeSymbol? FindTypeByName(Compilation compilation, string typeName)
-    {
-        var type = compilation.GetTypeByMetadataName(typeName);
-        if (type != null)
-            return type;
-
-        var simpleName = typeName.Contains(".", StringComparison.Ordinal)
-            ? typeName.Substring(typeName.LastIndexOf(".", StringComparison.Ordinal) + 1)
-            : typeName;
-        return FindTypeInNamespace(compilation.GlobalNamespace, simpleName, typeName);
-    }
-
-    private static INamedTypeSymbol? FindTypeInNamespace(INamespaceSymbol ns, string simpleName, string fullName)
-    {
         foreach (var type in ns.GetTypeMembers())
         {
-            if (type.Name == simpleName)
-            {
-                if (fullName.Contains(".", StringComparison.Ordinal))
-                {
-                    var typeFullName = type.ToDisplayString();
-                    if (typeFullName.Equals(fullName, StringComparison.Ordinal))
-                        return type;
-
-                    if (typeFullName.EndsWith(fullName, StringComparison.Ordinal))
-                    {
-                        var prefixLength = typeFullName.Length - fullName.Length;
-                        if (prefixLength == 0 || typeFullName[prefixLength - 1] == '.')
-                            return type;
-                    }
-                }
-                else
-                {
-                    return type;
-                }
-            }
-
-            foreach (var nested in type.GetTypeMembers())
-            {
-                if (nested.Name != simpleName)
-                    continue;
-
-                if (fullName.Contains(".", StringComparison.Ordinal))
-                {
-                    var nestedFullName = nested.ToDisplayString();
-                    if (nestedFullName.EndsWith(fullName, StringComparison.Ordinal))
-                        return nested;
-                }
-                else
-                {
-                    return nested;
-                }
-            }
+            AddTypeAndNestedTypes(type, result, cancellationToken);
         }
 
         foreach (var childNs in ns.GetNamespaceMembers())
         {
-            var found = FindTypeInNamespace(childNs, simpleName, fullName);
-            if (found != null)
-                return found;
+            AddNamespaceTypes(childNs, result, cancellationToken);
         }
+    }
 
-        return null;
+    private static void AddTypeAndNestedTypes(
+        INamedTypeSymbol type,
+        List<INamedTypeSymbol> result,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        result.Add(type);
+
+        foreach (var nested in type.GetTypeMembers())
+        {
+            AddTypeAndNestedTypes(nested, result, cancellationToken);
+        }
     }
 }

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyAnalyzer.cs
@@ -39,11 +39,20 @@ public sealed partial class MissingExplicitForeignKeyAnalyzer : DiagnosticAnalyz
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterSymbolAction(AnalyzeDbContext, SymbolKind.NamedType);
+        context.RegisterCompilationStartAction(InitializeCompilation);
     }
 
-    private void AnalyzeDbContext(SymbolAnalysisContext context)
+    private static void InitializeCompilation(CompilationStartAnalysisContext context)
     {
+        var compilationModel = new CompilationModel(context.Compilation);
+        context.RegisterSymbolAction(
+            symbolContext => AnalyzeDbContext(symbolContext, compilationModel),
+            SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeDbContext(SymbolAnalysisContext context, CompilationModel compilationModel)
+    {
+        context.CancellationToken.ThrowIfCancellationRequested();
         var namedType = (INamedTypeSymbol)context.Symbol;
 
         if (!namedType.IsDbContext()) return;
@@ -55,11 +64,12 @@ public sealed partial class MissingExplicitForeignKeyAnalyzer : DiagnosticAnalyz
         var ownedEntities = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
         var configuredForeignKeys = new HashSet<string>(StringComparer.Ordinal);
 
-        ScanOnModelCreating(namedType, context.Compilation, ownedEntities, configuredForeignKeys);
-        ScanEntityTypeConfigurations(context.Compilation, ownedEntities, configuredForeignKeys);
+        ScanOnModelCreating(namedType, compilationModel, ownedEntities, configuredForeignKeys, context.CancellationToken);
+        ScanEntityTypeConfigurations(compilationModel, ownedEntities, configuredForeignKeys, context.CancellationToken);
 
         foreach (var entityType in entityTypes)
         {
+            context.CancellationToken.ThrowIfCancellationRequested();
             CheckEntityForMissingForeignKeys(entityType, entityTypes, ownedEntities, configuredForeignKeys, context);
         }
     }

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyConfigurationAnalysis.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyConfigurationAnalysis.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -10,9 +11,10 @@ public sealed partial class MissingExplicitForeignKeyAnalyzer
 {
     private static void ScanOnModelCreating(
         INamedTypeSymbol dbContextType,
-        Compilation compilation,
+        CompilationModel compilationModel,
         HashSet<INamedTypeSymbol> ownedEntities,
-        HashSet<string> configuredForeignKeys)
+        HashSet<string> configuredForeignKeys,
+        CancellationToken cancellationToken)
     {
         var methods = dbContextType.GetMembers("OnModelCreating");
         if (methods.IsEmpty || methods[0] is not IMethodSymbol onModelCreating)
@@ -20,24 +22,41 @@ public sealed partial class MissingExplicitForeignKeyAnalyzer
 
         foreach (var syntaxRef in onModelCreating.DeclaringSyntaxReferences)
         {
-            var syntax = syntaxRef.GetSyntax();
-            ProcessConfigurationSyntax(syntax, compilation, null, ownedEntities, configuredForeignKeys);
+            cancellationToken.ThrowIfCancellationRequested();
+            var syntax = syntaxRef.GetSyntax(cancellationToken);
+            ProcessConfigurationSyntax(syntax, compilationModel, null, ownedEntities, configuredForeignKeys, cancellationToken);
         }
     }
 
     private static void ScanEntityTypeConfigurations(
-        Compilation compilation,
+        CompilationModel compilationModel,
         HashSet<INamedTypeSymbol> ownedEntities,
-        HashSet<string> configuredForeignKeys)
+        HashSet<string> configuredForeignKeys,
+        CancellationToken cancellationToken)
     {
+        var scan = compilationModel.GetConfigurationScan(cancellationToken);
+        ownedEntities.UnionWith(scan.OwnedEntities);
+        configuredForeignKeys.UnionWith(scan.ConfiguredForeignKeys);
+    }
+
+    private static ConfigurationScan BuildConfigurationScan(
+        CompilationModel compilationModel,
+        CancellationToken cancellationToken)
+    {
+        var scan = new ConfigurationScan();
+        var compilation = compilationModel.Compilation;
         var configInterface = compilation.GetTypeByMetadataName("Microsoft.EntityFrameworkCore.IEntityTypeConfiguration`1");
         if (configInterface == null)
-            return;
+            return scan;
 
-        foreach (var type in GetAllTypes(compilation.Assembly.GlobalNamespace))
+        foreach (var type in compilationModel.GetAllTypes(cancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             foreach (var iface in type.AllInterfaces)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (!SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, configInterface) ||
                     iface.TypeArguments.Length == 0 ||
                     iface.TypeArguments[0] is not INamedTypeSymbol entityType)
@@ -51,29 +70,45 @@ public sealed partial class MissingExplicitForeignKeyAnalyzer
 
                 foreach (var syntaxRef in configureMethod.DeclaringSyntaxReferences)
                 {
-                    var syntax = syntaxRef.GetSyntax();
-                    ProcessConfigurationSyntax(syntax, compilation, entityType, ownedEntities, configuredForeignKeys);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var syntax = syntaxRef.GetSyntax(cancellationToken);
+                    ProcessConfigurationSyntax(
+                        syntax,
+                        compilationModel,
+                        entityType,
+                        scan.OwnedEntities,
+                        scan.ConfiguredForeignKeys,
+                        cancellationToken);
                 }
             }
         }
+
+        return scan;
     }
 
     private static void ProcessConfigurationSyntax(
         SyntaxNode syntax,
-        Compilation compilation,
+        CompilationModel compilationModel,
         INamedTypeSymbol? configuredEntityType,
         HashSet<INamedTypeSymbol> ownedEntities,
-        HashSet<string> configuredForeignKeys)
+        HashSet<string> configuredForeignKeys,
+        CancellationToken cancellationToken)
     {
         foreach (var invocation in syntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
                 continue;
 
             var methodName = memberAccess.Name.Identifier.Text;
             if (methodName is "OwnsOne" or "OwnsMany")
             {
-                var resolvedOwnedType = ResolveOwnedTypeFromConfiguration(invocation, compilation, configuredEntityType);
+                var resolvedOwnedType = ResolveOwnedTypeFromConfiguration(
+                    invocation,
+                    compilationModel,
+                    configuredEntityType,
+                    cancellationToken);
                 if (resolvedOwnedType != null)
                     ownedEntities.Add(resolvedOwnedType);
                 continue;
@@ -93,7 +128,7 @@ public sealed partial class MissingExplicitForeignKeyAnalyzer
                 if (entityTypeName == null)
                     continue;
 
-                entityType = FindTypeByName(compilation, entityTypeName);
+                entityType = compilationModel.FindTypeByName(entityTypeName, cancellationToken);
             }
 
             if (entityType != null)
@@ -204,12 +239,13 @@ public sealed partial class MissingExplicitForeignKeyAnalyzer
 
     private static INamedTypeSymbol? ResolveOwnedTypeFromConfiguration(
         InvocationExpressionSyntax invocation,
-        Compilation compilation,
-        INamedTypeSymbol? configuredEntityType)
+        CompilationModel compilationModel,
+        INamedTypeSymbol? configuredEntityType,
+        CancellationToken cancellationToken)
     {
         var explicitTypeName = ExtractOwnedTypeName(invocation);
         if (explicitTypeName != null)
-            return FindTypeByName(compilation, explicitTypeName);
+            return compilationModel.FindTypeByName(explicitTypeName, cancellationToken);
 
         var entityType = configuredEntityType;
         if (entityType == null &&
@@ -217,7 +253,7 @@ public sealed partial class MissingExplicitForeignKeyAnalyzer
         {
             var entityTypeName = ExtractEntityTypeNameFromChain(memberAccess.Expression);
             if (entityTypeName != null)
-                entityType = FindTypeByName(compilation, entityTypeName);
+                entityType = compilationModel.FindTypeByName(entityTypeName, cancellationToken);
         }
 
         if (entityType == null)

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyTypeLookup.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyTypeLookup.cs
@@ -1,94 +1,148 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 
 namespace LinqContraband.Analyzers.LC027_MissingExplicitForeignKey;
 
 public sealed partial class MissingExplicitForeignKeyAnalyzer
 {
-    private static void TryAddResolvedType(string? typeName, Compilation compilation, HashSet<INamedTypeSymbol> targetSet)
+    private sealed class CompilationModel
     {
-        if (typeName == null) return;
-        var resolved = FindTypeByName(compilation, typeName);
-        if (resolved != null) targetSet.Add(resolved);
-    }
+        private readonly object syncRoot = new();
+        private readonly Compilation compilation;
+        private readonly Dictionary<string, INamedTypeSymbol?> typeLookupCache = new(StringComparer.Ordinal);
+        private List<INamedTypeSymbol>? allTypes;
+        private ConfigurationScan? configurationScan;
 
-    private static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol ns)
-    {
-        foreach (var type in ns.GetTypeMembers())
+        public CompilationModel(Compilation compilation)
         {
-            yield return type;
-            foreach (var nested in type.GetTypeMembers())
-                yield return nested;
+            this.compilation = compilation;
         }
 
-        foreach (var childNs in ns.GetNamespaceMembers())
+        public Compilation Compilation => compilation;
+
+        public IReadOnlyList<INamedTypeSymbol> GetAllTypes(CancellationToken cancellationToken)
         {
-            foreach (var type in GetAllTypes(childNs))
-                yield return type;
-        }
-    }
+            if (allTypes != null)
+                return allTypes;
 
-    private static INamedTypeSymbol? FindTypeByName(Compilation compilation, string typeName)
-    {
-        var type = compilation.GetTypeByMetadataName(typeName);
-        if (type != null) return type;
-
-        var simpleName = typeName.Contains(".", StringComparison.Ordinal)
-            ? typeName.Substring(typeName.LastIndexOf(".", StringComparison.Ordinal) + 1)
-            : typeName;
-        return FindTypeInNamespace(compilation.GlobalNamespace, simpleName, typeName);
-    }
-
-    private static INamedTypeSymbol? FindTypeInNamespace(INamespaceSymbol ns, string simpleName, string fullName)
-    {
-        foreach (var type in ns.GetTypeMembers())
-        {
-            if (type.Name == simpleName)
+            lock (syncRoot)
             {
-                if (fullName.Contains(".", StringComparison.Ordinal))
-                {
-                    var typeFullName = type.ToDisplayString();
-                    if (typeFullName.Equals(fullName, StringComparison.Ordinal))
-                        return type;
-
-                    if (typeFullName.EndsWith(fullName, StringComparison.Ordinal))
-                    {
-                        var prefixLength = typeFullName.Length - fullName.Length;
-                        if (prefixLength == 0 || typeFullName[prefixLength - 1] == '.')
-                            return type;
-                    }
-                }
-                else
-                {
-                    return type;
-                }
+                allTypes ??= BuildAllTypes(cancellationToken);
+                return allTypes;
             }
+        }
 
-            foreach (var nested in type.GetTypeMembers())
+        public INamedTypeSymbol? FindTypeByName(string typeName, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            lock (syncRoot)
             {
-                if (nested.Name != simpleName)
+                if (!typeLookupCache.TryGetValue(typeName, out var cachedType))
+                {
+                    cachedType = FindTypeByNameCore(typeName, cancellationToken);
+                    typeLookupCache[typeName] = cachedType;
+                }
+
+                return cachedType;
+            }
+        }
+
+        public ConfigurationScan GetConfigurationScan(CancellationToken cancellationToken)
+        {
+            if (configurationScan != null)
+                return configurationScan;
+
+            lock (syncRoot)
+            {
+                configurationScan ??= BuildConfigurationScan(this, cancellationToken);
+                return configurationScan;
+            }
+        }
+
+        private List<INamedTypeSymbol> BuildAllTypes(CancellationToken cancellationToken)
+        {
+            var result = new List<INamedTypeSymbol>();
+            AddNamespaceTypes(compilation.Assembly.GlobalNamespace, result, cancellationToken);
+            return result;
+        }
+
+        private INamedTypeSymbol? FindTypeByNameCore(string typeName, CancellationToken cancellationToken)
+        {
+            var type = compilation.GetTypeByMetadataName(typeName);
+            if (type != null)
+                return type;
+
+            var simpleName = typeName.Contains(".", StringComparison.Ordinal)
+                ? typeName.Substring(typeName.LastIndexOf(".", StringComparison.Ordinal) + 1)
+                : typeName;
+
+            foreach (var candidate in GetAllTypes(cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (candidate.Name != simpleName)
                     continue;
 
-                if (fullName.Contains(".", StringComparison.Ordinal))
+                if (!typeName.Contains(".", StringComparison.Ordinal))
+                    return candidate;
+
+                var fullName = candidate.ToDisplayString();
+                if (fullName.Equals(typeName, StringComparison.Ordinal))
+                    return candidate;
+
+                if (fullName.EndsWith(typeName, StringComparison.Ordinal))
                 {
-                    var nestedFullName = nested.ToDisplayString();
-                    if (nestedFullName.EndsWith(fullName, StringComparison.Ordinal))
-                        return nested;
-                }
-                else
-                {
-                    return nested;
+                    var prefixLength = fullName.Length - typeName.Length;
+                    if (prefixLength == 0 || fullName[prefixLength - 1] == '.')
+                        return candidate;
                 }
             }
+
+            return null;
+        }
+    }
+
+    private sealed class ConfigurationScan
+    {
+        public HashSet<INamedTypeSymbol> OwnedEntities { get; } =
+            new(SymbolEqualityComparer.Default);
+
+        public HashSet<string> ConfiguredForeignKeys { get; } =
+            new(StringComparer.Ordinal);
+    }
+
+    private static void AddNamespaceTypes(
+        INamespaceSymbol ns,
+        List<INamedTypeSymbol> result,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        foreach (var type in ns.GetTypeMembers())
+        {
+            AddTypeAndNestedTypes(type, result, cancellationToken);
         }
 
         foreach (var childNs in ns.GetNamespaceMembers())
         {
-            var found = FindTypeInNamespace(childNs, simpleName, fullName);
-            if (found != null) return found;
+            AddNamespaceTypes(childNs, result, cancellationToken);
         }
+    }
 
-        return null;
+    private static void AddTypeAndNestedTypes(
+        INamedTypeSymbol type,
+        List<INamedTypeSymbol> result,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        result.Add(type);
+
+        foreach (var nested in type.GetTypeMembers())
+        {
+            AddTypeAndNestedTypes(nested, result, cancellationToken);
+        }
     }
 }

--- a/tests/LinqContraband.Tests/Architecture/AnalyzerPerformanceTests.cs
+++ b/tests/LinqContraband.Tests/Architecture/AnalyzerPerformanceTests.cs
@@ -1,0 +1,280 @@
+using System.Collections.Immutable;
+using System.Text;
+using LinqContraband.Analyzers.LC011_EntityMissingPrimaryKey;
+using LinqContraband.Analyzers.LC023_FindInsteadOfFirstOrDefault;
+using LinqContraband.Analyzers.LC027_MissingExplicitForeignKey;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace LinqContraband.Tests.Architecture;
+
+public class AnalyzerPerformanceTests
+{
+    private static readonly TimeSpan AnalyzerTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task LC023_PrimaryKeyLookup_CompletesOnLargeCompilation()
+    {
+        var compilation = CreateCompilation(GenerateEfCoreMock(), GenerateLc023StressSource());
+
+        var diagnostics = await GetDiagnosticsWithinAsync(
+            new FindInsteadOfFirstOrDefaultAnalyzer(),
+            compilation,
+            AnalyzerTimeout);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == FindInsteadOfFirstOrDefaultAnalyzer.DiagnosticId);
+    }
+
+    [Fact]
+    public async Task SchemaAnalyzers_ConfigurationScans_CompleteOnLargeCompilation()
+    {
+        var compilation = CreateCompilation(GenerateEfCoreMock(), GenerateSchemaStressSource());
+
+        await GetDiagnosticsWithinAsync(new EntityMissingPrimaryKeyAnalyzer(), compilation, AnalyzerTimeout);
+        await GetDiagnosticsWithinAsync(new MissingExplicitForeignKeyAnalyzer(), compilation, AnalyzerTimeout);
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithinAsync(
+        DiagnosticAnalyzer analyzer,
+        Compilation compilation,
+        TimeSpan timeout)
+    {
+        using var cancellation = new CancellationTokenSource(timeout);
+        var diagnosticsTask = compilation
+            .WithAnalyzers(ImmutableArray.Create(analyzer))
+            .GetAnalyzerDiagnosticsAsync(cancellation.Token);
+        var completedTask = await Task.WhenAny(diagnosticsTask, Task.Delay(timeout));
+
+        if (!ReferenceEquals(completedTask, diagnosticsTask))
+            cancellation.Cancel();
+
+        Assert.True(
+            ReferenceEquals(completedTask, diagnosticsTask),
+            $"{analyzer.GetType().Name} did not complete within {timeout}.");
+
+        return await diagnosticsTask;
+    }
+
+    private static Compilation CreateCompilation(params string[] sources)
+    {
+        var syntaxTrees = sources.Select((source, index) =>
+            CSharpSyntaxTree.ParseText(
+                source,
+                CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
+                path: $"Perf{index}.cs"));
+
+        var trustedPlatformAssemblies =
+            ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))!
+            .Split(Path.PathSeparator)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+
+        return CSharpCompilation.Create(
+            "AnalyzerPerformance",
+            syntaxTrees,
+            trustedPlatformAssemblies,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static string GenerateLc023StressSource()
+    {
+        const int entityCount = 40;
+        const int queryCount = 160;
+        const int noiseCount = 300;
+        var source = new StringBuilder();
+        source.AppendLine(
+            """
+            using System.Linq;
+            using Microsoft.EntityFrameworkCore;
+
+            namespace PerfApp;
+
+            public class AppDbContext : DbContext
+            {
+                protected override void OnModelCreating(ModelBuilder modelBuilder)
+                {
+            """);
+
+        for (var i = 0; i < entityCount; i++)
+            source.AppendLine($"        modelBuilder.Entity<Entity{i}>().HasKey(e => e.ExternalId);");
+
+        source.AppendLine(
+            """
+                }
+            }
+            """);
+
+        for (var i = 0; i < entityCount; i++)
+            source.AppendLine($"public class Entity{i} {{ public int Id {{ get; set; }} public int ExternalId {{ get; set; }} }}");
+
+        source.AppendLine(
+            """
+            public static class Noise
+            {
+                public static void HasKey(int value) { }
+                public static void Run()
+                {
+            """);
+
+        for (var i = 0; i < noiseCount; i++)
+            source.AppendLine($"        HasKey({i});");
+
+        source.AppendLine(
+            """
+                }
+            }
+
+            public class Queries
+            {
+                public void Run(int id)
+                {
+            """);
+
+        for (var i = 0; i < queryCount; i++)
+        {
+            var entityIndex = i % entityCount;
+            source.AppendLine($"        var set{i} = new DbSet<Entity{entityIndex}>();");
+            source.AppendLine($"        var query{i} = set{i}.FirstOrDefault(e => e.ExternalId == id);");
+        }
+
+        source.AppendLine(
+            """
+                }
+            }
+            """);
+
+        return source.ToString();
+    }
+
+    private static string GenerateSchemaStressSource()
+    {
+        const int entityCount = 60;
+        const int contextCount = 8;
+        var source = new StringBuilder();
+        source.AppendLine(
+            """
+            using Microsoft.EntityFrameworkCore;
+
+            namespace PerfApp;
+            """);
+
+        for (var i = 0; i < contextCount; i++)
+        {
+            source.AppendLine($"public class AppDbContext{i} : DbContext");
+            source.AppendLine("{");
+            for (var j = 0; j < entityCount; j++)
+                source.AppendLine($"    public DbSet<Entity{j}> Entities{j} {{ get; set; }}");
+
+            source.AppendLine("    protected override void OnModelCreating(ModelBuilder modelBuilder)");
+            source.AppendLine("    {");
+            source.AppendLine($"        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext{i}).Assembly);");
+            source.AppendLine("    }");
+            source.AppendLine("}");
+        }
+
+        for (var i = 0; i < entityCount; i++)
+        {
+            var related = (i + 1) % entityCount;
+            source.AppendLine($$"""
+                public class Entity{{i}}
+                {
+                    public int CustomId { get; set; }
+                    public int Entity{{related}}Id { get; set; }
+                    public Entity{{related}} Entity{{related}} { get; set; }
+                }
+
+                public class Entity{{i}}Configuration : IEntityTypeConfiguration<Entity{{i}}>
+                {
+                    public void Configure(EntityTypeBuilder<Entity{{i}}> builder)
+                    {
+                        builder.HasKey(e => e.CustomId);
+                        builder.HasOne(e => e.Entity{{related}}).WithOne().HasForeignKey<Entity{{i}}>(e => e.Entity{{related}}Id);
+                    }
+                }
+                """);
+        }
+
+        return source.ToString();
+    }
+
+    private static string GenerateEfCoreMock()
+    {
+        return
+            """
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Linq.Expressions;
+            using System.Reflection;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace Microsoft.EntityFrameworkCore
+            {
+                public class DbContext
+                {
+                    protected virtual void OnModelCreating(ModelBuilder modelBuilder) { }
+                }
+
+                public class DbSet<TEntity> : IQueryable<TEntity> where TEntity : class
+                {
+                    public TEntity Find(params object[] keyValues) => null;
+                    public ValueTask<TEntity> FindAsync(params object[] keyValues) => default;
+                    public ValueTask<TEntity> FindAsync(object[] keyValues, CancellationToken cancellationToken) => default;
+                    public Type ElementType => typeof(TEntity);
+                    public Expression Expression => null;
+                    public IQueryProvider Provider => null;
+                    public IEnumerator<TEntity> GetEnumerator() => null;
+                    IEnumerator IEnumerable.GetEnumerator() => null;
+                }
+
+                public interface IEntityTypeConfiguration<TEntity> where TEntity : class
+                {
+                    void Configure(EntityTypeBuilder<TEntity> builder);
+                }
+
+                public class ModelBuilder
+                {
+                    public EntityTypeBuilder<TEntity> Entity<TEntity>() where TEntity : class => new EntityTypeBuilder<TEntity>();
+                    public void ApplyConfiguration<TEntity>(IEntityTypeConfiguration<TEntity> configuration) where TEntity : class { }
+                    public void ApplyConfigurationsFromAssembly(Assembly assembly) { }
+                }
+
+                public class EntityTypeBuilder<TEntity> where TEntity : class
+                {
+                    public EntityTypeBuilder<TEntity> HasKey<TProperty>(Expression<Func<TEntity, TProperty>> keyExpression) => this;
+                    public EntityTypeBuilder<TEntity> HasNoKey() => this;
+                    public OwnedNavigationBuilder<TEntity, TDependent> OwnsOne<TDependent>(Expression<Func<TEntity, TDependent>> navigationExpression) where TDependent : class => new OwnedNavigationBuilder<TEntity, TDependent>();
+                    public ReferenceNavigationBuilder<TEntity, TRelated> HasOne<TRelated>(Expression<Func<TEntity, TRelated>> navigationExpression = null) where TRelated : class => new ReferenceNavigationBuilder<TEntity, TRelated>();
+                }
+
+                public class OwnedNavigationBuilder<TEntity, TDependent>
+                    where TEntity : class
+                    where TDependent : class
+                {
+                }
+
+                public class ReferenceNavigationBuilder<TEntity, TRelated>
+                    where TEntity : class
+                    where TRelated : class
+                {
+                    public ReferenceReferenceBuilder<TEntity, TRelated> WithOne(Expression<Func<TRelated, TEntity>> navigationExpression = null) => new ReferenceReferenceBuilder<TEntity, TRelated>();
+                }
+
+                public class ReferenceReferenceBuilder<TEntity, TRelated>
+                    where TEntity : class
+                    where TRelated : class
+                {
+                    public ReferenceReferenceBuilder<TEntity, TRelated> HasForeignKey<TDependentEntity>(Expression<Func<TDependentEntity, object>> foreignKeyExpression) where TDependentEntity : class => this;
+                }
+
+                public static class EntityFrameworkQueryableExtensions
+                {
+                    public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) => Task.FromResult(default(TSource));
+                    public static Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken cancellationToken = default) => Task.FromResult(default(TSource));
+                }
+            }
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- cache LC023 primary-key lookups per compilation instead of scanning all syntax trees per query
- cache LC011/LC027 schema configuration scans and add cancellation checks
- fix concurrent option-cache access in LC028/LC038
- add large-compilation analyzer performance regression tests

## Validation
- dotnet build /Users/georgewall/fiveFive/LinqContraband/LinqContraband.sln
- dotnet test /Users/georgewall/fiveFive/LinqContraband/tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-build --framework net10.0 --verbosity normal

Note: full multi-target test run is blocked locally because arm64 .NET 8/9 runtimes are not installed; net10 full suite passed.