### PR TITLE
chore: prepare 5.4.1 release — publishes LC039 transaction-using-decl hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.1] - 2026-05-14
+
 ### Changed
 - Hardened `LC039` transaction-scope analysis so repeated saves inside C# 8+ `using` and `await using` local declarations of an EF Core transaction stay quiet, while non-transaction `using` declarations and saves preceding the declaration continue to report
 - Raised the `AnalyzerPerformanceTests` per-test budget from 10s to 30s so cold-JIT CI Linux runners no longer cancel stress-source analyzer runs mid-compilation; local M-class hardware still completes each stress source in well under a second

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.0</Version>
+        <Version>5.4.1</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Broad analyzer-hardening release for LC004, LC010, LC012, LC014, LC015, LC018, LC021, LC023, LC024, LC025, LC031, LC034, LC035, LC036, LC038, LC039, LC040, and LC043, covering false-positive reductions, safer fixer boundaries, EF Core namespace/source checks, and expanded regression coverage.</PackageReleaseNotes>
+        <PackageReleaseNotes>Hardens LC039 transaction-scope suppression for C# 8+ `using` and `await using` local declarations of an EF Core transaction so repeated saves inside the modern declaration form stay quiet, while non-transaction `using` declarations and saves preceding the declaration continue to report.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- Patch-bumps LinqContraband from 5.4.0 to 5.4.1.
- Updates the `PackageReleaseNotes` to describe the LC039 transaction-using-declaration precision tightening that landed in #108.
- Promotes the [Unreleased] CHANGELOG entries to a dated `## [5.4.1] - 2026-05-14` section.

## Impact
This release ships behaviour-only precision tightening — no public diagnostic IDs, severities, or config keys change. The package previously falsely reported LC039 against repeated saves inside the modern C# 8+ `using var tx = db.Database.BeginTransaction();` / `await using var tx = ...` forms; that false positive class is now closed without weakening the existing block-form `using (…) { … }` coverage.

## Validation
- [x] `dotnet build src/LinqContraband/LinqContraband.csproj --configuration Release` — 0 errors
- [x] `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release` — produced `LinqContraband.5.4.1.nupkg`
- [x] Full suite remains 785/785 on net10.0 from #108
- [x] `codex review --uncommitted` — clean, meaningful-improvement judgment confirmed