### PR TITLE
[codex] harden production analyzer feedback for 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0] - 2026-04-27
+
+### Changed
+- Hardened `LC001`, `LC002`, `LC007`, `LC008`, `LC016`, and `LC022` against production false positives from in-memory LINQ, translated query subqueries, and captured-value helpers
+- Changed `LC022` to an advisory `Info` diagnostic with modern EF Core wording for nested collection projection materialization
+- Coalesced repeated `LC016` clock diagnostics within one query lambda and expanded the fixer to replace matching repeated clock accesses together
+- Updated docs, analyzer health, and regression coverage for production feedback patterns
+
 ## [5.2.21] - 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -771,10 +771,11 @@ Ensure that bypassing global filters is intentional and necessary for the specif
 
 ---
 
-### LC022: ToList Inside Select Projection
+### LC022: Nested Collection Materialization Inside Projection
 
 Calling `ToList()`, `ToArray()`, or similar collection materializers inside a `Select()` projection on an IQueryable
-forces client-side evaluation or throws in EF Core 3+. EF Core handles collection projections natively.
+can be expensive or provider-version sensitive. Modern EF Core can translate some correlated collection projections,
+so this rule is advisory and should prompt a query-shape review.
 
 **👶 Explain it like I'm a ten year old:** Imagine you ask a baker to put frosting on 100 cupcakes. But for each
 cupcake, you tell them "First, put all the frosting in a separate bowl, then frost the cupcake from the bowl." The baker
@@ -784,12 +785,12 @@ everything down.
 **❌ The Crime:**
 
 ```csharp
-// Forces client-side evaluation of the sub-collection
+// Nested collection materialization inside the projection
 var result = db.Users.Select(u => u.Orders.ToList()).ToList();
 ```
 
 **✅ The Fix:**
-Remove the materializer from the projection. EF Core handles it.
+Project directly, use split queries when appropriate, or keep the materializer when a DTO contract requires a concrete list.
 
 ```csharp
 // EF Core projects the collection natively
@@ -797,7 +798,7 @@ var result = db.Users.Select(u => u.Orders).ToList();
 ```
 
 **🛡️ Reliability Notes:**
-- LC022 applies to normal `IQueryable.Select(...)` projections where the collection materializer is redundant or forces client evaluation.
+- LC022 applies to normal `IQueryable.Select(...)` projections where the collection materializer may add avoidable work.
 - Grouped projections like `GroupBy(...).Select(g => g.ToList())` are owned by `LC024`, which gives the more specific non-translatable `GroupBy` guidance.
 
 ---

--- a/docs/LC001_LocalMethod.md
+++ b/docs/LC001_LocalMethod.md
@@ -1,7 +1,7 @@
 # Spec: LC001 - Local Method Smuggler
 
 ## Goal
-Detect usage of local C# methods within LINQ to Entities queries that cannot be translated to SQL by the database provider.
+Detect usage of local C# methods in translation-critical LINQ to Entities query positions when the method depends on the query row.
 
 ## The Problem
 Entity Framework Core attempts to translate LINQ expressions into SQL. When it encounters a method it does not recognize (like a custom local method), it often has to resort to "Client-Side Evaluation." This means it fetches ALL the data from the table into your application's memory and then filters it using C#. For large tables, this is a massive performance and memory leak.
@@ -33,6 +33,10 @@ var users = db.Users.Where(u => u.DateOfBirth <= minDob).ToList();
 ### Algorithm
 1.  **Target**: Invocations within a lambda expression.
 2.  **Context**: Ensure the lambda is an argument to an `IQueryable` method.
-3.  **Check**: Skip known framework methods, trusted provider methods, and methods explicitly marked with
+3.  **Dependency**: Require the method call to depend on the query lambda parameter.
+4.  **Query position**: Report only translation-critical positions such as filters, ordering, joins, grouping keys, and predicates.
+5.  **Check**: Skip known framework methods, trusted provider methods, and methods explicitly marked with
     `[DbFunction]` or `[Projectable]`.
-4.  **Report**: If none of those exemptions apply, flag the invocation.
+6.  **Report**: If none of those exemptions apply, flag the invocation.
+
+LC001 intentionally ignores helper calls that depend only on captured/input values and top-level `Select` projection helpers, where EF Core can often parameterize the captured value or perform the projection after the main query shape is translated.

--- a/docs/LC002_PrematureMaterialization.md
+++ b/docs/LC002_PrematureMaterialization.md
@@ -6,7 +6,7 @@ Catch query work that moves from the provider to LINQ-to-Objects only because an
 ## What LC002 Reports
 
 ### 1. Premature query continuation
-LC002 reports approved `Enumerable` operators that run after a materializer sourced from `IQueryable`.
+LC002 reports approved `Enumerable` operators that run in the same fluent chain after a materializer or client boundary sourced from `IQueryable`.
 Lambda-based continuations must also pass a conservative provider-safety check before the rule reports.
 
 ```csharp
@@ -15,27 +15,17 @@ var count = db.Users.ToArray().Count();
 var ordered = db.Users.AsEnumerable().OrderBy(u => u.Name);
 ```
 
-The rule also follows single-assignment local hops and collection-constructor materialization when the `IQueryable` origin is still provable.
-
-```csharp
-var materialized = db.Users.ToList();
-var adults = materialized.Where(u => u.Age > 18);
-
-var set = new HashSet<User>(db.Users);
-var count = set.Count();
-```
-
 ### 2. Redundant materialization
-LC002 reports a second materializer when the sequence was already materialized from `IQueryable`.
+LC002 reports a second direct collection materializer when the sequence was already materialized in the same chain from `IQueryable`.
 
 ```csharp
-var users = db.Users.AsEnumerable().ToList();
 var usersAgain = db.Users.ToArray().ToList();
 ```
 
 ## What LC002 Intentionally Ignores
 - Ambiguous provenance such as multiple local assignments or control-flow-dependent sources
