### PR TITLE
fix: cache analyzer hot paths for large builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.19] - 2026-04-27
+
+### Changed
+- Cached `LC015` local query-source resolution per operation block and added a self-referential local guard to prevent pathological query provenance loops
+- Cached `LC007` local write scans and threaded analyzer cancellation through query provenance analysis to reduce repeated full-method traversal
+- Collapsed `LC017` whole-entity usage scans and syntax fallback scans into bounded single passes with cancellation checks
+- Added analyzer performance coverage for `LC007`, `LC015`, and `LC017` hot paths
+
 ## [5.2.18] - 2026-04-27
 
 ### Changed

--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalysis.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalysis.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -90,8 +92,12 @@ internal static class NPlusOneLooperAnalysis
         "ExecuteUpdateAsync"
     };
 
-    public static NPlusOneLoopMatch? AnalyzeInvocation(IInvocationOperation invocation)
+    private static readonly ConditionalWeakTable<IOperation, LocalWriteCache> LocalWriteCaches = new();
+
+    public static NPlusOneLoopMatch? AnalyzeInvocation(IInvocationOperation invocation, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var loop = invocation.FindEnclosingLoop();
         if (loop == null || !invocation.SharesOwningExecutableRoot(loop))
             return null;
@@ -99,7 +105,7 @@ internal static class NPlusOneLooperAnalysis
         if (!IsPerIterationInvocation(invocation, loop))
             return null;
 
-        if (!TryMatchDatabaseExecution(invocation, out var match))
+        if (!TryMatchDatabaseExecution(invocation, cancellationToken, out var match))
             return null;
 
         return new NPlusOneLoopMatch(match.PatternKind, match.MethodName, loop.GetLoopKind(), match.FixerEligible);
@@ -126,9 +132,9 @@ internal static class NPlusOneLooperAnalysis
         };
     }
 
-    public static bool IsProvenEfQuerySource(IOperation? operation)
+    public static bool IsProvenEfQuerySource(IOperation? operation, CancellationToken cancellationToken = default)
     {
-        return AnalyzeQueryProvenance(operation, operation).Kind == QueryProvenanceKind.Proven;
+        return AnalyzeQueryProvenance(operation, operation, cancellationToken).Kind == QueryProvenanceKind.Proven;
     }
 
     public static bool HasStronglyTypedNavigationAccessor(IInvocationOperation loadInvocation)
@@ -143,7 +149,10 @@ internal static class NPlusOneLooperAnalysis
                accessInvocation.Arguments[0].Value is IAnonymousFunctionOperation;
     }
 
-    private static bool TryMatchDatabaseExecution(IInvocationOperation invocation, out NPlusOneLoopMatch match)
+    private static bool TryMatchDatabaseExecution(
+        IInvocationOperation invocation,
+        CancellationToken cancellationToken,
+        out NPlusOneLoopMatch match)
     {
         var method = invocation.TargetMethod;
 
@@ -173,7 +182,7 @@ internal static class NPlusOneLooperAnalysis
             return false;
         }
 
-        var provenance = AnalyzeQueryProvenance(invocation.GetInvocationReceiver(), invocation);
+        var provenance = AnalyzeQueryProvenance(invocation.GetInvocationReceiver(), invocation, cancellationToken);
         if (provenance.Kind != QueryProvenanceKind.Proven)
         {
             match = null!;
@@ -192,7 +201,10 @@ internal static class NPlusOneLooperAnalysis
         return true;
     }
 
-    private static QueryProvenance AnalyzeQueryProvenance(IOperation? operation, IOperation? analysisScope)
+    private static QueryProvenance AnalyzeQueryProvenance(
+        IOperation? operation,
+        IOperation? analysisScope,
+        CancellationToken cancellationToken)
     {
         if (operation == null || analysisScope == null)
             return QueryProvenance.None;
@@ -202,6 +214,7 @@ internal static class NPlusOneLooperAnalysis
 
         while (current != null)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             current = current.UnwrapConversions();
 
             switch (current)
@@ -241,7 +254,7 @@ internal static class NPlusOneLooperAnalysis
                     if (!visitedLocals.Add(localReference.Local))
                         return QueryProvenance.Ambiguous;
 
-                    if (!TryGetSingleAssignedLocalValue(localReference.Local, analysisScope, out var valueOperation))
+                    if (!TryGetSingleAssignedLocalValue(localReference.Local, analysisScope, cancellationToken, out var valueOperation))
                     {
                         if (localReference.Type.IsDbSet() || localReference.Type.IsIQueryable())
                             return QueryProvenance.Ambiguous;
@@ -276,14 +289,18 @@ internal static class NPlusOneLooperAnalysis
         return QueryProvenance.None;
     }
 
-    private static bool TryGetSingleAssignedLocalValue(ILocalSymbol local, IOperation analysisScope, out IOperation valueOperation)
+    private static bool TryGetSingleAssignedLocalValue(
+        ILocalSymbol local,
+        IOperation analysisScope,
+        CancellationToken cancellationToken,
+        out IOperation valueOperation)
     {
         valueOperation = null!;
 
         if (local.DeclaringSyntaxReferences.Length != 1)
             return false;
 
-        var declarator = local.DeclaringSyntaxReferences[0].GetSyntax() as VariableDeclaratorSyntax;
+        var declarator = local.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken) as VariableDeclaratorSyntax;
         if (declarator?.Initializer?.Value == null)
             return false;
 
@@ -292,10 +309,14 @@ internal static class NPlusOneLooperAnalysis
         if (semanticModel == null || executableRoot == null)
             return false;
 
-        if (HasLocalWrites(local, executableRoot.Syntax, semanticModel))
+        var localWrites = LocalWriteCaches.GetValue(
+            executableRoot,
+            root => new LocalWriteCache(root.Syntax, semanticModel));
+
+        if (localWrites.HasWrite(local, cancellationToken))
             return false;
 
-        var operation = semanticModel.GetOperation(declarator.Initializer.Value);
+        var operation = semanticModel.GetOperation(declarator.Initializer.Value, cancellationToken);
         if (operation == null)
             return false;
 
@@ -303,39 +324,65 @@ internal static class NPlusOneLooperAnalysis
         return true;
     }
 
