### PR TITLE
chore: prepare 5.4.4 release — publishes LC034 variant coverage lock-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.4] - 2026-05-14
+
 ### Changed
 - Locked in `LC034` provider/API variant coverage with regression tests for the static-extension `RelationalDatabaseFacadeExtensions.ExecuteSqlRaw(...)` and `ExecuteSqlRawAsync(...)` forms firing on unsafe interpolation while the safe siblings `ExecuteSql`/`ExecuteSqlAsync` stay quiet on the same static-extension shapes
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.3</Version>
+        <Version>5.4.4</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Locks in LC018 provider/API variant coverage so the security-critical FromSqlRaw analyzer's receiver-resolution contract is regression-protected against the DbSet&lt;T&gt; instance call, the DbContext.Set&lt;T&gt;() chain, and the static-extension RelationalQueryableExtensions.FromSqlRaw(query, ...) form, with matching FromSqlInterpolated negatives on all three receiver shapes. Tests-only release; no analyzer or fixer behaviour change.</PackageReleaseNotes>
+        <PackageReleaseNotes>Locks in LC034 provider/API variant coverage so the security-critical ExecuteSqlRaw analyzer's receiver-resolution contract is regression-protected against the static-extension RelationalDatabaseFacadeExtensions.ExecuteSqlRaw and ExecuteSqlRawAsync forms, with matching ExecuteSql and ExecuteSqlAsync negatives on the same static-extension shape. Tests-only release; no analyzer or fixer behaviour change.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
Tests/docs-only patch release publishing #114. Same cadence pattern as 5.4.3 mirroring the LC018 pattern for the sibling ExecuteSqlRaw analyzer. No analyzer or fixer behaviour change. Validated: 800/800 net10.0 tests, dotnet pack succeeds for 5.4.4.