-- Field/property provenance and other shapes where the analyzer cannot prove the query origin safely
+- Already materialized locals, aliases, constructors, arrays, DTO lists, fields, properties, and other post-processing shapes where in-memory work may be intentional
+- `AsEnumerable()` by itself when it is used only as an explicit client boundary
 - Overloads or lambdas that do not have a clear `IQueryable`-safe equivalent, such as index-aware predicates/selectors, comparer-based overloads, delegated predicates, local/source methods, `Regex`, or `StringComparison` string calls
 - Pure in-memory sequences that never came from `IQueryable`
 

--- a/docs/LC007_NPlusOneLooper.md
+++ b/docs/LC007_NPlusOneLooper.md
@@ -40,10 +40,11 @@ while (hasWork)
 }
 ```
 
-The analyzer follows direct EF roots such as `DbSet<T>`, `DbContext.Set<T>()`, navigation `Query()` calls, and single-assignment local hops when the origin stays provable.
+The analyzer follows direct EF roots such as `DbSet<T>`, `DbContext.Set<T>()`, navigation `Query()` calls, and single-assignment query local hops when the origin stays provable.
 
 ## What LC007 Intentionally Ignores
 - Plain LINQ-to-Objects or `AsQueryable()` sources
+- Aggregates, lookups, or filters over already materialized `List<T>`/array/local DTO collections inside loops
 - Ambiguous `IQueryable` provenance through parameters, fields, properties, or multi-assignment locals
 - Query construction inside loops when no execution method is invoked
 - `Reference(...)` and `Collection(...)` access without `Load`, `LoadAsync`, or `Query()` execution

--- a/docs/LC008_SyncBlocker.md
+++ b/docs/LC008_SyncBlocker.md
@@ -6,6 +6,8 @@ Detect usage of synchronous materialization methods (like `ToList`) within an `a
 ## The Problem
 Synchronous calls like `db.Users.ToList()` block the current thread while waiting for the database response. In a web server, this leads to "Thread Starvation," where all available threads are stuck waiting, preventing the server from handling other incoming requests.
 
+LC008 intentionally ignores sync-looking LINQ operators inside `IQueryable` expression trees, such as query-expression subqueries in `let`, `where`, or projection clauses. Those calls are translated as SQL subqueries instead of blocking the async method directly.
+
 ### Example Violation
 ```csharp
 public async Task<List<User>> GetUsersAsync()

--- a/docs/LC016_AvoidDateTimeNow.md
+++ b/docs/LC016_AvoidDateTimeNow.md
@@ -22,6 +22,7 @@ var activeUsers = db.Users.Where(u => u.ExpiryDate > now).ToList();
 ```
 
 The fixer chooses a unique local name when `now` is already used by an enclosing method, local function, or lambda parameter.
+When the same clock property appears multiple times in one query lambda, LC016 reports it once and the fixer replaces each identical access in that lambda.
 
 ## Analyzer Logic
 

--- a/docs/LC022_ToListInSelectProjection.md
+++ b/docs/LC022_ToListInSelectProjection.md
@@ -1,16 +1,16 @@
-# LC022: ToList/ToArray Inside Select Projection
+# LC022: Nested Collection Materialization Inside Projection
 
 ## What it flags
 
-Flags per-row buffering inside projections because nested materialization often causes translation failures, client evaluation, or repeated in-memory work.
+Flags nested collection materialization inside projections because it can be expensive, provider-version sensitive, or better expressed with direct projection/split-query shaping.
 
 ## Why it matters
 
-LinqContraband reports this rule when the query shape suggests a risky or non-translatable pattern that is better made explicit before it reaches production.
+LinqContraband reports this rule as an advisory performance signal. Modern EF Core can translate some correlated collection projections, so the diagnostic should prompt review rather than automatic removal.
 
 ## Typical fix
 
-Keep the projection provider-friendly, flatten the shape, or materialize once at the outer boundary when nested collections are intentional.
+Keep the projection provider-friendly, flatten the shape, use split queries where appropriate, or keep the nested materializer when a DTO contract requires a concrete collection.
 
 The code fix is intentionally conservative. It only removes `ToList()` when the receiver type already matches the materialized type, such as a `List<T>` navigation projected as `navigation.ToList()`. It does not rewrite `ToArray()`, dictionary/set materializers, anonymous/object initializer members, or type-changing shapes such as `stringValue.ToList()`.
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -49,7 +49,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC019 | Conditional Include expression | Loading & Includes | Warning | 4 | 4 | 4 | 3 | 4 | 4 | Low | Good manual-only rule; would benefit from more filtered Include and non-EF Include edge cases. |
 | LC020 | Untranslatable string comparison overloads | Query Shape & Translation | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Hardened around Queryable expression-lambda proof, direct/nested query-parameter-dependent receivers, captured local/constant negatives, and semantically bound fixer argument removal. |
 | LC021 | IgnoreQueryFilters usage | Raw SQL & Security | Warning | 3 | 2 | 2 | 2 | 3 | 4 | High | Intentional bypasses are common enough that the rule needs suppression/allow-list guidance and stronger negative tests. |
