### PR TITLE
test: harden LC021 noise boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.1] - 2026-04-27
+
+### Changed
+- Hardened `LC021` regression coverage for non-EF lookalikes, local suppression, and fixer query-chain preservation to prevent false-positive and unsafe-fix regressions
+- Clarified `LC021` intentional-bypass documentation and refreshed analyzer-health priority after the noise-boundary coverage
+
 ## [5.3.0] - 2026-04-27
 
 ### Changed

--- a/docs/LC021_AvoidIgnoreQueryFilters.md
+++ b/docs/LC021_AvoidIgnoreQueryFilters.md
@@ -38,6 +38,17 @@ db.Users.IgnoreQueryFilters().Where(x => x.Active);
 db.Users.Where(x => x.Active);
 ```
 
+LC021 intentionally stays quiet for lookalikes that are not the EF Core extension method:
+
+```csharp
+// Custom IQueryable helper outside Microsoft.EntityFrameworkCore is not LC021.
+CustomQueryExtensions.IgnoreQueryFilters(query);
+
+// Instance or IEnumerable helpers with the same name are not LC021.
+auditQuery.IgnoreQueryFilters();
+values.IgnoreQueryFilters();
+```
+
 ## Shipped Behavior
 
 LC021 reports EF Core `IgnoreQueryFilters()` calls so filter bypasses are visible during review. The fixer removes the call when the bypass is accidental; keep the diagnostic suppressed or documented only when the query intentionally crosses tenant, soft-delete, or security-filter boundaries.
@@ -54,4 +65,6 @@ var reviewedUser = db.Users
 #pragma warning restore LC021
 ```
 
-Avoid broad suppressions for this rule. If a query needs to bypass filters regularly, prefer a named repository/service method that documents the business reason and applies explicit replacement filters.
+Prefer a narrow pragma around the reviewed query over disabling LC021 for a whole file or project. If a query needs to bypass filters regularly, prefer a named repository/service method that documents the business reason and applies explicit replacement filters.
+
+The fixer is intentionally narrow: it removes only the `.IgnoreQueryFilters()` call and preserves the rest of the query chain. Do not apply the fixer when the bypass is part of an approved administrative, tenant-review, soft-delete restore, or security-audit workflow.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -48,7 +48,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC018 | FromSqlRaw with interpolated strings | Raw SQL & Security | Warning | 4 | 4 | 4 | 3 | 4 | 5 | Medium | Security-critical and mostly sound, but one test file and limited dedicated fixer coverage leave avoidable risk. |
 | LC019 | Conditional Include expression | Loading & Includes | Warning | 4 | 4 | 4 | 3 | 4 | 4 | Low | Good manual-only rule; would benefit from more filtered Include and non-EF Include edge cases. |
 | LC020 | Untranslatable string comparison overloads | Query Shape & Translation | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Hardened around Queryable expression-lambda proof, direct/nested query-parameter-dependent receivers, captured local/constant negatives, and semantically bound fixer argument removal. |
-| LC021 | IgnoreQueryFilters usage | Raw SQL & Security | Warning | 3 | 2 | 2 | 2 | 3 | 4 | High | Intentional bypasses are common enough that the rule needs suppression/allow-list guidance and stronger negative tests. |
+| LC021 | IgnoreQueryFilters usage | Raw SQL & Security | Warning | 3 | 3 | 3 | 3 | 4 | 4 | Medium | Narrow EF-extension detection, lookalike negatives, local suppression coverage, and fixer-boundary tests now reduce noise risk; remaining work is richer real-world intentional-bypass examples. |
 | LC022 | Nested collection materialization inside projection | Materialization & Projection | Info | 4 | 4 | 3 | 4 | 4 | 3 | Low | Advisory projection-shape rule after production hardening; severity and wording now reflect modern EF Core correlated collection support. |
 | LC023 | Prefer Find/FindAsync for primary key lookups | Materialization & Projection | Info | 3 | 3 | 3 | 2 | 4 | 3 | Medium | Helpful cleanup rule, but key-shape/model-awareness and async fixer cases remain thin. |
 | LC024 | GroupBy with non-translatable projection | Query Shape & Translation | Warning | 4 | 4 | 4 | 3 | 4 | 5 | Medium | High-impact manual rule; add more provider/LINQ-to-Objects boundaries and nested projection negatives. |