-    private static bool HasLocalWrites(ILocalSymbol local, SyntaxNode executableRootSyntax, SemanticModel semanticModel)
+    private sealed class LocalWriteCache
     {
-        foreach (var assignment in executableRootSyntax.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        private readonly SyntaxNode executableRootSyntax;
+        private readonly SemanticModel semanticModel;
+        private readonly object syncRoot = new();
+        private HashSet<ILocalSymbol>? writtenLocals;
+
+        public LocalWriteCache(SyntaxNode executableRootSyntax, SemanticModel semanticModel)
         {
-            if (SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(assignment.Left).Symbol, local))
-                return true;
+            this.executableRootSyntax = executableRootSyntax;
+            this.semanticModel = semanticModel;
         }
 
-        foreach (var prefix in executableRootSyntax.DescendantNodes().OfType<PrefixUnaryExpressionSyntax>())
+        public bool HasWrite(ILocalSymbol local, CancellationToken cancellationToken)
         {
-            if (!prefix.IsKind(SyntaxKind.PreIncrementExpression) &&
-                !prefix.IsKind(SyntaxKind.PreDecrementExpression))
+            return GetWrittenLocals(cancellationToken).Contains(local);
+        }
+
+        private HashSet<ILocalSymbol> GetWrittenLocals(CancellationToken cancellationToken)
+        {
+            if (writtenLocals != null)
+                return writtenLocals;
+
+            lock (syncRoot)
             {
-                continue;
+                writtenLocals ??= BuildWrittenLocals(cancellationToken);
+                return writtenLocals;
+            }
+        }
+
+        private HashSet<ILocalSymbol> BuildWrittenLocals(CancellationToken cancellationToken)
+        {
+            var locals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+
+            foreach (var node in executableRootSyntax.DescendantNodes())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                ExpressionSyntax? target = node switch
+                {
+                    AssignmentExpressionSyntax assignment => assignment.Left,
+                    PrefixUnaryExpressionSyntax prefix when
+                        prefix.IsKind(SyntaxKind.PreIncrementExpression) ||
+                        prefix.IsKind(SyntaxKind.PreDecrementExpression) => prefix.Operand,
+                    PostfixUnaryExpressionSyntax postfix when
+                        postfix.IsKind(SyntaxKind.PostIncrementExpression) ||
+                        postfix.IsKind(SyntaxKind.PostDecrementExpression) => postfix.Operand,
+                    _ => null
+                };
+
+                if (target == null)
+                    continue;
+
+                if (semanticModel.GetSymbolInfo(target, cancellationToken).Symbol is ILocalSymbol local)
+                    locals.Add(local);
             }
 
-            if (SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(prefix.Operand).Symbol, local))
-                return true;
+            return locals;
         }
-
-        foreach (var postfix in executableRootSyntax.DescendantNodes().OfType<PostfixUnaryExpressionSyntax>())
-        {
-            if (!postfix.IsKind(SyntaxKind.PostIncrementExpression) &&
-                !postfix.IsKind(SyntaxKind.PostDecrementExpression))
-            {
-                continue;
-            }
-
-            if (SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(postfix.Operand).Symbol, local))
-                return true;
-        }
-
-        return false;
     }
 
     private static bool IsDbContextSetInvocation(IInvocationOperation invocation)