-| LC022 | ToList/ToArray inside Select projection | Materialization & Projection | Warning | 3 | 3 | 2 | 3 | 3 | 4 | High | Important performance smell; fixer behavior needs dedicated tests or a clearer supported-boundary statement. |
+| LC022 | Nested collection materialization inside projection | Materialization & Projection | Info | 4 | 4 | 3 | 4 | 4 | 3 | Low | Advisory projection-shape rule after production hardening; severity and wording now reflect modern EF Core correlated collection support. |
 | LC023 | Prefer Find/FindAsync for primary key lookups | Materialization & Projection | Info | 3 | 3 | 3 | 2 | 4 | 3 | Medium | Helpful cleanup rule, but key-shape/model-awareness and async fixer cases remain thin. |
 | LC024 | GroupBy with non-translatable projection | Query Shape & Translation | Warning | 4 | 4 | 4 | 3 | 4 | 5 | Medium | High-impact manual rule; add more provider/LINQ-to-Objects boundaries and nested projection negatives. |
 | LC025 | AsNoTracking with Update/Remove | Change Tracking & Context Lifetime | Warning | 4 | 4 | 3 | 3 | 4 | 4 | Medium | Good core data-loss guardrail; fixer and alias/order coverage should be broadened. |
@@ -79,10 +79,10 @@ The next improvement batch should focus on rules where user impact and health ga
 
 | Priority | Rules | Work |
 | --- | --- | --- |
-| High | LC021, LC022 | Harden Warning rules with weak fixer/test confidence. Add dedicated fixer tests, intentional-use guidance, and tighter diagnostic placement. |
+| High | LC021 | Harden Warning rules with weak fixer/test confidence. Add dedicated fixer tests, intentional-use guidance, and tighter diagnostic placement. |
 | High | LC031, LC039, LC040 | Build out high-value heuristic rules. Add source/context aliasing, branch/transaction/workflow negatives, opt-out guidance, and richer docs before raising scores. |
 | Medium | LC010, LC012, LC014, LC015, LC018, LC023, LC024, LC025, LC034, LC035, LC036, LC038, LC043 | Improve targeted tests and docs, especially around safe/unsafe fixer boundaries and intentional-use cases. |
-| Low | LC002, LC003, LC005, LC006, LC007, LC008, LC009, LC011, LC013, LC016, LC017, LC019, LC020, LC026, LC027, LC028, LC029, LC030, LC032, LC033, LC037, LC041, LC042, LC044 | Treat as currently acceptable, reference examples, or low-impact tuning rules. |
+| Low | LC002, LC003, LC005, LC006, LC007, LC008, LC009, LC011, LC013, LC016, LC017, LC019, LC020, LC022, LC026, LC027, LC028, LC029, LC030, LC032, LC033, LC037, LC041, LC042, LC044 | Treat as currently acceptable, reference examples, or low-impact tuning rules. |
 
 ## Verification Baseline
 

--- a/docs/rule-catalog.md
+++ b/docs/rule-catalog.md
@@ -51,7 +51,7 @@ This page is generated from that catalog and grouped by domain.
 | `LC002` Premature query continuation after materialization | `Warning` | `Performance` | Code fix | [`LC002_PrematureMaterialization`](./LC002_PrematureMaterialization.md) | `Samples/LC002_PrematureMaterialization/` |
 | `LC003` Prefer Any() over Count() existence checks | `Warning` | `Performance` | Code fix | [`LC003_AnyOverCount`](./LC003_AnyOverCount.md) | `Samples/LC003_AnyOverCount/` |
 | `LC017` Performance: Consider using Select() projection | `Info` | `Performance` | Code fix | [`LC017_WholeEntityProjection`](./LC017_WholeEntityProjection.md) | `Samples/LC017_WholeEntityProjection/` |
-| `LC022` ToList/ToArray Inside Select Projection | `Warning` | `Performance` | Code fix | [`LC022_ToListInSelectProjection`](./LC022_ToListInSelectProjection.md) | `Samples/LC022_ToListInSelectProjection/` |
+| `LC022` Nested collection materialization inside projection | `Info` | `Performance` | Code fix | [`LC022_ToListInSelectProjection`](./LC022_ToListInSelectProjection.md) | `Samples/LC022_ToListInSelectProjection/` |
 | `LC023` Use Find/FindAsync for primary key lookups | `Info` | `Performance` | Code fix | [`LC023_FindInsteadOfFirstOrDefault`](./LC023_FindInsteadOfFirstOrDefault.md) | `Samples/LC023_FindInsteadOfFirstOrDefault/` |
 | `LC029` Redundant identity Select | `Info` | `Performance` | Code fix | [`LC029_RedundantIdentitySelect`](./LC029_RedundantIdentitySelect.md) | `Samples/LC029_RedundantIdentitySelect/` |
 | `LC031` Unbounded Query Materialization | `Info` | `Performance` | Manual only | [`LC031_UnboundedQueryMaterialization`](./LC031_UnboundedQueryMaterialization.md) | `Samples/LC031_UnboundedQueryMaterialization/` |

