### PR TITLE
fix: cache analyzer scans for release 5.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.20] - 2026-04-27
+
+### Changed
+- Cached shared local assignment scans for `LC002` and `LC031` query provenance resolution to reduce repeated full-method operation walks
+- Cached `LC044` SaveChanges analysis inputs per executable root so local declarations, foreach loops, mutations, reattach calls, and prior SaveChanges calls are scanned once
+- Updated package release notes for the analyzer scan-cache performance pass
+
 ## [5.2.19] - 2026-04-27
 
 ### Changed

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
 
 namespace LinqContraband.Analyzers.LC044_AsNoTrackingThenModify;
 
@@ -38,12 +38,6 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
         Description,
         helpLinkUri: "https://github.com/georgepwall1991/LinqContraband/blob/master/docs/LC044_AsNoTrackingThenModifySilentWrite.md");
 
-    private static readonly ImmutableHashSet<string> ReattachMethodNames = ImmutableHashSet.Create(
-        "Update", "UpdateRange", "Attach", "AttachRange");
-
-    private static readonly ImmutableHashSet<string> TrackingStates = ImmutableHashSet.Create(
-        "Modified", "Added");
-
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
     public override void Initialize(AnalysisContext context)
@@ -61,28 +55,26 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
         if (method.Name != "SaveChanges" && method.Name != "SaveChangesAsync") return;
         if (!method.ContainingType.IsDbContext()) return;
 
-        if (!TryGetSymbol(save.Instance, out var saveContextSymbol) || saveContextSymbol == null) return;
+        if (!AsNoTrackingThenModifyRootScan.TryGetSymbol(save.Instance, out var saveContextSymbol) ||
+            saveContextSymbol == null) return;
 
         var root = save.FindOwningExecutableRoot();
         if (root == null) return;
 
+        var scan = AsNoTrackingThenModifyRootScan.GetOrBuild(root, context.CancellationToken);
         var saveSpan = save.Syntax.SpanStart;
         var reported = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
 
-        foreach (var op in Descendants(root))
+        foreach (var decl in scan.InitializedDeclarators)
         {
-            switch (op)
-            {
-                case IVariableDeclaratorOperation decl when decl.Initializer?.Value != null:
-                    TryReportForLocal(
-                        context, root, save, saveContextSymbol, saveSpan,
-                        decl.Symbol, decl.Syntax.SpanStart, decl.Initializer.Value, reported);
-                    break;
+            TryReportForLocal(
+                context, root, save, saveContextSymbol, saveSpan, scan,
+                decl.Symbol, decl.Syntax.SpanStart, decl.Initializer!.Value, reported);
+        }
 
-                case IForEachLoopOperation forEach:
-                    TryReportForForeach(context, root, save, saveContextSymbol, saveSpan, forEach, reported);
-                    break;
-            }
+        foreach (var forEach in scan.ForEachLoops)
+        {
+            TryReportForForeach(context, root, save, saveContextSymbol, saveSpan, scan, forEach, reported);
         }
     }
 
@@ -92,6 +84,7 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
         IInvocationOperation save,
         ISymbol saveContext,
         int saveSpan,
+        AsNoTrackingThenModifyRootScan scan,
         ILocalSymbol local,
         int declSpan,
         IOperation initializer,
@@ -106,16 +99,16 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
 
         if (HasMultipleAssignments(root, local)) return;
 
-        var mutationNullable = FindFirstPropertyMutation(root, local, declSpan, saveSpan);
+        var mutationNullable = FindFirstPropertyMutation(scan, local, declSpan, saveSpan);
         if (mutationNullable == null) return;
         var mutation = mutationNullable.Value;
 
         if (!BlockReaches(mutation.Operation, save)) return;
 
-        if (HasEarlierSaveChangesOnSameContext(root, saveContext, mutation.Operation.Syntax.SpanStart, saveSpan))
+        if (HasEarlierSaveChangesOnSameContext(scan, saveContext, mutation.Operation.Syntax.SpanStart, saveSpan))
             return;
 
-        if (HasReattach(root, local, saveContext, mutation.Operation.Syntax.SpanStart, saveSpan))
+        if (HasReattach(scan, local, saveContext, mutation.Operation.Syntax.SpanStart, saveSpan))
             return;
 
         reported.Add(local);
@@ -132,6 +125,7 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
         IInvocationOperation save,
         ISymbol saveContext,
         int saveSpan,