--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalyzer.cs
@@ -52,7 +52,7 @@ public sealed class NPlusOneLooperAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeInvocation(OperationAnalysisContext context)
     {
         var invocation = (IInvocationOperation)context.Operation;
-        var match = NPlusOneLooperAnalysis.AnalyzeInvocation(invocation);
+        var match = NPlusOneLooperAnalysis.AnalyzeInvocation(invocation, context.CancellationToken);
         if (match == null)
             return;
 

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionAnalyzer.cs
@@ -70,7 +70,7 @@ public sealed partial class WholeEntityProjectionAnalyzer : DiagnosticAnalyzer
         var variableInfo = FindVariableAssignment(invocation);
         if (variableInfo == null) return;
 
-        var usage = AnalyzeVariableUsage(invocation, variableInfo.Value.Symbol, analysis.EntityType);
+        var usage = AnalyzeVariableUsage(invocation, variableInfo.Value.Symbol, analysis.EntityType, context.CancellationToken);
         if (usage.HasEscapingUsage) return;
         if (usage.AccessedProperties.Count > MaxAccessedProperties) return;
         if (usage.AccessedProperties.Count == 0) return;

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionSyntaxAnalysis.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionSyntaxAnalysis.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -22,7 +23,8 @@ public sealed partial class WholeEntityProjectionAnalyzer
         ITypeSymbol entityType,
         HashSet<ILocalSymbol> foreachLocals,
         HashSet<ILocalSymbol> manualIterationLocals,
-        HashSet<string> accessedProperties)
+        HashSet<string> accessedProperties,
+        CancellationToken cancellationToken)
     {
         var semanticModel = invocation.SemanticModel;
         if (semanticModel == null) return;
@@ -32,28 +34,43 @@ public sealed partial class WholeEntityProjectionAnalyzer
                     invocation.Syntax.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>() as SyntaxNode;
         if (scope == null) return;
 
-        foreach (var conditionalAccess in scope.DescendantNodes().OfType<ConditionalAccessExpressionSyntax>())
+        foreach (var node in scope.DescendantNodes())
         {
-            if (!IsTrackedEntitySyntax(conditionalAccess.Expression, variable, foreachLocals, manualIterationLocals, semanticModel))
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (node is ConditionalAccessExpressionSyntax conditionalAccess)
+            {
+                if (!IsTrackedEntitySyntax(
+                        conditionalAccess.Expression,
+                        variable,
+                        foreachLocals,
+                        manualIterationLocals,
+                        semanticModel,
+                        cancellationToken))
+                {
+                    continue;
+                }
+
+                if (conditionalAccess.WhenNotNull is MemberBindingExpressionSyntax memberBinding &&
+                    semanticModel.GetSymbolInfo(memberBinding, cancellationToken).Symbol is IPropertySymbol conditionalProperty &&
+                    IsPropertyOfType(conditionalProperty, entityType))
+                {
+                    accessedProperties.Add(conditionalProperty.Name);
+                }
+
+                continue;
+            }
+
+            if (node is not MemberAccessExpressionSyntax memberAccess)
                 continue;
 
-            if (conditionalAccess.WhenNotNull is MemberBindingExpressionSyntax memberBinding &&
-                semanticModel.GetSymbolInfo(memberBinding).Symbol is IPropertySymbol property &&
-                IsPropertyOfType(property, entityType))
-            {
-                accessedProperties.Add(property.Name);
-            }
-        }
-
-        foreach (var memberAccess in scope.DescendantNodes().OfType<MemberAccessExpressionSyntax>())
-        {
             if (memberAccess.Expression is not ElementAccessExpressionSyntax elementAccess) continue;
-            if (!IsCollectionElementAccess(elementAccess, variable, semanticModel)) continue;
+            if (!IsCollectionElementAccess(elementAccess, variable, semanticModel, cancellationToken)) continue;
 
-            if (semanticModel.GetSymbolInfo(memberAccess).Symbol is IPropertySymbol property &&
-                IsPropertyOfType(property, entityType))
+            if (semanticModel.GetSymbolInfo(memberAccess, cancellationToken).Symbol is IPropertySymbol elementProperty &&
+                IsPropertyOfType(elementProperty, entityType))
             {
-                accessedProperties.Add(property.Name);
+                accessedProperties.Add(elementProperty.Name);
             }
         }
     }
@@ -63,12 +80,13 @@ public sealed partial class WholeEntityProjectionAnalyzer
         ILocalSymbol variable,
         HashSet<ILocalSymbol> foreachLocals,
         HashSet<ILocalSymbol> manualIterationLocals,
-        SemanticModel semanticModel)
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         if (expression is ElementAccessExpressionSyntax elementAccess)
-            return IsCollectionElementAccess(elementAccess, variable, semanticModel);
+            return IsCollectionElementAccess(elementAccess, variable, semanticModel, cancellationToken);
 
-        var symbol = semanticModel.GetSymbolInfo(expression).Symbol as ILocalSymbol;
+        var symbol = semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol as ILocalSymbol;
         if (symbol == null) return false;
 
         return SymbolEqualityComparer.Default.Equals(symbol, variable) ||