--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalysis.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalysis.cs
@@ -220,6 +220,9 @@ internal static class NPlusOneLooperAnalysis
             switch (current)
             {
                 case IInvocationOperation invocation:
+                    if (IsClientBoundaryInvocation(invocation))
+                        return QueryProvenance.None;
+
                     if (IsDbContextSetInvocation(invocation))
                         return QueryProvenance.Proven;
 
@@ -389,6 +392,13 @@ internal static class NPlusOneLooperAnalysis
     {
         return invocation.TargetMethod.Name == "Set" &&
                invocation.TargetMethod.ContainingType.IsDbContext();
+    }
+
+    private static bool IsClientBoundaryInvocation(IInvocationOperation invocation)
+    {
+        return invocation.TargetMethod.Name == "AsEnumerable" ||
+               ImmediateQueryExecutionMethods.Contains(invocation.TargetMethod.Name) ||
+               SetBasedExecutorMethods.Contains(invocation.TargetMethod.Name);
     }
 
     private static bool IsNavigationQueryInvocation(IInvocationOperation invocation)

--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC008_SyncBlocker/SyncBlockerAnalyzer.cs
@@ -59,6 +59,8 @@ public sealed class SyncBlockerAnalyzer : DiagnosticAnalyzer
         // 2. Is it an EF Core related method?
         if (!IsEfCoreMethod(method, invocation)) return;
 
+        if (IsInsideQueryableExpressionLambda(invocation)) return;
+
         // 3. Is the containing method Async?
         if (!IsInsideAsyncMethod(context.Operation)) return;
 
@@ -86,6 +88,55 @@ public sealed class SyncBlockerAnalyzer : DiagnosticAnalyzer
         var receiverType = invocation.GetInvocationReceiverType();
 
         return receiverType?.IsIQueryable() == true;
+    }
+
+    private static bool IsInsideQueryableExpressionLambda(IOperation operation)
+    {
+        var current = operation.Parent;
+        while (current != null)
+        {
+            if (current is IAnonymousFunctionOperation lambda &&
+                IsLambdaArgumentToQueryableInvocation(lambda))
+            {
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private static bool IsLambdaArgumentToQueryableInvocation(IAnonymousFunctionOperation lambda)
+    {
+        var current = lambda.Parent;
+        while (current != null)
+        {
+            if (current is IArgumentOperation)
+            {
+                current = current.Parent;
+                continue;
+            }
+
+            if (current is IConversionOperation or IDelegateCreationOperation)
+            {
+                current = current.Parent;
+                continue;
+            }
+
+            if (current is not IInvocationOperation invocation)
+                return false;
+
+            if (invocation.TargetMethod.ContainingType.Name == "Queryable" &&
+                invocation.TargetMethod.ContainingType.ContainingNamespace?.ToString() == "System.Linq")
+            {
+                return true;
+            }
+
+            return invocation.GetInvocationReceiverType()?.IsIQueryable() == true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationAnalyzer.cs
@@ -122,12 +122,7 @@ public sealed partial class PrematureMaterializationAnalyzer : DiagnosticAnalyze
         if (!IsApprovedContinuationMethod(invocation.TargetMethod, out _)) return;
         if (!HasProviderSafeContinuationArguments(invocation)) return;
 
-        if (!TryResolveMaterializationOrigin(
-                unwrappedReceiver,
-                invocation.Syntax.SpanStart,
-                context.Operation.FindOwningExecutableRoot(),
-                new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default),
-                out var materializationOrigin))
+        if (!TryResolveInlineMaterializationOrigin(unwrappedReceiver, out var materializationOrigin))
         {
             return;
         }

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationOriginAnalysis.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationOriginAnalysis.cs
@@ -15,14 +15,14 @@ public sealed partial class PrematureMaterializationAnalyzer
         out Diagnostic diagnostic)
     {
         diagnostic = null!;
-        if (!IsMaterializingMethod(invocation.TargetMethod)) return false;
+        if (!IsMaterializingMethod(invocation.TargetMethod) ||
+            invocation.TargetMethod.Name == "AsEnumerable")
+        {
+            return false;
+        }
 
-        if (!TryResolveMaterializationOrigin(
-                receiver,
-                invocation.Syntax.SpanStart,
-                context.Operation.FindOwningExecutableRoot(),
-                new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default),
-                out var previousMaterialization))
+        if (!TryResolveInlineMaterializationOrigin(receiver, out var previousMaterialization) ||
+            previousMaterialization.MaterializerName == "AsEnumerable")
         {
             return false;
         }
@@ -105,6 +105,35 @@ public sealed partial class PrematureMaterializationAnalyzer
         }
 
         return false;
+    }
+
+    private static bool TryResolveInlineMaterializationOrigin(
+        IOperation operation,
+        out MaterializationOrigin origin)
+    {
+        origin = default;
+        var unwrapped = operation.UnwrapConversions();
+
+        if (unwrapped is IInvocationOperation materializerInvocation &&
+            IsMaterializingMethod(materializerInvocation.TargetMethod) &&
+            TryResolveInlineQueryableSource(materializerInvocation.GetInvocationReceiver()))
+        {
+            origin = new MaterializationOrigin(InlineInvocationOriginKind, materializerInvocation.TargetMethod.Name);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveInlineQueryableSource(IOperation? operation)
+    {
+        if (operation == null) return false;
+
+        var unwrapped = operation.UnwrapConversions();
+        if (unwrapped.Type?.IsIQueryable() == true) return true;
+
+        return unwrapped is IInvocationOperation invocation &&
+               TryResolveInlineQueryableSource(invocation.GetInvocationReceiver());
     }
 
     private static bool TryResolveQueryableOrMaterializedSource(

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC022_ToListInSelectProjection/ToListInSelectProjectionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC022_ToListInSelectProjection/ToListInSelectProjectionAnalyzer.cs
@@ -9,27 +9,27 @@ namespace LinqContraband.Analyzers.LC022_ToListInSelectProjection;
 
 /// <summary>
 /// Detects ToList/ToArray/ToDictionary/ToHashSet calls inside Select projections on IQueryable,
-/// which forces client-side evaluation or throws in EF Core 3+. Diagnostic ID: LC022
+/// which can be expensive or provider-version sensitive. Diagnostic ID: LC022
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class ToListInSelectProjectionAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LC022";
     private const string Category = "Performance";
-    private static readonly LocalizableString Title = "ToList/ToArray Inside Select Projection";
+    private static readonly LocalizableString Title = "Nested collection materialization inside projection";
 
     private static readonly LocalizableString MessageFormat =
-        "'{0}' inside a Select projection forces client-side evaluation. Remove it — EF Core handles collection projection natively.";
+        "'{0}' inside a Select projection can be expensive. Consider projecting directly or using split queries.";
 
     private static readonly LocalizableString Description =
-        "Calling collection materializers (ToList, ToArray, etc.) inside a Select projection on IQueryable forces client-side evaluation or throws. EF Core handles collection projection natively.";
+        "Calling collection materializers (ToList, ToArray, etc.) inside a Select projection on IQueryable can be expensive or provider-version sensitive.";
 
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
         Title,
         MessageFormat,
         Category,
-        DiagnosticSeverity.Warning,
+        DiagnosticSeverity.Info,
         true,
         Description);
 

--- a/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodAnalyzer.cs
@@ -31,6 +31,28 @@ public sealed class LocalMethodAnalyzer : DiagnosticAnalyzer
     private static readonly LocalizableString Description =
         "Methods invoked inside an IQueryable expression must be translatable to SQL.";
 
+    private static readonly ImmutableHashSet<string> TranslationCriticalQueryMethods = ImmutableHashSet.Create(
+        "Where",
+        "OrderBy",
+        "OrderByDescending",
+        "ThenBy",
+        "ThenByDescending",
+        "Join",
+        "GroupJoin",
+        "GroupBy",
+        "Any",
+        "All",
+        "Count",
+        "LongCount",
+        "First",
+        "FirstOrDefault",
+        "Single",
+        "SingleOrDefault",
+        "Last",
+        "LastOrDefault",
+        "SkipWhile",
+        "TakeWhile");
+
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,
         Title,
@@ -78,13 +100,13 @@ public sealed class LocalMethodAnalyzer : DiagnosticAnalyzer
 
         // Constraint 1: Inside a Lambda
         var parent = invocation.Parent;
-        IOperation? lambda = null;
+        IAnonymousFunctionOperation? lambda = null;
 
         while (parent != null)
         {
-            if (parent.Kind == OperationKind.AnonymousFunction)
+            if (parent is IAnonymousFunctionOperation anonymousFunction)
             {
-                lambda = parent;
+                lambda = anonymousFunction;
                 break;
             }
 
@@ -92,6 +114,7 @@ public sealed class LocalMethodAnalyzer : DiagnosticAnalyzer
         }
 
         if (lambda == null) return;
+        if (!InvocationDependsOnLambdaParameter(invocation, lambda)) return;
 
         // Constraint 2: Lambda is argument to IQueryable extension method
         var current = lambda.Parent;
@@ -106,6 +129,9 @@ public sealed class LocalMethodAnalyzer : DiagnosticAnalyzer
 
                 if (type.IsIQueryable())
                 {
+                    if (!TranslationCriticalQueryMethods.Contains(queryInvocation.TargetMethod.Name))
+                        return;
+
                     context.ReportDiagnostic(
                         Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), methodSymbol.Name));
                     return;
@@ -114,6 +140,19 @@ public sealed class LocalMethodAnalyzer : DiagnosticAnalyzer
 
             current = current.Parent;
         }
+    }
+
+    private static bool InvocationDependsOnLambdaParameter(
+        IInvocationOperation invocation,
+        IAnonymousFunctionOperation lambda)
+    {
+        foreach (var parameter in lambda.Symbol.Parameters)
+        {
+            if (invocation.ReferencesParameter(parameter))
+                return true;
+        }
+
+        return false;
     }
 
     private static bool IsTrustedTranslatableMethod(

--- a/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowAnalyzer.cs
@@ -78,13 +78,29 @@ public sealed class AvoidDateTimeNowAnalyzer : DiagnosticAnalyzer
         if (!isDateTime && !isDateTimeOffset) return;
 
         // Check if inside IQueryable lambda
-        if (!IsInsideQueryableLambda(operation)) return;
+        var queryLambda = FindQueryableLambda(operation);
+        if (queryLambda == null) return;
+
+        if (HasEarlierIdenticalClockReference(queryLambda, operation)) return;
 
         context.ReportDiagnostic(Diagnostic.Create(Rule, operation.Syntax.GetLocation(),
             $"{containingType.Name}.{property.Name}"));
     }
 
