### PR TITLE
fix: suppress invalid LC008 await fixes

### DIFF
--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerFixer.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerFixer.cs
@@ -38,6 +38,8 @@ public class SyncBlockerFixer : CodeFixProvider
         var invocation = root?.FindNode(diagnosticSpan) as InvocationExpressionSyntax;
         if (invocation == null) return;
 
+        if (IsInvalidAwaitContext(invocation)) return;
+
         // We need the method name to find the replacement
         if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
         {
@@ -50,6 +52,45 @@ public class SyncBlockerFixer : CodeFixProvider
                         "UseAsyncMethod"),
                     diagnostic);
         }
+    }
+
+    private static bool IsInvalidAwaitContext(SyntaxNode invocation)
+    {
+        for (SyntaxNode? node = invocation; node != null; node = node.Parent)
+        {
+            var parent = node.Parent;
+            if (parent == null) continue;
+
+            switch (parent)
+            {
+                case FromClauseSyntax fromClause when fromClause.Expression == node:
+                    // 'await' is only legal in the FIRST from clause of a query
+                    // expression. Subsequent (continuation) from clauses appear
+                    // as children of QueryBodySyntax and do not allow await.
+                    return fromClause.Parent is not QueryExpressionSyntax;
+
+                case JoinClauseSyntax joinClause when joinClause.InExpression == node:
+                    // 'await' is allowed in the collection expression of a join.
+                    return false;
+
+                case QueryClauseSyntax:
+                case SelectOrGroupClauseSyntax:
+                case OrderingSyntax:
+                case QueryContinuationSyntax:
+                    return true;
+            }
+
+            if (parent is AnonymousFunctionExpressionSyntax anonymousFunction)
+                return !anonymousFunction.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword);
+
+            if (parent is LocalFunctionStatementSyntax localFunction)
+                return !localFunction.Modifiers.Any(SyntaxKind.AsyncKeyword);
+
+            if (parent is BaseMethodDeclarationSyntax method)
+                return !method.Modifiers.Any(SyntaxKind.AsyncKeyword);
+        }
+
+        return false;
     }
 
     private async Task<Document> ApplyFixAsync(Document document, InvocationExpressionSyntax invocation,

--- a/tests/LinqContraband.Tests/Analyzers/LC008_SyncBlocker/SyncBlockerFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC008_SyncBlocker/SyncBlockerFixerTests.cs
@@ -138,4 +138,135 @@ class Program
 
         await testObj.RunAsync();
     }
+
+    [Fact]
+    public async Task FixCrime_InsideLetClause_DiagnosticReportedButNoFixApplied()
+    {
+        // 'await' is illegal inside a 'let' clause of a query expression
+        // (CS1995). The analyzer should still flag the sync call, but the
+        // automated code fix must not transform it.
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        var q = from u in db.Users
+                let posts = db.Users.Where(x => x.Id == u.Id).ToList()
+                select new { u, posts };
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = test
+        };
+
+        testObj.ExpectedDiagnostics.Add(new DiagnosticResult("LC008", DiagnosticSeverity.Warning)
+            .WithSpan(15, 29, 15, 71)
+            .WithArguments("ToList", "ToListAsync"));
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixCrime_InsideWhereClause_DiagnosticReportedButNoFixApplied()
+    {
+        // Sanity-check another disallowed clause position. Awaiting inside a
+        // where clause expression is also illegal in query syntax.
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        var q = from u in db.Users
+                where db.Users.Where(x => x.Id == u.Id).ToList().Count > 0
+                select u;
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = test
+        };
+
+        testObj.ExpectedDiagnostics.Add(new DiagnosticResult("LC008", DiagnosticSeverity.Warning)
+            .WithSpan(15, 23, 15, 65)
+            .WithArguments("ToList", "ToListAsync"));
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixCrime_InsideInitialFromClause_FixIsApplied()
+    {
+        // 'await' IS legal inside the collection expression of the initial
+        // 'from' clause, so the fixer should still rewrite the call there.
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        var q = from u in db.Users.ToList()
+                select u;
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        var q = from u in await db.Users.ToListAsync() select u;
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        testObj.ExpectedDiagnostics.Add(new DiagnosticResult("LC008", DiagnosticSeverity.Warning)
+            .WithSpan(14, 27, 14, 44)
+            .WithArguments("ToList", "ToListAsync"));
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixCrime_InsideNonAsyncLambda_DiagnosticReportedButNoFixApplied()
+    {
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        Func<List<User>> getUsers = () => db.Users.ToList();
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = test
+        };
+
+        testObj.ExpectedDiagnostics.Add(new DiagnosticResult("LC008", DiagnosticSeverity.Warning)
+            .WithSpan(14, 43, 14, 60)
+            .WithArguments("ToList", "ToListAsync"));
+
+        await testObj.RunAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- Skip LC008 code fixes when adding await would be invalid in query clauses or non-async scopes
- Keep fixes enabled for legal initial from and join collection expressions
- Add regression coverage for let, where, initial from, and non-async lambda cases

## Validation
- dotnet build LinqContraband.sln --nologo -v minimal
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --nologo --framework net10.0 --filter "FullyQualifiedName~SyncBlockerFixerTests"
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --nologo --framework net10.0