@@ -79,9 +97,10 @@ public sealed partial class WholeEntityProjectionAnalyzer
     private static bool IsCollectionElementAccess(
         ElementAccessExpressionSyntax elementAccess,
         ILocalSymbol variable,
-        SemanticModel semanticModel)
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
-        var symbol = semanticModel.GetSymbolInfo(elementAccess.Expression).Symbol as ILocalSymbol;
+        var symbol = semanticModel.GetSymbolInfo(elementAccess.Expression, cancellationToken).Symbol as ILocalSymbol;
         return symbol != null && SymbolEqualityComparer.Default.Equals(symbol, variable);
     }
 

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionUsageAnalysis.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionUsageAnalysis.cs
@@ -25,6 +25,7 @@ public sealed partial class WholeEntityProjectionAnalyzer
 
         var foreachLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
         var manualIterationLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+        var usageCandidates = new List<IOperation>();
 
         foreach (var descendant in root.Descendants())
         {
@@ -50,6 +51,18 @@ public sealed partial class WholeEntityProjectionAnalyzer
                     IsIndexedAccessOf(assignment.Value, variable):
                     manualIterationLocals.Add(targetLocal.Local);
                     break;
+            }
+
+            if (descendant is IReturnOperation or IInvocationOperation or IAnonymousFunctionOperation or IPropertyReferenceOperation)
+                usageCandidates.Add(descendant);
+        }
+
+        foreach (var descendant in usageCandidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            switch (descendant)
+            {
                 case IReturnOperation returnOperation when
                     returnOperation.ReturnedValue != null &&
                     IsDirectVariableEscape(returnOperation.ReturnedValue, variable, foreachLocals, manualIterationLocals):

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionUsageAnalysis.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC017_WholeEntityProjection/WholeEntityProjectionUsageAnalysis.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
@@ -11,7 +12,8 @@ public sealed partial class WholeEntityProjectionAnalyzer
     private static VariableUsageAnalysis AnalyzeVariableUsage(
         IInvocationOperation invocation,
         ILocalSymbol variable,
-        ITypeSymbol entityType)
+        ITypeSymbol entityType,
+        CancellationToken cancellationToken)
     {
         var result = new VariableUsageAnalysis();
         var root = FindMethodBody(invocation);
@@ -26,6 +28,8 @@ public sealed partial class WholeEntityProjectionAnalyzer
 
         foreach (var descendant in root.Descendants())
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             switch (descendant)
             {
                 case IForEachLoopOperation forEach when
@@ -46,13 +50,6 @@ public sealed partial class WholeEntityProjectionAnalyzer
                     IsIndexedAccessOf(assignment.Value, variable):
                     manualIterationLocals.Add(targetLocal.Local);
                     break;
-            }
-        }
-
-        foreach (var descendant in root.Descendants())
-        {
-            switch (descendant)
-            {
                 case IReturnOperation returnOperation when
                     returnOperation.ReturnedValue != null &&
                     IsDirectVariableEscape(returnOperation.ReturnedValue, variable, foreachLocals, manualIterationLocals):
@@ -65,7 +62,7 @@ public sealed partial class WholeEntityProjectionAnalyzer
                     break;
 
                 case IAnonymousFunctionOperation lambda when
-                    LambdaDirectlyReferences(lambda, variable, foreachLocals, manualIterationLocals):
+                    LambdaDirectlyReferences(lambda, variable, foreachLocals, manualIterationLocals, cancellationToken):
                     result.HasEscapingUsage = true;
                     break;
 
@@ -79,7 +76,14 @@ public sealed partial class WholeEntityProjectionAnalyzer
             if (result.HasEscapingUsage) return result;
         }
 
-        CollectSyntaxBasedPropertyAccesses(invocation, variable, entityType, foreachLocals, manualIterationLocals, result.AccessedProperties);
+        CollectSyntaxBasedPropertyAccesses(
+            invocation,
+            variable,
+            entityType,
+            foreachLocals,
+            manualIterationLocals,
+            result.AccessedProperties,
+            cancellationToken);
         return result;
     }
 
@@ -120,10 +124,13 @@ public sealed partial class WholeEntityProjectionAnalyzer
         IAnonymousFunctionOperation lambda,
         ILocalSymbol variable,
         HashSet<ILocalSymbol> foreachLocals,
-        HashSet<ILocalSymbol> manualIterationLocals)
+        HashSet<ILocalSymbol> manualIterationLocals,
+        CancellationToken cancellationToken)
     {
         foreach (var descendant in lambda.Descendants())
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (descendant is not ILocalReferenceOperation localReference) continue;
 
             if (SymbolEqualityComparer.Default.Equals(localReference.Local, variable) ||

--- a/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC015_MissingOrderBy/MissingOrderByAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC015_MissingOrderBy/MissingOrderByAnalyzer.cs
@@ -102,7 +102,7 @@ public sealed partial class MissingOrderByAnalyzer : DiagnosticAnalyzer
         LocalValueCache localValueCache,
         CancellationToken cancellationToken)
     {
-        var visitedLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+        var visitedLocalReferences = new HashSet<LocalReferenceKey>(LocalReferenceKeyComparer.Instance);
         var current = operation;
         while (current != null)
         {
@@ -130,7 +130,7 @@ public sealed partial class MissingOrderByAnalyzer : DiagnosticAnalyzer
                     continue;
 
                 case ILocalReferenceOperation localReference:
-                    if (!visitedLocals.Add(localReference.Local))
+                    if (!visitedLocalReferences.Add(new LocalReferenceKey(localReference.Local, localReference.Syntax.SpanStart)))
                         return false;
 
                     if (localReference.Type.IsDbSet())
@@ -202,6 +202,9 @@ public sealed partial class MissingOrderByAnalyzer : DiagnosticAnalyzer
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                if (write.ValueStart <= referenceStart && referenceStart < write.ValueEnd)
+                    continue;
+
                 if (write.SpanStart >= referenceStart || write.SpanStart <= bestWriteStart)
                     continue;
 
@@ -245,14 +248,22 @@ public sealed partial class MissingOrderByAnalyzer : DiagnosticAnalyzer
                         if (declarator.Initializer == null)
                             continue;
 
-                        AddWrite(writes, declarator.Symbol, declarator.Syntax.SpanStart, declarator.Initializer.Value);
+                        AddWrite(
+                            writes,
+                            declarator.Symbol,
+                            declarator.Syntax.SpanStart,
+                            declarator.Initializer.Value);
                     }
                 }
 
                 if (descendant is ISimpleAssignmentOperation assignment &&
                     assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal)
                 {
-                    AddWrite(writes, targetLocal.Local, assignment.Syntax.SpanStart, assignment.Value);
+                    AddWrite(
+                        writes,
+                        targetLocal.Local,
+                        assignment.Syntax.SpanStart,
+                        assignment.Value);
                 }
             }
 