-    private bool IsInsideQueryableLambda(IOperation operation)
+    private static bool IsClockPropertyReference(IPropertyReferenceOperation operation)
+    {
+        var property = operation.Property;
+        if (property.Name is not ("Now" or "UtcNow")) return false;
+
+        var containingType = property.ContainingType;
+        var isDateTime = containingType.SpecialType == SpecialType.System_DateTime;
+        var isDateTimeOffset = !isDateTime && containingType.Name == "DateTimeOffset" &&
+                               containingType.ContainingNamespace.ToString() == "System";
+
+        return isDateTime || isDateTimeOffset;
+    }
+
+    private static IAnonymousFunctionOperation? FindQueryableLambda(IOperation operation)
     {
         var current = operation.Parent;
         while (current != null)
@@ -100,12 +116,59 @@ public sealed class AvoidDateTimeNowAnalyzer : DiagnosticAnalyzer
                         // Must be on IQueryable
                         if (method.ContainingType.Name == "Queryable" &&
                             method.ContainingNamespace?.ToString() == "System.Linq")
-                            return true;
+                            return FindEnclosingLambda(operation);
                 }
 
             current = current.Parent;
         }
 
+        return null;
+    }
+
+    private static IAnonymousFunctionOperation? FindEnclosingLambda(IOperation operation)
+    {
+        var current = operation.Parent;
+        while (current != null)
+        {
+            if (current is IAnonymousFunctionOperation lambda)
+                return lambda;
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    private static bool HasEarlierIdenticalClockReference(
+        IAnonymousFunctionOperation lambda,
+        IPropertyReferenceOperation current)
+    {
+        var currentStart = current.Syntax.SpanStart;
+        foreach (var candidate in EnumerateOperations(lambda))
+        {
+            if (candidate is not IPropertyReferenceOperation propertyReference ||
+                ReferenceEquals(propertyReference, current) ||
+                propertyReference.Syntax.SpanStart >= currentStart ||
+                !IsClockPropertyReference(propertyReference))
+            {
+                continue;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(propertyReference.Property, current.Property))
+                return true;
+        }
+
         return false;
+    }
+
+    private static IEnumerable<IOperation> EnumerateOperations(IOperation operation)
+    {
+        yield return operation;
+
+        foreach (var child in operation.ChildOperations)
+        {
+            foreach (var descendant in EnumerateOperations(child))
+                yield return descendant;
+        }
     }
 }

--- a/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixer.cs
+++ b/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixer.cs
@@ -53,6 +53,8 @@ public class AvoidDateTimeNowFixer : CodeFixProvider
         if (root == null) return document;
 
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel == null) return document;
 
         // Find the statement containing the expression
         var statement = memberAccess.AncestorsAndSelf().OfType<StatementSyntax>().FirstOrDefault();
