### PR TITLE
chore: prepare 5.4.3 release — publishes LC018 variant coverage lock-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.3] - 2026-05-14
+
 ### Changed
 - Locked in `LC018` provider/API variant coverage with regression tests for the `DbSet<T>` instance call, the `DbContext.Set<T>()` chain, and the static-extension `RelationalQueryableExtensions.FromSqlRaw(...)` form firing on unsafe interpolation while the safe `FromSqlInterpolated` sibling stays quiet on the same receiver shapes
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Locks in LC018 provider/API variant coverage so the security-critical `FromSqlRaw` analyzer's receiver-resolution contract is regression-protected against the `DbSet<T>` instance call, the `DbContext.Set<T>()` chain, and the static-extension `RelationalQueryableExtensions.FromSqlRaw(query, ...)` form, with matching `FromSqlInterpolated` negatives on all three receiver shapes. Tests-only release; no analyzer or fixer behaviour change.</PackageReleaseNotes>
+        <PackageReleaseNotes>Locks in LC018 provider/API variant coverage so the security-critical FromSqlRaw analyzer's receiver-resolution contract is regression-protected against the DbSet&lt;T&gt; instance call, the DbContext.Set&lt;T&gt;() chain, and the static-extension RelationalQueryableExtensions.FromSqlRaw(query, ...) form, with matching FromSqlInterpolated negatives on all three receiver shapes. Tests-only release; no analyzer or fixer behaviour change.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.2</Version>
+        <Version>5.4.3</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Hardens the LC010 `do`-loop fixer so it no longer offers to move `SaveChanges`/`SaveChangesAsync` out of a `do` loop that is itself nested inside another loop, removing a misleading code action whose rewrite still triggered LC010. Adds locked-in regression coverage for the async, multiple-save, non-final-statement, and only-statement fixer edge cases.</PackageReleaseNotes>
+        <PackageReleaseNotes>Locks in LC018 provider/API variant coverage so the security-critical `FromSqlRaw` analyzer's receiver-resolution contract is regression-protected against the `DbSet<T>` instance call, the `DbContext.Set<T>()` chain, and the static-extension `RelationalQueryableExtensions.FromSqlRaw(query, ...)` form, with matching `FromSqlInterpolated` negatives on all three receiver shapes. Tests-only release; no analyzer or fixer behaviour change.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- Tests/docs-only patch release publishing the regression-coverage hardening from #112.
- Same cadence pattern as 5.3.1 ("test: harden LC021 noise boundaries"), where the repo previously shipped a coverage-only patch for a Raw SQL & Security rule.
- Fixed up `PackageReleaseNotes` to escape `<T>` generic brackets so `dotnet pack` accepts the XML (an early commit on this branch had the unescaped form and broke `pack`).

## Impact
No analyzer or fixer behaviour change. LC018's receiver-resolution contract for the DbSet, Set<T>(), and static-extension call shapes is now regression-protected against future drift.

## Validation
- [x] `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release` — produced `LinqContraband.5.4.3.nupkg`
- [x] Full suite remains 796/796 on net10.0 from #112