@@ -286,6 +297,39 @@ public sealed partial class MissingOrderByAnalyzer : DiagnosticAnalyzer
         public int SpanStart { get; }
 
         public IOperation Value { get; }
+
+        public int ValueStart => Value.Syntax.SpanStart;
+
+        public int ValueEnd => Value.Syntax.Span.End;
+    }
+
+    private readonly struct LocalReferenceKey
+    {
+        public LocalReferenceKey(ILocalSymbol local, int spanStart)
+        {
+            Local = local;
+            SpanStart = spanStart;
+        }
+
+        public ILocalSymbol Local { get; }
+
+        public int SpanStart { get; }
+    }
+
+    private sealed class LocalReferenceKeyComparer : IEqualityComparer<LocalReferenceKey>
+    {
+        public static readonly LocalReferenceKeyComparer Instance = new();
+
+        public bool Equals(LocalReferenceKey x, LocalReferenceKey y)
+        {
+            return x.SpanStart == y.SpanStart &&
+                   SymbolEqualityComparer.Default.Equals(x.Local, y.Local);
+        }
+
+        public int GetHashCode(LocalReferenceKey obj)
+        {
+            return SymbolEqualityComparer.Default.GetHashCode(obj.Local) ^ obj.SpanStart;
+        }
     }
 
     private static Location GetMethodLocation(IInvocationOperation invocation)

--- a/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC015_MissingOrderBy/MissingOrderByAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC015_MissingOrderBy/MissingOrderByAnalyzer.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -52,10 +54,18 @@ public sealed partial class MissingOrderByAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        context.RegisterOperationBlockStartAction(InitializeOperationBlock);
     }
 
