### PR TITLE
chore: prepare 5.4.6 release — publishes LC006 AsSplitQuery tradeoff docs and reference-sibling lock-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.6] - 2026-05-14
+
 ### Changed
-- Widened the `LC006` doc (~95 lines) to spell out the `AsSplitQuery()` tradeoff (extra roundtrips, per-statement plan cost, snapshot consistency, pagination interaction), when Cartesian is legitimately the right call, and the rule boundary against LC028 (depth) and LC038 (count); added a lock-in test that two sibling reference navigations stay quiet because reference navigations cannot Cartesian-explode
+- Widened the `LC006` doc (~95 lines) to spell out the `AsSplitQuery()` tradeoff (extra roundtrips, per-statement plan cost, snapshot consistency, transaction scope), when Cartesian is legitimately the right call, and the rule boundary against LC028 (depth) and LC038 (count); added a lock-in test that two sibling reference navigations stay quiet because reference navigations cannot Cartesian-explode
 
 ## [5.4.5] - 2026-05-14
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -88,9 +88,9 @@ The next improvement batch should focus on rules where user impact and health ga
 
 ## Verification Baseline
 
-Package version: 5.4.5
+Package version: 5.4.6
 
-Base audited commit: 142ea70
+Base audited commit: bdac6b2
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
@@ -121,6 +121,6 @@ Current local verification:
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC039_NestedSaveChanges` passed with 19 tests.
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC040_MixedTrackingAndNoTracking` passed with 15 tests.
 - `dotnet test LinqContraband.sln --framework net10.0 --no-restore` passed with 807 tests.
-- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.5` produced `LinqContraband.5.4.5.nupkg`.
+- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.6` produced `LinqContraband.5.4.6.nupkg`.
 - `git diff --check` passed.
 - `dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.5</Version>
+        <Version>5.4.6</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Locks in LC018 constant-only interpolation precision: regression tests for `const` locals, numeric literals, multi-hole all-constant interpolations, and `nameof(...)` staying quiet, plus boundary positives for mixed constant-and-runtime holes and `static readonly` field references still triggering. Tightens the LC018 doc to spell out the IOperation.ConstantValue safe-shape gate and the LC037 upstream-construction boundary. Tests-only release; no analyzer or fixer behaviour change.</PackageReleaseNotes>
+        <PackageReleaseNotes>Widens the LC006 doc (~95 lines) to spell out the AsSplitQuery() tradeoff (extra roundtrips, per-statement plan cost, snapshot consistency, transaction scope), when Cartesian is legitimately the right call, and the rule boundary against LC028 (depth) and LC038 (count). Adds a lock-in test that two sibling reference navigations stay quiet because reference navigations cannot Cartesian-inflate. Tests-only release; no analyzer or fixer behaviour change.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

- Bumps package version 5.4.5 → 5.4.6
- Refreshes `PackageReleaseNotes` with the LC006 doc widening + reference-sibling lock-in summary
- Closes the `[Unreleased]` CHANGELOG section under `[5.4.6] - 2026-05-14`
- Updates `docs/analyzer-health.md` `Package version`, `Base audited commit` (→ `bdac6b2`), and pack-output verification line

## Impact

Tests-only release. No analyzer or fixer behaviour change. Publishing 5.4.6 ships the LC006 hardening from #120 to consumers via the package: a ~95-line doc that maps the `AsSplitQuery()` tradeoff and the rule boundary against LC028/LC038, plus a lock-in test that sibling reference navigations stay quiet because they cannot Cartesian-inflate.

## Validation

- `dotnet build LinqContraband.sln --configuration Release` clean.
- `dotnet test LinqContraband.sln --framework net10.0` — 807/807 passing.
- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.6` produced `LinqContraband.5.4.6.nupkg`.
- `git diff --cached --check` clean on the staged diff.
- `codex review --uncommitted` clean on staged content; meaningful-improvement judgment positive — "package version, release notes, changelog, and analyzer-health baseline all point at the doc/test boundary work that narrows user understanding of when LC006 should and should not fire."

## Post-merge

GitHub release for `v5.4.6` triggers `publish.yml` and pushes the package to NuGet.