@@ -75,13 +77,38 @@ public class AvoidDateTimeNowFixer : CodeFixProvider
             )
         ).WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
 
-        // Replace the member access with the variable reference
-        editor.ReplaceNode(memberAccess, SyntaxFactory.IdentifierName(variableName).WithTriviaFrom(memberAccess));
+        foreach (var access in FindMatchingClockAccesses(memberAccess, semanticModel, cancellationToken))
+        {
+            editor.ReplaceNode(access, SyntaxFactory.IdentifierName(variableName).WithTriviaFrom(access));
+        }
 
         // Insert the declaration before the statement
         editor.InsertBefore(statement, newVariable);
 
         return editor.GetChangedDocument();
+    }
+
+    private static IEnumerable<MemberAccessExpressionSyntax> FindMatchingClockAccesses(
+        MemberAccessExpressionSyntax memberAccess,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var symbol = semanticModel.GetSymbolInfo(memberAccess, cancellationToken).Symbol;
+        if (symbol == null)
+        {
+            yield return memberAccess;
+            yield break;
+        }
+
+        var lambda = memberAccess.AncestorsAndSelf().OfType<LambdaExpressionSyntax>().FirstOrDefault();
+        var searchRoot = (SyntaxNode?)lambda ?? memberAccess;
+
+        foreach (var candidate in searchRoot.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+        {
+            var candidateSymbol = semanticModel.GetSymbolInfo(candidate, cancellationToken).Symbol;
+            if (SymbolEqualityComparer.Default.Equals(candidateSymbol, symbol))
+                yield return candidate;
+        }
     }
 
     private static string GetUniqueVariableName(SyntaxNode node)

--- a/src/LinqContraband/Catalog/RuleCatalog.cs
+++ b/src/LinqContraband/Catalog/RuleCatalog.cs
@@ -305,10 +305,10 @@ public static class RuleCatalog
         new RuleCatalogEntry(
             id: "LC022",
             slug: "LC022_ToListInSelectProjection",
-            title: "ToList/ToArray Inside Select Projection",
+            title: "Nested collection materialization inside projection",
             category: "Performance",
             domain: "Materialization & Projection",
-            severity: DiagnosticSeverity.Warning,
+            severity: DiagnosticSeverity.Info,
             analyzerTypeName: "ToListInSelectProjectionAnalyzer",
             fixerTypeName: "ToListInSelectProjectionFixer",
             documentationPath: "docs/LC022_ToListInSelectProjection.md",

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.2.21</Version>
+        <Version>5.3.0</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Suppresses LC008 code fixes when adding await would produce invalid C# in query clauses or non-async scopes.</PackageReleaseNotes>
+        <PackageReleaseNotes>Hardens LC001, LC002, LC007, LC008, LC016, and LC022 against production false positives from in-memory LINQ, translated query subqueries, and advisory nested collection projections.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC001_LocalMethod/LocalMethodSmugglerEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC001_LocalMethod/LocalMethodSmugglerEdgeCasesTests.cs
@@ -183,7 +183,7 @@ class Program
     }
 
     [Fact]
-    public async Task TestCrime_LocalMethodInSelect_ShouldTriggerLC001()
+    public async Task TestInnocent_LocalMethodInTopLevelSelect_ShouldNotTrigger()
     {
         var test = Usings + @"
 class Program
@@ -198,11 +198,27 @@ class Program
 }
 " + MockNamespace;
 
-        var expected = VerifyCS.Diagnostic("LC001")
-            .WithSpan(13, 42, 13, 60)
-            .WithArguments("FormatName");
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
 
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    [Fact]
+    public async Task TestInnocent_CapturedOnlyHelperInWhere_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main(string status)
+    {
+        var db = new DbContext();
+        var normalized = Normalize(status);
+        var query = db.Users.Where(u => u.Name == Normalize(status));
+    }
+
+    string Normalize(string value) => value.Trim();
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]

--- a/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationEdgeCasesTests.cs
@@ -36,7 +36,7 @@ public class PrematureMaterializationEdgeCasesTests
         """;
 
     [Fact]
-    public async Task Reports_WhenLocalAliasesSingleAssignmentMaterialization()
+    public async Task DoesNotReport_WhenLocalAliasesSingleAssignmentMaterialization()
     {
         var test = CommonUsings + """
 
@@ -47,20 +47,16 @@ public class PrematureMaterializationEdgeCasesTests
                     var db = new DbContext();
                     var materialized = db.Users.ToList();
                     var alias = materialized;