+        AsNoTrackingThenModifyRootScan scan,
         IForEachLoopOperation forEach,
         HashSet<ILocalSymbol> reported)
     {
@@ -142,18 +136,20 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
         if (!TryGetQueryContextSymbol(queryReceiver, out var queryContextSymbol)) return;
         if (!SymbolEqualityComparer.Default.Equals(saveContext, queryContextSymbol)) return;
 
+        var forEachSpan = forEach.Syntax.Span;
+
         foreach (var loopLocal in forEach.Locals)
         {
             if (reported.Contains(loopLocal)) continue;
 
-            var mutationNullable = FindFirstPropertyMutation(forEach, loopLocal, forEach.Syntax.SpanStart - 1, saveSpan);
+            var mutationNullable = FindFirstPropertyMutation(scan, loopLocal, forEach.Syntax.SpanStart - 1, saveSpan);
             if (mutationNullable == null) continue;
             var mutation = mutationNullable.Value;
 
-            if (HasReattachInRange(forEach, loopLocal, saveContext)) continue;
+            if (HasReattachInRange(scan, loopLocal, saveContext, forEachSpan)) continue;
             if (!BlockReaches(forEach, save)) continue;
 
-            if (HasEarlierSaveChangesOnSameContext(root, saveContext, forEach.Syntax.SpanStart, saveSpan))
+            if (HasEarlierSaveChangesOnSameContext(scan, saveContext, forEach.Syntax.SpanStart, saveSpan))
                 continue;
 
             reported.Add(loopLocal);
@@ -179,24 +175,22 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
         public string PropertyName { get; }
     }
 
-    private static MutationHit? FindFirstPropertyMutation(IOperation root, ILocalSymbol local, int afterSpan, int beforeSpan)
+    private static MutationHit? FindFirstPropertyMutation(
+        AsNoTrackingThenModifyRootScan scan,
+        ILocalSymbol local,
+        int afterSpan,
+        int beforeSpan)
     {
+        if (!scan.MutationsByLocal.TryGetValue(local, out var mutations)) return null;
+
         MutationHit? best = null;
-        foreach (var op in Descendants(root))
+        for (var i = 0; i < mutations.Count; i++)
         {
-            if (op is not ISimpleAssignmentOperation assignment) continue;
-            if (assignment.Target is not IPropertyReferenceOperation propRef) continue;
-
-            var instance = propRef.Instance?.UnwrapConversions();
-            if (instance is not ILocalReferenceOperation localRef) continue;
-            if (!SymbolEqualityComparer.Default.Equals(localRef.Local, local)) continue;
-
-            var span = assignment.Syntax.SpanStart;
-            if (span <= afterSpan || span >= beforeSpan) continue;
-
-            if (best == null || span < best.Value.Operation.Syntax.SpanStart)
+            var entry = mutations[i];
+            if (entry.SpanStart <= afterSpan || entry.SpanStart >= beforeSpan) continue;
+            if (best == null || entry.SpanStart < best.Value.Operation.Syntax.SpanStart)
             {
-                best = new MutationHit(assignment, propRef.Syntax.GetLocation(), propRef.Property.Name);
+                best = new MutationHit(entry.Operation, entry.TargetLocation, entry.PropertyName);
             }
         }
 
@@ -205,126 +199,51 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
 
     private static bool HasMultipleAssignments(IOperation root, ILocalSymbol local)
     {
-        var count = 0;
-        foreach (var op in Descendants(root))
-        {
-            if (op is ISimpleAssignmentOperation assignment &&
-                assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal &&
-                SymbolEqualityComparer.Default.Equals(targetLocal.Local, local))
-            {
-                count++;
-            }
-            else if (op is IVariableDeclaratorOperation declarator &&
-                     SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) &&
-                     declarator.Initializer != null)
-            {
-                count++;
-            }
-
-            if (count > 1) return true;
-        }
-
-        return false;
+        var assignments = LocalAssignmentCache.GetAssignments(root, local);
+        return assignments.Count > 1;
     }
 
     private static bool HasReattach(
-        IOperation root,
+        AsNoTrackingThenModifyRootScan scan,
         ILocalSymbol local,
         ISymbol saveContext,
         int afterSpan,
         int beforeSpan)
     {
-        foreach (var op in Descendants(root))
+        if (!scan.ReattachesByLocal.TryGetValue(local, out var reattaches)) return false;
+
+        for (var i = 0; i < reattaches.Count; i++)
         {
-            var span = op.Syntax.SpanStart;
-            if (span <= afterSpan || span >= beforeSpan) continue;
+            var entry = reattaches[i];
+            if (entry.SpanStart <= afterSpan || entry.SpanStart >= beforeSpan) continue;
 
-            if (op is IInvocationOperation inv && IsReattachInvocation(inv, local, saveContext))
-                return true;
-
-            if (op is ISimpleAssignmentOperation assign && IsEntryStateReattach(assign, local, saveContext))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static bool HasReattachInRange(IOperation range, ILocalSymbol local, ISymbol saveContext)
-    {
-        foreach (var op in Descendants(range))
-        {
-            if (op is IInvocationOperation inv && IsReattachInvocation(inv, local, saveContext))
-                return true;
-
-            if (op is ISimpleAssignmentOperation assign && IsEntryStateReattach(assign, local, saveContext))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static bool IsReattachInvocation(IInvocationOperation invocation, ILocalSymbol local, ISymbol saveContext)
-    {
-        if (!ReattachMethodNames.Contains(invocation.TargetMethod.Name)) return false;
-
-        var container = invocation.TargetMethod.ContainingType;
-        if (!container.IsDbContext() && !container.IsDbSet()) return false;
-
-        if (invocation.Arguments.Length == 0) return false;
-        var argValue = invocation.Arguments[0].Value.UnwrapConversions();
-        if (argValue is not ILocalReferenceOperation argLocal) return false;
-        if (!SymbolEqualityComparer.Default.Equals(argLocal.Local, local)) return false;
-
-        return TryResolveInvocationContext(invocation, out var invContext)
-               && SymbolEqualityComparer.Default.Equals(invContext, saveContext);
-    }
-
-    private static bool IsEntryStateReattach(ISimpleAssignmentOperation assignment, ILocalSymbol local, ISymbol saveContext)
-    {
-        if (assignment.Target is not IPropertyReferenceOperation targetProp) return false;
-        if (targetProp.Property.Name != "State") return false;
-        if (targetProp.Property.ContainingType?.Name != "EntityEntry") return false;
-
-        if (targetProp.Instance is not IInvocationOperation entryInv) return false;
-        if (entryInv.TargetMethod.Name != "Entry") return false;
-        if (!entryInv.TargetMethod.ContainingType.IsDbContext()) return false;
-
-        if (entryInv.Arguments.Length == 0) return false;
-        var argValue = entryInv.Arguments[0].Value.UnwrapConversions();
-        if (argValue is not ILocalReferenceOperation argLocal) return false;
-        if (!SymbolEqualityComparer.Default.Equals(argLocal.Local, local)) return false;
-
-        if (!TryGetSymbol(entryInv.Instance, out var entryContext)) return false;
-        if (!SymbolEqualityComparer.Default.Equals(entryContext, saveContext)) return false;
-
-        var value = assignment.Value.UnwrapConversions();
-        if (value is not IFieldReferenceOperation fieldRef) return false;
-        if (fieldRef.Field.ContainingType?.Name != "EntityState") return false;
-
-        return TrackingStates.Contains(fieldRef.Field.Name);
-    }
-
-    private static bool TryResolveInvocationContext(IInvocationOperation invocation, out ISymbol? contextSymbol)
-    {
-        contextSymbol = null;
-
-        if (invocation.TargetMethod.ContainingType.IsDbContext())
-        {
-            return TryGetSymbol(invocation.Instance, out contextSymbol);
-        }
-
-        if (invocation.TargetMethod.ContainingType.IsDbSet())
-        {
-            var dbSetInstance = invocation.Instance?.UnwrapConversions();
-            switch (dbSetInstance)
+            if (entry.ContextSymbol != null &&
+                SymbolEqualityComparer.Default.Equals(entry.ContextSymbol, saveContext))
             {
-                case IPropertyReferenceOperation propRef when propRef.Type.IsDbSet():
-                    return TryGetSymbol(propRef.Instance, out contextSymbol);
-                case IFieldReferenceOperation fieldRef when fieldRef.Type.IsDbSet():
-                    return TryGetSymbol(fieldRef.Instance, out contextSymbol);
-                case IInvocationOperation setCall when setCall.TargetMethod.Name == "Set" &&
-                                                      setCall.TargetMethod.ContainingType.IsDbContext():
-                    return TryGetSymbol(setCall.Instance, out contextSymbol);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasReattachInRange(
+        AsNoTrackingThenModifyRootScan scan,
+        ILocalSymbol local,
+        ISymbol saveContext,
+        TextSpan range)
+    {
+        if (!scan.ReattachesByLocal.TryGetValue(local, out var reattaches)) return false;
+
+        for (var i = 0; i < reattaches.Count; i++)
+        {
+            var entry = reattaches[i];
+            if (!range.Contains(entry.Span)) continue;
+
+            if (entry.ContextSymbol != null &&
+                SymbolEqualityComparer.Default.Equals(entry.ContextSymbol, saveContext))
+            {
+                return true;
             }
         }
 
@@ -332,22 +251,18 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
     }
 
     private static bool HasEarlierSaveChangesOnSameContext(
-        IOperation root,
+        AsNoTrackingThenModifyRootScan scan,
         ISymbol saveContext,
         int afterSpan,
         int currentSaveSpan)
     {
-        foreach (var op in Descendants(root))
+        var saves = scan.SaveChangesCalls;
+        for (var i = 0; i < saves.Count; i++)
         {
-            if (op is not IInvocationOperation inv) continue;
-            if (inv.TargetMethod.Name != "SaveChanges" && inv.TargetMethod.Name != "SaveChangesAsync") continue;
-            if (!inv.TargetMethod.ContainingType.IsDbContext()) continue;
-
-            var span = inv.Syntax.SpanStart;
-            if (span <= afterSpan || span >= currentSaveSpan) continue;
-
-            if (TryGetSymbol(inv.Instance, out var sym) &&
-                SymbolEqualityComparer.Default.Equals(sym, saveContext))
+            var entry = saves[i];
+            if (entry.SpanStart <= afterSpan || entry.SpanStart >= currentSaveSpan) continue;
+            if (entry.ContextSymbol != null &&
+                SymbolEqualityComparer.Default.Equals(entry.ContextSymbol, saveContext))
             {
                 return true;
             }
@@ -438,14 +353,14 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
             switch (current)
             {
                 case IPropertyReferenceOperation propRef when propRef.Type.IsDbSet():
-                    return TryGetSymbol(propRef.Instance, out contextSymbol);
+                    return AsNoTrackingThenModifyRootScan.TryGetSymbol(propRef.Instance, out contextSymbol);
 
                 case IFieldReferenceOperation fieldRef when fieldRef.Type.IsDbSet():
-                    return TryGetSymbol(fieldRef.Instance, out contextSymbol);
+                    return AsNoTrackingThenModifyRootScan.TryGetSymbol(fieldRef.Instance, out contextSymbol);
 
                 case IInvocationOperation inv when inv.TargetMethod.Name == "Set" &&
                                                    inv.TargetMethod.ContainingType.IsDbContext():
-                    return TryGetSymbol(inv.Instance, out contextSymbol);
+                    return AsNoTrackingThenModifyRootScan.TryGetSymbol(inv.Instance, out contextSymbol);
 
                 case IInvocationOperation inv:
                     var next = inv.GetInvocationReceiver();
@@ -459,40 +374,5 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
-    }
-
-    private static bool TryGetSymbol(IOperation? operation, out ISymbol? symbol)
-    {
-        symbol = null;
-        if (operation == null) return false;
-
-        switch (operation.UnwrapConversions())
-        {
-            case ILocalReferenceOperation localRef:
-                symbol = localRef.Local;
-                return true;
-            case IParameterReferenceOperation paramRef:
-                symbol = paramRef.Parameter;
-                return true;
-            case IFieldReferenceOperation fieldRef:
-                symbol = fieldRef.Field;
-                return true;
-            case IPropertyReferenceOperation propRef:
-                symbol = propRef.Property;
-                return true;
-            case IInstanceReferenceOperation:
-                symbol = null;
-                return false;
-            default:
-                return false;
-        }
-    }
-
-    private static IEnumerable<IOperation> Descendants(IOperation root)
-    {
-        yield return root;
-        foreach (var child in root.ChildOperations)
-            foreach (var d in Descendants(child))
-                yield return d;
     }
 }

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyRootScan.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyRootScan.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
+
+namespace LinqContraband.Analyzers.LC044_AsNoTrackingThenModify;
+
+/// <summary>
+/// Per-executable-root scan that pre-buckets the operations LC044 needs (initialized declarators,
+/// foreach loops, property mutations by local, reattach calls by local, and SaveChanges calls).
+/// Cached via <see cref="ConditionalWeakTable{TKey,TValue}"/> so the scan only runs once per root.
+/// </summary>
+internal sealed class AsNoTrackingThenModifyRootScan
+{
+    private static readonly ConditionalWeakTable<IOperation, AsNoTrackingThenModifyRootScan> Cache = new();
+
+    private static readonly ImmutableHashSet<string> ReattachMethodNames = ImmutableHashSet.Create(
+        "Update", "UpdateRange", "Attach", "AttachRange");
+
+    private static readonly ImmutableHashSet<string> TrackingStates = ImmutableHashSet.Create(
+        "Modified", "Added");
+
+    private static readonly List<IVariableDeclaratorOperation> EmptyDeclarators = new();
+    private static readonly List<IForEachLoopOperation> EmptyForEachLoops = new();
+    private static readonly List<SaveChangesEntry> EmptySaveChanges = new();
+
+    private AsNoTrackingThenModifyRootScan() { }
+
+    public List<IVariableDeclaratorOperation> InitializedDeclarators { get; private set; } = EmptyDeclarators;
+    public List<IForEachLoopOperation> ForEachLoops { get; private set; } = EmptyForEachLoops;
+    public Dictionary<ILocalSymbol, List<MutationEntry>> MutationsByLocal { get; }
+        = new(SymbolEqualityComparer.Default);
+    public Dictionary<ILocalSymbol, List<ReattachEntry>> ReattachesByLocal { get; }
+        = new(SymbolEqualityComparer.Default);
+    public List<SaveChangesEntry> SaveChangesCalls { get; private set; } = EmptySaveChanges;
+
+    public static AsNoTrackingThenModifyRootScan GetOrBuild(IOperation root, CancellationToken cancellationToken)
+    {
+        if (Cache.TryGetValue(root, out var existing))
+            return existing;
+
+        var scan = Build(root, cancellationToken);
+        try
+        {
+            Cache.Add(root, scan);
+        }
+        catch (ArgumentException)
+        {
+            if (Cache.TryGetValue(root, out var raced))
+                return raced;
+        }
+
+        return scan;
+    }
+
+    private static AsNoTrackingThenModifyRootScan Build(IOperation root, CancellationToken cancellationToken)
+    {
+        var scan = new AsNoTrackingThenModifyRootScan();
+        List<IVariableDeclaratorOperation>? decls = null;
+        List<IForEachLoopOperation>? loops = null;
+        List<SaveChangesEntry>? saves = null;
+
+        Visit(root, scan, ref decls, ref loops, ref saves, cancellationToken);
+
+        foreach (var descendant in root.Descendants())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Visit(descendant, scan, ref decls, ref loops, ref saves, cancellationToken);
+        }
+
+        scan.InitializedDeclarators = decls ?? EmptyDeclarators;
+        scan.ForEachLoops = loops ?? EmptyForEachLoops;
+        scan.SaveChangesCalls = saves ?? EmptySaveChanges;
+        return scan;
+    }
+
+    private static void Visit(
+        IOperation op,
+        AsNoTrackingThenModifyRootScan scan,
+        ref List<IVariableDeclaratorOperation>? decls,
+        ref List<IForEachLoopOperation>? loops,
+        ref List<SaveChangesEntry>? saves,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        switch (op)
+        {
+            case IVariableDeclaratorOperation declarator when declarator.Initializer?.Value != null:
+                decls ??= new List<IVariableDeclaratorOperation>();
+                decls.Add(declarator);
+                break;
+
+            case IForEachLoopOperation forEach:
+                loops ??= new List<IForEachLoopOperation>();
+                loops.Add(forEach);
+                break;
+
+            case ISimpleAssignmentOperation assignment:
+                HandleAssignment(scan, assignment);
+                break;
+
+            case IInvocationOperation invocation:
+                HandleInvocation(scan, invocation, ref saves);
+                break;
+        }
+    }
+
+    private static void HandleAssignment(AsNoTrackingThenModifyRootScan scan, ISimpleAssignmentOperation assignment)
+    {
+        if (assignment.Target is IPropertyReferenceOperation propRef &&
+            propRef.Instance?.UnwrapConversions() is ILocalReferenceOperation instanceLocal)
+        {
+            var entry = new MutationEntry(
+                assignment,
+                propRef.Syntax.GetLocation(),
+                propRef.Property.Name,
+                assignment.Syntax.SpanStart);
+            AddMutation(scan, instanceLocal.Local, entry);
+        }
+
+        if (TryParseEntryStateReattach(assignment, out var entryLocal, out var entryContext))
+        {
+            AddReattach(
+                scan,
+                entryLocal,
+                new ReattachEntry(entryContext, assignment.Syntax.SpanStart, assignment.Syntax.Span));
+        }
+    }
+
+    private static void HandleInvocation(
+        AsNoTrackingThenModifyRootScan scan,
+        IInvocationOperation invocation,
+        ref List<SaveChangesEntry>? saves)
+    {
+        var method = invocation.TargetMethod;
+
+        if ((method.Name == "SaveChanges" || method.Name == "SaveChangesAsync") &&
+            method.ContainingType.IsDbContext())
+        {
+            if (TryGetSymbol(invocation.Instance, out var sym))
+            {
+                saves ??= new List<SaveChangesEntry>();
+                saves.Add(new SaveChangesEntry(sym, invocation.Syntax.SpanStart));
+            }
+        }
+
+        if (TryParseReattachInvocation(invocation, out var reattachLocal, out var reattachContext))
+        {
+            AddReattach(
+                scan,
+                reattachLocal,
+                new ReattachEntry(reattachContext, invocation.Syntax.SpanStart, invocation.Syntax.Span));
+        }
+    }
+
+    private static bool TryParseReattachInvocation(
+        IInvocationOperation invocation,
+        out ILocalSymbol local,
+        out ISymbol? contextSymbol)
+    {
+        local = null!;
+        contextSymbol = null;
+
+        if (!ReattachMethodNames.Contains(invocation.TargetMethod.Name)) return false;
+
+        var container = invocation.TargetMethod.ContainingType;
+        if (!container.IsDbContext() && !container.IsDbSet()) return false;
+
+        if (invocation.Arguments.Length == 0) return false;
+        if (invocation.Arguments[0].Value.UnwrapConversions() is not ILocalReferenceOperation argLocal)
+            return false;
+
+        if (!TryResolveInvocationContext(invocation, out contextSymbol)) return false;
+
+        local = argLocal.Local;
+        return true;
+    }
+
+    private static bool TryParseEntryStateReattach(
+        ISimpleAssignmentOperation assignment,
+        out ILocalSymbol local,
+        out ISymbol? contextSymbol)
+    {
+        local = null!;
+        contextSymbol = null;
+
+        if (assignment.Target is not IPropertyReferenceOperation targetProp) return false;
+        if (targetProp.Property.Name != "State") return false;
+        if (targetProp.Property.ContainingType?.Name != "EntityEntry") return false;
+
+        if (targetProp.Instance is not IInvocationOperation entryInv) return false;
+        if (entryInv.TargetMethod.Name != "Entry") return false;
+        if (!entryInv.TargetMethod.ContainingType.IsDbContext()) return false;
+
+        if (entryInv.Arguments.Length == 0) return false;
+        if (entryInv.Arguments[0].Value.UnwrapConversions() is not ILocalReferenceOperation argLocal) return false;
+
+        if (!TryGetSymbol(entryInv.Instance, out contextSymbol)) return false;
+
+        var value = assignment.Value.UnwrapConversions();
+        if (value is not IFieldReferenceOperation fieldRef) return false;
+        if (fieldRef.Field.ContainingType?.Name != "EntityState") return false;
+        if (!TrackingStates.Contains(fieldRef.Field.Name)) return false;
+
+        local = argLocal.Local;
+        return true;
+    }
+
+    private static bool TryResolveInvocationContext(IInvocationOperation invocation, out ISymbol? contextSymbol)
+    {
+        contextSymbol = null;
+
+        if (invocation.TargetMethod.ContainingType.IsDbContext())
+            return TryGetSymbol(invocation.Instance, out contextSymbol);
+
+        if (invocation.TargetMethod.ContainingType.IsDbSet())
+        {
+            var dbSetInstance = invocation.Instance?.UnwrapConversions();
+            switch (dbSetInstance)
+            {
+                case IPropertyReferenceOperation propRef when propRef.Type.IsDbSet():
+                    return TryGetSymbol(propRef.Instance, out contextSymbol);
+                case IFieldReferenceOperation fieldRef when fieldRef.Type.IsDbSet():
+                    return TryGetSymbol(fieldRef.Instance, out contextSymbol);
+                case IInvocationOperation setCall when setCall.TargetMethod.Name == "Set" &&
+                                                      setCall.TargetMethod.ContainingType.IsDbContext():
+                    return TryGetSymbol(setCall.Instance, out contextSymbol);
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool TryGetSymbol(IOperation? operation, out ISymbol? symbol)
+    {
+        symbol = null;
+        if (operation == null) return false;
+
+        switch (operation.UnwrapConversions())
+        {
+            case ILocalReferenceOperation localRef:
+                symbol = localRef.Local;
+                return true;
+            case IParameterReferenceOperation paramRef:
+                symbol = paramRef.Parameter;
+                return true;
+            case IFieldReferenceOperation fieldRef:
+                symbol = fieldRef.Field;
+                return true;
+            case IPropertyReferenceOperation propRef:
+                symbol = propRef.Property;
+                return true;
+            case IInstanceReferenceOperation:
+                symbol = null;
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private static void AddMutation(AsNoTrackingThenModifyRootScan scan, ILocalSymbol local, MutationEntry entry)
+    {
+        if (!scan.MutationsByLocal.TryGetValue(local, out var list))
+        {
+            list = new List<MutationEntry>();
+            scan.MutationsByLocal[local] = list;
+        }
+
+        list.Add(entry);
+    }
+
+    private static void AddReattach(AsNoTrackingThenModifyRootScan scan, ILocalSymbol local, ReattachEntry entry)
+    {
+        if (!scan.ReattachesByLocal.TryGetValue(local, out var list))
+        {
+            list = new List<ReattachEntry>();
+            scan.ReattachesByLocal[local] = list;
+        }
+
+        list.Add(entry);
+    }
+}
+
+internal readonly struct MutationEntry
+{
+    public MutationEntry(IOperation operation, Location targetLocation, string propertyName, int spanStart)
+    {
+        Operation = operation;
+        TargetLocation = targetLocation;
+        PropertyName = propertyName;
+        SpanStart = spanStart;
+    }
+
+    public IOperation Operation { get; }
+    public Location TargetLocation { get; }
+    public string PropertyName { get; }
+    public int SpanStart { get; }
+}
+
+internal readonly struct ReattachEntry
+{
+    public ReattachEntry(ISymbol? contextSymbol, int spanStart, TextSpan span)
+    {
+        ContextSymbol = contextSymbol;
+        SpanStart = spanStart;
+        Span = span;
+    }
+
+    public ISymbol? ContextSymbol { get; }
+    public int SpanStart { get; }
+    public TextSpan Span { get; }
+}
+
+internal readonly struct SaveChangesEntry
+{
+    public SaveChangesEntry(ISymbol? contextSymbol, int spanStart)
+    {
+        ContextSymbol = contextSymbol;
+        SpanStart = spanStart;
+    }
+
+    public ISymbol? ContextSymbol { get; }
+    public int SpanStart { get; }
+}

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationOriginAnalysis.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationOriginAnalysis.cs
@@ -143,42 +143,10 @@ public sealed partial class PrematureMaterializationAnalyzer
         value = null!;
         if (!visitedLocals.Add(local)) return false;
 
-        IOperation? latestValue = null;
-        var latestPosition = -1;
-        var assignmentCount = 0;
-
-        foreach (var descendant in executableRoot.Descendants())
-        {
-            if (descendant.Syntax.SpanStart >= position) continue;
-
-            switch (descendant)
-            {
-                case IVariableDeclaratorOperation declarator when
-                    SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) &&
-                    declarator.Initializer != null &&
-                    declarator.Syntax.SpanStart > latestPosition:
-                    latestValue = declarator.Initializer.Value;
-                    latestPosition = declarator.Syntax.SpanStart;
-                    assignmentCount++;
-                    break;
-
-                case ISimpleAssignmentOperation assignment when
-                    assignment.Target is ILocalReferenceOperation targetLocal &&
-                    SymbolEqualityComparer.Default.Equals(targetLocal.Local, local) &&
-                    assignment.Syntax.SpanStart > latestPosition:
-                    latestValue = assignment.Value;
-                    latestPosition = assignment.Syntax.SpanStart;
-                    assignmentCount++;
-                    break;
-            }
-        }
-
-        if (latestValue == null || assignmentCount != 1)
-        {
-            return false;
-        }
-
-        value = latestValue.UnwrapConversions();
-        return true;
+        return LocalAssignmentCache.TryGetSingleAssignedValueBefore(
+            executableRoot,
+            local,
+            position,
+            out value);
     }
 }

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC031_UnboundedQueryMaterialization/UnboundedQueryMaterializationAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC031_UnboundedQueryMaterialization/UnboundedQueryMaterializationAnalyzer.cs
@@ -1,5 +1,5 @@
-using System.Collections.Immutable;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using LinqContraband.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -161,53 +161,10 @@ public sealed class UnboundedQueryMaterializationAnalyzer : DiagnosticAnalyzer
         int position,
         out IOperation value)
     {
-        value = null!;
-        IOperation? latestValue = null;
-        var latestPosition = -1;
-        var assignmentCount = 0;
-
-        foreach (var operation in EnumerateOperations(executableRoot))
-        {
-            if (operation.Syntax.SpanStart >= position)
-                continue;
-
-            switch (operation)
-            {
-                case IVariableDeclaratorOperation declarator
-                    when SymbolEqualityComparer.Default.Equals(declarator.Symbol, local) &&
-                         declarator.Initializer != null &&
-                         declarator.Syntax.SpanStart > latestPosition:
-                    latestValue = declarator.Initializer.Value;
-                    latestPosition = declarator.Syntax.SpanStart;
-                    assignmentCount++;
-                    break;
-
-                case ISimpleAssignmentOperation assignment
-                    when assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal &&
-                         SymbolEqualityComparer.Default.Equals(targetLocal.Local, local) &&
-                         assignment.Syntax.SpanStart > latestPosition:
-                    latestValue = assignment.Value;
-                    latestPosition = assignment.Syntax.SpanStart;
-                    assignmentCount++;
-                    break;
-            }
-        }
-
-        if (latestValue == null || assignmentCount != 1)
-            return false;
-
-        value = latestValue.UnwrapConversions();
-        return true;
-    }
-
-    private static IEnumerable<IOperation> EnumerateOperations(IOperation root)
-    {
-        yield return root;
-
-        foreach (var child in root.ChildOperations)
-        {
-            foreach (var descendant in EnumerateOperations(child))
-                yield return descendant;
-        }
+        return LocalAssignmentCache.TryGetSingleAssignedValueBefore(
+            executableRoot,
+            local,
+            position,
+            out value);
     }
 }

--- a/src/LinqContraband/Extensions/LocalAssignmentCache.cs
+++ b/src/LinqContraband/Extensions/LocalAssignmentCache.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Extensions;
+
+/// <summary>
+/// Per-executable-root cache of local variable assignments and declarator initializers.
+/// The cache is keyed by the executable root <see cref="IOperation"/> and lives only as long
+/// as that operation is reachable, so it is automatically released between compilations.
+/// </summary>
+internal static class LocalAssignmentCache
+{
+    private static readonly ConditionalWeakTable<IOperation, RootScan> Cache = new();
+
+    public static IReadOnlyList<LocalAssignment> GetAssignments(
+        IOperation executableRoot,
+        ILocalSymbol local,
+        CancellationToken cancellationToken = default)
+    {
+        var scan = GetOrAdd(executableRoot, cancellationToken);
+        return scan.GetAssignments(local);
+    }
+
+    public static bool TryGetSingleAssignedValueBefore(
+        IOperation executableRoot,
+        ILocalSymbol local,
+        int beforePosition,
+        out IOperation value,
+        CancellationToken cancellationToken = default)
+    {
+        value = null!;
+        var assignments = GetAssignments(executableRoot, local, cancellationToken);
+        if (assignments.Count == 0) return false;
+
+        IOperation? latest = null;
+        var latestSpan = -1;
+        var matchCount = 0;
+
+        for (var i = 0; i < assignments.Count; i++)
+        {
+            var assignment = assignments[i];
+            if (assignment.SpanStart >= beforePosition) continue;
+
+            matchCount++;
+            if (assignment.SpanStart > latestSpan)
+            {
+                latestSpan = assignment.SpanStart;
+                latest = assignment.Value;
+            }
+        }
+
+        if (matchCount != 1 || latest == null) return false;
+
+        value = latest.UnwrapConversions();
+        return true;
+    }
+
+    private static RootScan GetOrAdd(IOperation executableRoot, CancellationToken cancellationToken)
+    {
+#if NETSTANDARD2_0 || NETSTANDARD2_1
+        if (Cache.TryGetValue(executableRoot, out var existing))
+            return existing;
+
+        var scan = RootScan.Build(executableRoot, cancellationToken);
+        try
+        {
+            Cache.Add(executableRoot, scan);
+            return scan;
+        }
+        catch (ArgumentException)
+        {
+            return Cache.TryGetValue(executableRoot, out var raced) ? raced : scan;
+        }
+#else
+        return Cache.GetValue(executableRoot, root => RootScan.Build(root, cancellationToken));
+#endif
+    }
+
+    private sealed class RootScan
+    {
+        private static readonly IReadOnlyList<LocalAssignment> EmptyAssignments = Array.Empty<LocalAssignment>();
+
+        private readonly Dictionary<ILocalSymbol, List<LocalAssignment>> assignmentsByLocal;
+
+        private RootScan(Dictionary<ILocalSymbol, List<LocalAssignment>> assignmentsByLocal)
+        {
+            this.assignmentsByLocal = assignmentsByLocal;
+        }
+
+        public IReadOnlyList<LocalAssignment> GetAssignments(ILocalSymbol local)
+        {
+            return assignmentsByLocal.TryGetValue(local, out var list)
+                ? list
+                : EmptyAssignments;
+        }
+
+        public static RootScan Build(IOperation executableRoot, CancellationToken cancellationToken)
+        {
+            var assignments = new Dictionary<ILocalSymbol, List<LocalAssignment>>(SymbolEqualityComparer.Default);
+
+            foreach (var descendant in executableRoot.Descendants())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                switch (descendant)
+                {
+                    case IVariableDeclaratorOperation declarator
+                        when declarator.Initializer != null:
+                        Add(assignments, declarator.Symbol, declarator.Syntax.SpanStart, declarator.Initializer.Value);
+                        break;
+
+                    case ISimpleAssignmentOperation assignment
+                        when assignment.Target.UnwrapConversions() is ILocalReferenceOperation targetLocal:
+                        Add(assignments, targetLocal.Local, assignment.Syntax.SpanStart, assignment.Value);
+                        break;
+                }
+            }
+
+            return new RootScan(assignments);
+        }
+
+        private static void Add(
+            Dictionary<ILocalSymbol, List<LocalAssignment>> assignments,
+            ILocalSymbol local,
+            int spanStart,
+            IOperation value)
+        {
+            if (!assignments.TryGetValue(local, out var list))
+            {
+                list = new List<LocalAssignment>();
+                assignments[local] = list;
+            }
+
+            list.Add(new LocalAssignment(spanStart, value));
+        }
+    }
+}
+
+internal readonly struct LocalAssignment
+{
+    public LocalAssignment(int spanStart, IOperation value)
+    {
+        SpanStart = spanStart;
+        Value = value;
+    }
+
+    public int SpanStart { get; }
+
+    public IOperation Value { get; }
+}

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.19</Version>
+        <Version>5.2.20</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Further reduces analyzer build overhead by caching and canceling hot LC007, LC015, and LC017 analysis paths.</PackageReleaseNotes>
+        <PackageReleaseNotes>Further reduces analyzer build overhead by caching hot LC002, LC031, and LC044 operation scans.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- Cache shared local assignment scans for LC002 and LC031 provenance resolution
- Cache LC044 SaveChanges analysis inputs per executable root
- Bump package metadata and changelog to 5.2.20

## Validation
- dotnet build LinqContraband.sln -c Release --nologo
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -c Release -f net10.0 --nologo
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0

Note: local machine only has .NET 10 runtime installed; CI covers net8/net9.