@@ -79,9 +79,8 @@ The next improvement batch should focus on rules where user impact and health ga
 
 | Priority | Rules | Work |
 | --- | --- | --- |
-| High | LC021 | Harden Warning rules with weak fixer/test confidence. Add dedicated fixer tests, intentional-use guidance, and tighter diagnostic placement. |
 | High | LC031, LC039, LC040 | Build out high-value heuristic rules. Add source/context aliasing, branch/transaction/workflow negatives, opt-out guidance, and richer docs before raising scores. |
-| Medium | LC010, LC012, LC014, LC015, LC018, LC023, LC024, LC025, LC034, LC035, LC036, LC038, LC043 | Improve targeted tests and docs, especially around safe/unsafe fixer boundaries and intentional-use cases. |
+| Medium | LC010, LC012, LC014, LC015, LC018, LC021, LC023, LC024, LC025, LC034, LC035, LC036, LC038, LC043 | Improve targeted tests and docs, especially around safe/unsafe fixer boundaries and intentional-use cases. |
 | Low | LC002, LC003, LC005, LC006, LC007, LC008, LC009, LC011, LC013, LC016, LC017, LC019, LC020, LC022, LC026, LC027, LC028, LC029, LC030, LC032, LC033, LC037, LC041, LC042, LC044 | Treat as currently acceptable, reference examples, or low-impact tuning rules. |
 
 ## Verification Baseline

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.3.0</Version>
+        <Version>5.3.1</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Hardens LC001, LC002, LC007, LC008, LC016, and LC022 against production false positives from in-memory LINQ, translated query subqueries, and advisory nested collection projections.</PackageReleaseNotes>
+        <PackageReleaseNotes>Hardens LC021 regression coverage and documentation for non-EF lookalikes, local suppression, and conservative IgnoreQueryFilters fixer behavior.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersFixerTests.cs
@@ -83,6 +83,37 @@ namespace LinqContraband.Test
     }
 
     [Fact]
+    public async Task IgnoreQueryFilters_BeforeWhere_ShouldRemoveOnlyBypassCall()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new int[0].AsQueryable();
+            var result = {|LC021:query.IgnoreQueryFilters()|}.Where(x => x > 0).ToList();
+        }
+    }
+}";
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new int[0].AsQueryable();
+            var result = query.Where(x => x > 0).ToList();
+        }
+    }
+}";
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
     public async Task IgnoreQueryFilters_Standalone_ShouldBeRemoved()
     {
         var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"

--- a/tests/LinqContraband.Tests/Analyzers/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersTests.cs
@@ -36,6 +36,18 @@ namespace Microsoft.EntityFrameworkCore
 }
 ";
 
+    private const string NonEfQueryableMock = @"
+using System.Linq;
+
+namespace TestApp
+{
+    public static class QueryableFilterExtensions
+    {
+        public static IQueryable<TEntity> IgnoreQueryFilters<TEntity>(this IQueryable<TEntity> source) => source;
+    }
+}
+";
+
     [Fact]
     public async Task IgnoreQueryFilters_OnIQueryable_ShouldTriggerLC021()
     {
@@ -105,6 +117,46 @@ namespace LinqContraband.Test
         {
             var values = new[] { 1, 2, 3 };
             var result = values.IgnoreQueryFilters();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task IgnoreQueryFilters_NonEfExtensionOnQueryable_ShouldNotTrigger()
+    {
+        var test = @"using System.Linq;" + NonEfQueryableMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new int[0].AsQueryable();
+            var result = TestApp.QueryableFilterExtensions.IgnoreQueryFilters(query).ToList();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task IgnoreQueryFilters_WithLocalPragmaSuppression_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new int[0].AsQueryable();
+#pragma warning disable LC021
+            var result = query.IgnoreQueryFilters().ToList();
+#pragma warning restore LC021
         }
     }
 }";


### PR DESCRIPTION
## Summary
- Add LC021 analyzer tests that lock down non-EF lookalike and local suppression behavior.
- Add fixer coverage proving only `.IgnoreQueryFilters()` is removed while preserving the rest of the query chain.
- Document intentional bypass guidance and update the analyzer health priority now that the noise-boundary coverage exists.

## Verification
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --filter FullyQualifiedName~LC021`
- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check`
- `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0`
- `dotnet test LinqContraband.sln --framework net10.0`
- `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release`
- `git diff --check`
- `codex review --uncommitted`