-                    var filtered = {|#0:alias.Where(x => x.Age > 18)|};
+                    var filtered = alias.Where(x => x.Age > 18);
                 }
             }
             """ + MockTypes;
 
-        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
-            .WithLocation(0)
-            .WithArguments("Where");
-
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
-    public async Task Reports_WhenMaterializingConstructorFeedsCount()
+    public async Task DoesNotReport_WhenMaterializingConstructorFeedsCount()
     {
         var test = CommonUsings + """
 
@@ -70,16 +66,12 @@ public class PrematureMaterializationEdgeCasesTests
                 {
                     var db = new DbContext();
                     var materialized = new HashSet<User>(db.Users);
-                    var count = {|#0:materialized.Count()|};
+                    var count = materialized.Count();
                 }
             }
             """ + MockTypes;
 
-        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
-            .WithLocation(0)
-            .WithArguments("Count");
-
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]

--- a/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationFixerTests.cs
@@ -208,7 +208,7 @@ public class PrematureMaterializationFixerTests
     }
 
     [Fact]
-    public async Task Fixes_RedundantToListThenAsEnumerable()
+    public async Task DoesNotReport_RedundantToListThenAsEnumerable()
     {
         var test = CommonUsings + """
 
@@ -217,28 +217,12 @@ public class PrematureMaterializationFixerTests
                 void Main()
                 {
                     var db = new DbContext();
-                    var query = {|#0:db.Users.ToList().AsEnumerable()|};
+                    var query = db.Users.ToList().AsEnumerable();
                 }
             }
             """ + MockTypes;
 
-        var fixedCode = CommonUsings + """
-
-            class Program
-            {
-                void Main()
-                {
-                    var db = new DbContext();
-                    var query = db.Users.ToList();
-                }
-            }
-            """ + MockTypes;
-
-        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.RedundantRule)
-            .WithLocation(0)
-            .WithArguments("AsEnumerable", "ToList");
-
-        await VerifyCS.VerifyCodeFixAsync(test, expected, fixedCode);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
@@ -274,16 +258,12 @@ public class PrematureMaterializationFixerTests
                 {
                     var db = new DbContext();
                     var materialized = db.Users.ToList();
-                    var query = {|#0:materialized.Where(x => x.Age > 18)|};
+                    var query = materialized.Where(x => x.Age > 18);
                 }
             }
             """ + MockTypes;
 
-        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
-            .WithLocation(0)
-            .WithArguments("Where");
-
-        await VerifyCS.VerifyCodeFixAsync(test, expected, test);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
@@ -330,16 +310,12 @@ public class PrematureMaterializationFixerTests
                 {
                     var db = new DbContext();
                     var materialized = new HashSet<User>(db.Users);
-                    var query = {|#0:materialized.Where(x => x.Age > 18)|};
+                    var query = materialized.Where(x => x.Age > 18);
                 }
             }
             """ + MockTypes;
 
-        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.Rule)
-            .WithLocation(0)
-            .WithArguments("Where");
-
-        await VerifyCS.VerifyCodeFixAsync(test, expected, test);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
@@ -424,7 +400,7 @@ public class PrematureMaterializationFixerTests
                     var db = new DbContext();
                     var adults = {|#0:db.Users.ToList().Where(x => x.Age >= 18)|};
                     var materialized = db.Users.ToList();
-                    var older = {|#1:materialized.Where(x => x.Age >= 21)|};
+                    var older = materialized.Where(x => x.Age >= 21);
                 }
             }
             """ + MockTypes;
@@ -455,18 +431,6 @@ public class PrematureMaterializationFixerTests
         testObj.ExpectedDiagnostics.Add(
             new DiagnosticResult(PrematureMaterializationAnalyzer.Rule)
                 .WithLocation(0)
-                .WithArguments("Where"));
-        testObj.ExpectedDiagnostics.Add(
-            new DiagnosticResult(PrematureMaterializationAnalyzer.Rule)
-                .WithLocation(1)
-                .WithArguments("Where"));
-        testObj.FixedState.ExpectedDiagnostics.Add(
-            new DiagnosticResult(PrematureMaterializationAnalyzer.Rule)
-                .WithSpan(12, 21, 12, 57)
-                .WithArguments("Where"));
-        testObj.BatchFixedState.ExpectedDiagnostics.Add(
-            new DiagnosticResult(PrematureMaterializationAnalyzer.Rule)
-                .WithSpan(12, 21, 12, 57)
                 .WithArguments("Where"));
 
         await testObj.RunAsync();

--- a/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationTests.cs
@@ -241,7 +241,7 @@ public class PrematureMaterializationTests
     }
 
     [Fact]
-    public async Task Reports_Redundant_AsEnumerableThenToList()
+    public async Task DoesNotReport_Redundant_AsEnumerableThenToList()
     {
         var test = CommonUsings + """
 
@@ -250,20 +250,16 @@ public class PrematureMaterializationTests
                 void Main()
                 {
                     var db = new DbContext();
-                    var users = {|#0:db.Users.AsEnumerable().ToList()|};
+                    var users = db.Users.AsEnumerable().ToList();
                 }
             }
             """ + MockTypes;
 
-        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.RedundantRule)
-            .WithLocation(0)
-            .WithArguments("ToList", "AsEnumerable");
-
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]
-    public async Task Reports_Redundant_LocalMaterializedThenToList()
+    public async Task DoesNotReport_Redundant_LocalMaterializedThenToList()
     {
         var test = CommonUsings + """
 
@@ -273,16 +269,12 @@ public class PrematureMaterializationTests
                 {
                     var db = new DbContext();
                     var materialized = db.Users.ToList();
-                    var users = {|#0:materialized.ToList()|};
+                    var users = materialized.ToList();
                 }
             }
             """ + MockTypes;
 
-        var expected = VerifyCS.Diagnostic(PrematureMaterializationAnalyzer.RedundantRule)
-            .WithLocation(0)
-            .WithArguments("ToList", "ToList");
-
-        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        await VerifyCS.VerifyAnalyzerAsync(test);
     }
 
     [Fact]

