### PR TITLE
chore: prepare 5.4.5 release — publishes LC018 constant-only interpolation precision contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.5] - 2026-05-14
+
 ### Changed
 - Locked in `LC018` constant-only interpolation FP coverage with regression tests for `const` locals, numeric literals, multi-hole constant interpolations, and `nameof(...)` staying quiet, plus boundary positives for mixed-constant-and-runtime interpolation holes and `static readonly` field references still triggering; tightened the LC018 doc to spell out the `IOperation.ConstantValue` safe-shape gate and the upstream-construction LC037 boundary
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -88,9 +88,9 @@ The next improvement batch should focus on rules where user impact and health ga
 
 ## Verification Baseline
 
-Package version: 5.4.4
+Package version: 5.4.5
 
-Base audited commit: 43b7c1a
+Base audited commit: 142ea70
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
@@ -121,6 +121,6 @@ Current local verification:
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC039_NestedSaveChanges` passed with 19 tests.
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC040_MixedTrackingAndNoTracking` passed with 15 tests.
 - `dotnet test LinqContraband.sln --framework net10.0 --no-restore` passed with 806 tests.
-- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.4` produced `LinqContraband.5.4.4.nupkg`.
+- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.5` produced `LinqContraband.5.4.5.nupkg`.
 - `git diff --check` passed.
 - `dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.4</Version>
+        <Version>5.4.5</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Locks in LC034 provider/API variant coverage so the security-critical ExecuteSqlRaw analyzer's receiver-resolution contract is regression-protected against the static-extension RelationalDatabaseFacadeExtensions.ExecuteSqlRaw and ExecuteSqlRawAsync forms, with matching ExecuteSql and ExecuteSqlAsync negatives on the same static-extension shape. Tests-only release; no analyzer or fixer behaviour change.</PackageReleaseNotes>
+        <PackageReleaseNotes>Locks in LC018 constant-only interpolation precision: regression tests for `const` locals, numeric literals, multi-hole all-constant interpolations, and `nameof(...)` staying quiet, plus boundary positives for mixed constant-and-runtime holes and `static readonly` field references still triggering. Tightens the LC018 doc to spell out the IOperation.ConstantValue safe-shape gate and the LC037 upstream-construction boundary. Tests-only release; no analyzer or fixer behaviour change.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

- Bumps package version 5.4.4 → 5.4.5
- Refreshes `PackageReleaseNotes` to describe the LC018 constant-only interpolation precision contract that landed in #118 (commit `142ea70`)
- Closes the `[Unreleased]` CHANGELOG section under `[5.4.5] - 2026-05-14`
- Updates `docs/analyzer-health.md` `Package version`, `Base audited commit` (→ `142ea70`), and the pack-output verification line

## Impact

Tests-only release. No analyzer or fixer behaviour change. Publishing 5.4.5 hands the new precision contract to consumers via the package: six lock-in tests that prove LC018 will not flag safe constant-only interpolation shapes (`const` local, numeric literal, multi-hole constants, `nameof`) while still triggering on mixed constant-and-runtime holes and `static readonly` field references.

## Validation

- `dotnet build LinqContraband.sln --configuration Release` clean (sample-app warnings are intentional rule triggers).
- `dotnet test LinqContraband.sln --framework net10.0` — 806/806 passing.
- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.5` produced `LinqContraband.5.4.5.nupkg`.
- `dotnet run --project tools/RuleCatalogDocGenerator -- --check` — `docs/rule-catalog.md` up to date.
- `dotnet run --project tools/SampleDiagnosticsVerifier -- --frameworks net10.0` — 43 diagnostic paths verified.
- `git diff --cached --check` clean on the staged diff.
- `codex review --uncommitted` clean on staged content; meaningful-improvement judgment positive — "publishes the LC018 constant-only interpolation contract from PR #118 through the package version, release notes, changelog, and analyzer-health verification trail."

## Post-merge

After this merges, a GitHub release for `v5.4.5` triggers `publish.yml` and pushes the package to NuGet.