### PR TITLE
chore: prepare 5.4.2 release — publishes LC010 do-while fixer hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.2] - 2026-05-14
+
 ### Changed
 - Hardened the `LC010` `do`-loop fixer so it no longer offers to move `SaveChanges`/`SaveChangesAsync` out of a `do` loop that is itself nested inside another loop, because the rewrite would leave the save inside the outer loop and still trigger `LC010`; locked in async-`SaveChangesAsync`, multiple-save, non-final-statement, and only-statement edge cases as fixer regression tests
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.1</Version>
+        <Version>5.4.2</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Hardens LC039 transaction-scope suppression for C# 8+ `using` and `await using` local declarations of an EF Core transaction so repeated saves inside the modern declaration form stay quiet, while non-transaction `using` declarations and saves preceding the declaration continue to report.</PackageReleaseNotes>
+        <PackageReleaseNotes>Hardens the LC010 `do`-loop fixer so it no longer offers to move `SaveChanges`/`SaveChangesAsync` out of a `do` loop that is itself nested inside another loop, removing a misleading code action whose rewrite still triggered LC010. Adds locked-in regression coverage for the async, multiple-save, non-final-statement, and only-statement fixer edge cases.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- Patch-bumps LinqContraband from 5.4.1 to 5.4.2.
- Updates `PackageReleaseNotes` to describe the LC010 do-while fixer hardening that landed in #110.
- Promotes the [Unreleased] CHANGELOG entry to a dated `## [5.4.2] - 2026-05-14` section.

## Impact
Behaviour-only fixer precision tightening. No public diagnostic IDs, severities, or config keys change. Removes a misleading code action that left LC010 still triggering after rewrite.

## Validation
- [x] `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release` — produced `LinqContraband.5.4.2.nupkg`
- [x] Full suite remains 790/790 on net10.0 from #110
- [x] `codex review --uncommitted` — clean, meaningful-improvement judgment confirmed