--- a/tests/LinqContraband.Tests/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperTests.cs
@@ -408,6 +408,29 @@ class Program
     }
 
     [Fact]
+    public async Task MaterializedListAggregates_InLoop_AreIgnored()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var users = db.Users.ToList();
+
+        foreach (var id in new[] { 1, 2, 3 })
+        {
+            var single = users.Single(u => u.Id == id);
+            var sum = users.Sum(u => u.Id);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task AccessorsWithoutExecution_AreIgnored()
     {
         var test = Usings + @"

--- a/tests/LinqContraband.Tests/Analyzers/LC008_SyncBlocker/SyncBlockerEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC008_SyncBlocker/SyncBlockerEdgeCasesTests.cs
@@ -200,6 +200,46 @@ class Program
     }
 
     [Fact]
+    public async Task TestInnocent_QueryableSubqueryInsideProjection_ShouldNotTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        var query = db.Users.Select(u => db.Users.FirstOrDefault(inner => inner.Id == u.Id));
+        await Task.Delay(1);
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestCrime_SyncQueryInsideInMemoryProjection_ShouldTrigger()
+    {
+        var test = Usings + @"
+class Program
+{
+    async Task Main(List<User> users)
+    {
+        var db = new MyDbContext();
+        var query = users.Select(u => db.Users.FirstOrDefault(inner => inner.Id == u.Id));
+        await Task.Delay(1);
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC008")
+            .WithSpan(14, 39, 14, 89)
+            .WithArguments("FirstOrDefault", "FirstOrDefaultAsync");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task TestInnocent_SyncLambdaInSyncMethod_NoDiagnostic()
     {
         var test = Usings + @"

--- a/tests/LinqContraband.Tests/Analyzers/LC008_SyncBlocker/SyncBlockerFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC008_SyncBlocker/SyncBlockerFixerTests.cs
@@ -140,11 +140,10 @@ class Program
     }
 
     [Fact]
-    public async Task FixCrime_InsideLetClause_DiagnosticReportedButNoFixApplied()
+    public async Task FixCrime_InsideLetClause_QuerySubqueryDoesNotReport()
     {
-        // 'await' is illegal inside a 'let' clause of a query expression
-        // (CS1995). The analyzer should still flag the sync call, but the
-        // automated code fix must not transform it.
+        // The sync-looking call is part of the query expression and translates
+        // as a SQL subquery instead of blocking the async method directly.
         var test = Usings + @"
 class Program
 {
@@ -164,18 +163,13 @@ class Program
             FixedCode = test
         };
 
-        testObj.ExpectedDiagnostics.Add(new DiagnosticResult("LC008", DiagnosticSeverity.Warning)
-            .WithSpan(15, 29, 15, 71)
-            .WithArguments("ToList", "ToListAsync"));
-
         await testObj.RunAsync();
     }
 
     [Fact]
-    public async Task FixCrime_InsideWhereClause_DiagnosticReportedButNoFixApplied()
+    public async Task FixCrime_InsideWhereClause_QuerySubqueryDoesNotReport()
     {
-        // Sanity-check another disallowed clause position. Awaiting inside a
-        // where clause expression is also illegal in query syntax.
+        // Sanity-check another translated query expression clause position.
         var test = Usings + @"
 class Program
 {
@@ -194,10 +188,6 @@ class Program
             TestCode = test,
             FixedCode = test
         };
-
-        testObj.ExpectedDiagnostics.Add(new DiagnosticResult("LC008", DiagnosticSeverity.Warning)
-            .WithSpan(15, 23, 15, 65)
-            .WithArguments("ToList", "ToListAsync"));
 
         await testObj.RunAsync();
     }

--- a/tests/LinqContraband.Tests/Analyzers/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixerTests.cs
@@ -110,4 +110,37 @@ namespace LinqContraband.Test
 
         await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
     }
+
+    [Fact]
+    public async Task Fixer_ShouldReplaceRepeatedIdenticalClockUseInSameLambda()
+    {
+        var test = Usings + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new List<DateTime>().AsQueryable();
+            var result = query.Where(x => x < {|LC016:DateTime.UtcNow|} && x > DateTime.UtcNow.AddDays(-1)).ToList();
+        }
+    }
+}";
+
+        var fixedCode = Usings + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new List<DateTime>().AsQueryable();
+            var now = DateTime.UtcNow;
+            var result = query.Where(x => x < now && x > now.AddDays(-1)).ToList();
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC016_AvoidDateTimeNow/AvoidDateTimeNowTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC016_AvoidDateTimeNow/AvoidDateTimeNowTests.cs
@@ -127,4 +127,24 @@ class Test
 }";
         await VerifyCS.VerifyAnalyzerAsync(test);
     }
+
+    [Fact]
+    public async Task Diagnostic_RepeatedIdenticalClockUse_InOneQuery_ReportsOnce()
+    {
+        var test = @"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+class User { public DateTime Dob { get; set; } }
+
+class Test
+{
+    void Method(IQueryable<User> users)
+    {
+        var q = users.Where(u => u.Dob < {|LC016:DateTime.UtcNow|} && u.Dob > DateTime.UtcNow.AddDays(-1));
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
 }


### PR DESCRIPTION
## Summary
- Harden LC001, LC002, LC007, LC008, LC016, and LC022 against production false positives
- Change LC022 to an advisory Info diagnostic with modern EF Core wording
- Bump package version and changelog to 5.3.0

## Validation
- `dotnet test LinqContraband.sln --framework net10.0`
- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check`
- `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0`
- `git diff --check`