-    private void AnalyzeInvocation(OperationAnalysisContext context)
+    private void InitializeOperationBlock(OperationBlockStartAnalysisContext context)
+    {
+        var localValueCache = new LocalValueCache();
+        context.RegisterOperationAction(
+            operationContext => AnalyzeInvocation(operationContext, localValueCache),
+            OperationKind.Invocation);
+    }
+
+    private void AnalyzeInvocation(OperationAnalysisContext context, LocalValueCache localValueCache)
     {
         var invocation = (IInvocationOperation)context.Operation;
         var method = invocation.TargetMethod;
@@ -69,7 +79,7 @@ public sealed partial class MissingOrderByAnalyzer : DiagnosticAnalyzer
         if (receiver == null || !receiver.Type.IsIQueryable())
             return;
 
-        if (!HasEntityFrameworkQuerySource(receiver))
+        if (!HasEntityFrameworkQuerySource(receiver, localValueCache, context.CancellationToken))
             return;
 
         if (isSorting)
@@ -87,11 +97,16 @@ public sealed partial class MissingOrderByAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool HasEntityFrameworkQuerySource(IOperation operation)
+    private static bool HasEntityFrameworkQuerySource(
+        IOperation operation,
+        LocalValueCache localValueCache,
+        CancellationToken cancellationToken)
     {
+        var visitedLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
         var current = operation;
         while (current != null)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             current = current.UnwrapConversions();
 
             if (current.Type.IsDbSet())
@@ -115,10 +130,19 @@ public sealed partial class MissingOrderByAnalyzer : DiagnosticAnalyzer
                     continue;
 
                 case ILocalReferenceOperation localReference:
+                    if (!visitedLocals.Add(localReference.Local))
+                        return false;
+
                     if (localReference.Type.IsDbSet())
                         return true;
 
-                    if (TryResolveLocalValue(localReference.Local, localReference, localReference.FindOwningExecutableRoot(), out var resolvedValue))
+                    if (TryResolveLocalValue(
+                            localReference.Local,
+                            localReference,
+                            localReference.FindOwningExecutableRoot(),
+                            localValueCache,
+                            cancellationToken,
+                            out var resolvedValue))
                     {
                         current = resolvedValue;
                         continue;
@@ -134,48 +158,134 @@ public sealed partial class MissingOrderByAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool TryResolveLocalValue(ILocalSymbol local, IOperation reference, IOperation? executableRoot, out IOperation value)
+    private static bool TryResolveLocalValue(
+        ILocalSymbol local,
+        IOperation reference,
+        IOperation? executableRoot,
+        LocalValueCache localValueCache,
+        CancellationToken cancellationToken,
+        out IOperation value)
     {
         value = null!;
 
         if (executableRoot == null)
             return false;
 
-        var referenceStart = reference.Syntax.SpanStart;
-        var bestWriteStart = -1;
+        return localValueCache.TryGetLatestValue(
+            executableRoot,
+            local,
+            reference.Syntax.SpanStart,
+            cancellationToken,
+            out value);
+    }
 
-        foreach (var descendant in executableRoot.Descendants())
+    private sealed class LocalValueCache
+    {
+        private readonly object syncRoot = new();
+        private readonly Dictionary<IOperation, Dictionary<ILocalSymbol, List<LocalWrite>>> writesByRoot = new();
+
+        public bool TryGetLatestValue(
+            IOperation executableRoot,
+            ILocalSymbol local,
+            int referenceStart,
+            CancellationToken cancellationToken,
+            out IOperation value)
         {
-            if (descendant is IVariableDeclarationOperation declaration)
+            value = null!;
+            var writes = GetWrites(executableRoot, cancellationToken);
+            if (!writes.TryGetValue(local, out var localWrites))
+                return false;
+
+            var bestWriteStart = -1;
+
+            foreach (var write in localWrites)
             {
-                foreach (var declarator in declaration.Declarators)
-                {
-                    if (!SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) || declarator.Initializer == null)
-                        continue;
+                cancellationToken.ThrowIfCancellationRequested();
 
-                    var writeStart = declarator.Syntax.SpanStart;
-                    if (writeStart >= referenceStart || writeStart <= bestWriteStart)
-                        continue;
-
-                    bestWriteStart = writeStart;
-                    value = declarator.Initializer.Value;
-                }
-            }
-
-            if (descendant is ISimpleAssignmentOperation assignment &&
-                assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal &&
-                SymbolEqualityComparer.Default.Equals(targetLocal.Local, local))
-            {
-                var writeStart = assignment.Syntax.SpanStart;
-                if (writeStart >= referenceStart || writeStart <= bestWriteStart)
+                if (write.SpanStart >= referenceStart || write.SpanStart <= bestWriteStart)
                     continue;
 
-                bestWriteStart = writeStart;
-                value = assignment.Value;
+                bestWriteStart = write.SpanStart;
+                value = write.Value;
+            }
+
+            return bestWriteStart >= 0;
+        }
+
+        private Dictionary<ILocalSymbol, List<LocalWrite>> GetWrites(
+            IOperation executableRoot,
+            CancellationToken cancellationToken)
+        {
+            lock (syncRoot)
+            {
+                if (!writesByRoot.TryGetValue(executableRoot, out var writes))
+                {
+                    writes = BuildWrites(executableRoot, cancellationToken);
+                    writesByRoot.Add(executableRoot, writes);
+                }
+
+                return writes;
             }
         }
 
-        return bestWriteStart >= 0;
+        private static Dictionary<ILocalSymbol, List<LocalWrite>> BuildWrites(
+            IOperation executableRoot,
+            CancellationToken cancellationToken)
+        {
+            var writes = new Dictionary<ILocalSymbol, List<LocalWrite>>(SymbolEqualityComparer.Default);
+
+            foreach (var descendant in executableRoot.Descendants())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (descendant is IVariableDeclarationOperation declaration)
+                {
+                    foreach (var declarator in declaration.Declarators)
+                    {
+                        if (declarator.Initializer == null)
+                            continue;
+
+                        AddWrite(writes, declarator.Symbol, declarator.Syntax.SpanStart, declarator.Initializer.Value);
+                    }
+                }
+
+                if (descendant is ISimpleAssignmentOperation assignment &&
+                    assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal)
+                {
+                    AddWrite(writes, targetLocal.Local, assignment.Syntax.SpanStart, assignment.Value);
+                }
+            }
+
+            return writes;
+        }
+
+        private static void AddWrite(
+            Dictionary<ILocalSymbol, List<LocalWrite>> writes,
+            ILocalSymbol local,
+            int spanStart,
+            IOperation value)
+        {
+            if (!writes.TryGetValue(local, out var localWrites))
+            {
+                localWrites = new List<LocalWrite>();
+                writes.Add(local, localWrites);
+            }
+
+            localWrites.Add(new LocalWrite(spanStart, value));
+        }
+    }
+
+    private readonly struct LocalWrite
+    {
+        public LocalWrite(int spanStart, IOperation value)
+        {
+            SpanStart = spanStart;
+            Value = value;
+        }
+
+        public int SpanStart { get; }
+
+        public IOperation Value { get; }
     }
 
     private static Location GetMethodLocation(IInvocationOperation invocation)

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.18</Version>
+        <Version>5.2.19</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Further reduces analyzer build overhead by limiting LC023 Fluent key scans to relevant syntax trees and indexing LC011/LC027 model type lookups.</PackageReleaseNotes>
+        <PackageReleaseNotes>Further reduces analyzer build overhead by caching and canceling hot LC007, LC015, and LC017 analysis paths.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC015_MissingOrderBy/MissingOrderByTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC015_MissingOrderBy/MissingOrderByTests.cs
@@ -98,6 +98,34 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task Skip_OnComposedIQueryableAliasFromDbSet_ShouldTrigger()
+    {
+        var test = Usings + @"
+namespace TestApp
+{
+    public class AppDbContext : TestNamespace.DbContext { public TestNamespace.DbSet<User> Users { get; set; } }
+
+    public class Program
+    {
+        public void Main()
+        {
+            using var db = new AppDbContext();
+            IQueryable<User> query = db.Users;
+            query = query.Where(u => u.Id > 0);
+
+            var result = query.{|#0:Skip|}(10);
+        }
+    }
+}" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic(MissingOrderByAnalyzer.Rule)
+            .WithLocation(0)
+            .WithArguments("Skip");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task Last_WithoutOrderBy_ShouldTrigger()
     {
         var test = Usings + @"

--- a/tests/LinqContraband.Tests/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC017_WholeEntityProjection/WholeEntityProjectionTests.cs
@@ -302,4 +302,28 @@ class Program
 
         await VerifyCS.VerifyAnalyzerAsync(test);
     }
+
+    [Fact]
+    public async Task TestInnocent_ManualIterationLocalCapturedAfterLambdaDeclaration_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    public void ProcessWithCapturedManualLocal()
+    {
+        LargeEntity current = null;
+        Action useLater = () => DoSomething(current);
+        var db = new MyDbContext();
+        var entities = db.LargeEntities.ToList();
+        current = entities[0];
+        Console.WriteLine(current.Name);
+        useLater();
+    }
+
+    private void DoSomething(LargeEntity e) { }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
 }

--- a/tests/LinqContraband.Tests/Architecture/AnalyzerPerformanceTests.cs
+++ b/tests/LinqContraband.Tests/Architecture/AnalyzerPerformanceTests.cs
@@ -1,6 +1,9 @@
 using System.Collections.Immutable;
 using System.Text;
 using LinqContraband.Analyzers.LC011_EntityMissingPrimaryKey;
+using LinqContraband.Analyzers.LC007_NPlusOneLooper;
+using LinqContraband.Analyzers.LC015_MissingOrderBy;
+using LinqContraband.Analyzers.LC017_WholeEntityProjection;
 using LinqContraband.Analyzers.LC023_FindInsteadOfFirstOrDefault;
 using LinqContraband.Analyzers.LC027_MissingExplicitForeignKey;
 using Microsoft.CodeAnalysis;
@@ -46,6 +49,56 @@ public class AnalyzerPerformanceTests
         await GetDiagnosticsWithinAsync(new MissingExplicitForeignKeyAnalyzer(), compilation, AnalyzerTimeout);
     }
 
+    [Fact]
+    public async Task LC015_LocalQueryResolution_CompletesOnLargeMethod()
+    {
+        var compilation = CreateCompilation(GenerateEfCoreMock(), GenerateLc015StressSource());
+
+        var diagnostics = await GetDiagnosticsWithinAsync(
+            new MissingOrderByAnalyzer(),
+            compilation,
+            AnalyzerTimeout);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == MissingOrderByAnalyzer.DiagnosticId);
+    }
+
+    [Fact]
+    public async Task LC015_LocalQueryResolution_CompletesOnSelfReferentialLocal()
+    {
+        var compilation = CreateCompilation(GenerateEfCoreMock(), GenerateLc015SelfReferentialSource());
+
+        await GetDiagnosticsWithinAsync(
+            new MissingOrderByAnalyzer(),
+            compilation,
+            AnalyzerTimeout);
+    }
+
+    [Fact]
+    public async Task LC007_LocalQueryProvenance_CompletesOnLargeLoopMethod()
+    {
+        var compilation = CreateCompilation(GenerateEfCoreMock(), GenerateLc007StressSource());
+
+        var diagnostics = await GetDiagnosticsWithinAsync(
+            new NPlusOneLooperAnalyzer(),
+            compilation,
+            AnalyzerTimeout);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == NPlusOneLooperAnalyzer.DiagnosticId);
+    }
+
+    [Fact]
+    public async Task LC017_WholeEntityUsage_CompletesOnManyMaterializers()
+    {
+        var compilation = CreateCompilation(GenerateEfCoreMock(), GenerateLc017StressSource());
+
+        var diagnostics = await GetDiagnosticsWithinAsync(
+            new WholeEntityProjectionAnalyzer(),
+            compilation,
+            AnalyzerTimeout);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == WholeEntityProjectionAnalyzer.DiagnosticId);
+    }
+
     private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithinAsync(
         DiagnosticAnalyzer analyzer,
         Compilation compilation,
@@ -85,6 +138,189 @@ public class AnalyzerPerformanceTests
             syntaxTrees,
             trustedPlatformAssemblies,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static string GenerateLc015StressSource()
+    {
+        const int queryCount = 240;
+        const int noiseCount = 500;
+        var source = new StringBuilder();
+        source.AppendLine(
+            """
+            using System.Linq;
+            using Microsoft.EntityFrameworkCore;
+
+            namespace PerfApp;
+
+            public class AppDbContext : DbContext
+            {
+                public DbSet<User> Users { get; set; }
+            }
+
+            public class User
+            {
+                public int Id { get; set; }
+                public string Name { get; set; }
+            }
+
+            public class Queries
+            {
+                public void Run()
+                {
+                    var db = new AppDbContext();
+                    var query = db.Users.Where(u => u.Id > 0);
+            """);
+
+        for (var i = 0; i < noiseCount; i++)
+            source.AppendLine($"        var noise{i} = {i};");
+
+        for (var i = 0; i < queryCount; i++)
+            source.AppendLine($"        var page{i} = query.Skip({i});");
+
+        source.AppendLine(
+            """
+                }
+            }
+            """);
+
+        return source.ToString();
+    }
+
+    private static string GenerateLc015SelfReferentialSource()
+    {
+        return
+            """
+            using System.Linq;
+            using Microsoft.EntityFrameworkCore;
+
+            namespace PerfApp;
+
+            public class User
+            {
+                public int Id { get; set; }
+            }
+
+            public class Queries
+            {
+                public void Run()
+                {
+                    IQueryable<User> query = query;
+                    var page = query.Skip(1);
+                }
+            }
+            """;
+    }
+
+    private static string GenerateLc007StressSource()
+    {
+        const int queryCount = 160;
+        const int noiseCount = 400;
+        var source = new StringBuilder();
+        source.AppendLine(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Microsoft.EntityFrameworkCore;
+
+            namespace PerfApp;
+
+            public class AppDbContext : DbContext
+            {
+                public DbSet<User> Users { get; set; }
+            }
+
+            public class User
+            {
+                public int Id { get; set; }
+                public string Name { get; set; }
+            }
+
+            public class Queries
+            {
+                public void Run(List<int> ids)
+                {
+                    var db = new AppDbContext();
+                    var query = db.Users.Where(u => u.Id > 0);
+            """);
+
+        for (var i = 0; i < noiseCount; i++)
+            source.AppendLine($"        var noise{i} = {i};");
+
+        source.AppendLine(
+            """
+                    foreach (var id in ids)
+                    {
+            """);
+
+        for (var i = 0; i < queryCount; i++)
+            source.AppendLine($"            var users{i} = query.Where(u => u.Id == id).ToList();");
+
+        source.AppendLine(
+            """
+                    }
+                }
+            }
+            """);
+
+        return source.ToString();
+    }
+
+    private static string GenerateLc017StressSource()
+    {
+        const int materializerCount = 80;
+        var source = new StringBuilder();
+        source.AppendLine(
+            """
+            using System;
+            using System.Linq;
+            using Microsoft.EntityFrameworkCore;
+
+            namespace PerfApp;
+
+            public class AppDbContext : DbContext
+            {
+                public DbSet<LargeEntity> LargeEntities { get; set; }
+            }
+
+            public class LargeEntity
+            {
+                public int Id { get; set; }
+                public string Name { get; set; }
+                public string P01 { get; set; }
+                public string P02 { get; set; }
+                public string P03 { get; set; }
+                public string P04 { get; set; }
+                public string P05 { get; set; }
+                public string P06 { get; set; }
+                public string P07 { get; set; }
+                public string P08 { get; set; }
+                public string P09 { get; set; }
+                public string P10 { get; set; }
+            }
+
+            public class Queries
+            {
+                public void Run()
+                {
+                    var db = new AppDbContext();
+            """);
+
+        for (var i = 0; i < materializerCount; i++)
+        {
+            source.AppendLine($"        var entities{i} = db.LargeEntities.ToList();");
+            source.AppendLine($"        foreach (var entity{i} in entities{i})");
+            source.AppendLine("        {");
+            source.AppendLine($"            Console.WriteLine(entity{i}.Name);");
+            source.AppendLine("        }");
+        }
+
+        source.AppendLine(
+            """
+                }
+            }
+            """);
+
+        return source.ToString();
     }
 
     private static string GenerateLc023StressSource()


### PR DESCRIPTION
## Summary
- Cache LC015 local query-source resolution per operation block and guard self-referential locals
- Cache LC007 local write scans and thread cancellation through provenance analysis
- Collapse LC017 usage/syntax scans and add performance coverage for LC007/LC015/LC017
- Prepare 5.2.19 package metadata and changelog

## Validation
- dotnet build LinqContraband.sln --no-restore
- DOTNET_ROLL_FORWARD=Major dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore