### PR TITLE
chore: prepare 5.4.7 release — publishes LC015 composite-key fixer hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.7] - 2026-05-14
+
 ### Changed
-- Hardened the `LC015` code fix so it no longer registers on composite-keyed entities. `TryFindPrimaryKey` returns the first `[Key]`-annotated property and never sees siblings, so without the new composite-key gate the fixer would offer a partial-key `OrderBy(x => x.<firstKey>)` that does not guarantee deterministic pagination — the very behaviour LC015 exists to surface. Added a regression test for the two-`[Key]`-property shape and widened the LC015 doc to enumerate when the fixer registers, when it does not, and how to pick a stable key in the no-fix case (composite keys, time-series tiebreakers, floating-point/text-collation anti-patterns)
+- Hardened the `LC015` code fix so it no longer registers on composite-keyed entities, including the EF Core 7+ class-level `[PrimaryKey(...)]` attribute form. `TryFindPrimaryKey` returns the first `[Key]`-annotated property and never sees siblings, so without the new composite-key gate the fixer would offer a partial-key `OrderBy(x => x.<firstKey>)` that does not guarantee deterministic pagination — the very behaviour LC015 exists to surface. Added regression tests for the two-`[Key]`-property shape and the `[PrimaryKey]` class-level shape, and widened the LC015 doc to enumerate when the fixer registers, when it does not, and how to pick a stable key in the no-fix case (composite keys, time-series tiebreakers, floating-point/text-collation anti-patterns)
 
 ## [5.4.6] - 2026-05-14
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -88,9 +88,9 @@ The next improvement batch should focus on rules where user impact and health ga
 
 ## Verification Baseline
 
-Package version: 5.4.6
+Package version: 5.4.7
 
-Base audited commit: bdac6b2
+Base audited commit: 62ba410
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
@@ -121,6 +121,6 @@ Current local verification:
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC039_NestedSaveChanges` passed with 19 tests.
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC040_MixedTrackingAndNoTracking` passed with 15 tests.
 - `dotnet test LinqContraband.sln --framework net10.0 --no-restore` passed with 809 tests.
-- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.6` produced `LinqContraband.5.4.6.nupkg`.
+- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.7` produced `LinqContraband.5.4.7.nupkg`.
 - `git diff --check` passed.
 - `dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.6</Version>
+        <Version>5.4.7</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Widens the LC006 doc (~95 lines) to spell out the AsSplitQuery() tradeoff (extra roundtrips, per-statement plan cost, snapshot consistency, transaction scope), when Cartesian is legitimately the right call, and the rule boundary against LC028 (depth) and LC038 (count). Adds a lock-in test that two sibling reference navigations stay quiet because reference navigations cannot Cartesian-inflate. Tests-only release; no analyzer or fixer behaviour change.</PackageReleaseNotes>
+        <PackageReleaseNotes>Hardens the LC015 fixer so it no longer registers on composite-keyed entities. Previously the fixer would silently offer a partial-key OrderBy on entities with multiple [Key] property attributes or an EF Core 7+ class-level [PrimaryKey(...)] declaring two or more named parts — a partial-key sort does not guarantee deterministic pagination, which is the exact failure LC015 exists to surface. Single-key cases ([Key] on one property, Id convention, EntityTypeId convention) continue to register unchanged. Widens the LC015 doc to enumerate exactly when the fixer registers, when it does not, and how to choose a stable key in the no-fix case (composite keys, time-series tiebreakers, floating-point and case-insensitive collation anti-patterns). The 2026-05-14 fine-comb re-audit High shortlist is now empty.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

- Bumps package version 5.4.6 → 5.4.7
- Refreshes `PackageReleaseNotes` with the LC015 composite-key hardening summary
- Closes the `[Unreleased]` CHANGELOG section under `[5.4.7] - 2026-05-14`
- Updates `docs/analyzer-health.md` `Package version`, `Base audited commit` (→ `62ba410`), and pack-output verification line

## Impact

5.4.7 publishes the LC015 hardening from #122. The fixer now refuses to register on composite-keyed entities — both property-level multi-`[Key]` and the EF Core 7+ class-level `[PrimaryKey(nameof(A), nameof(B), ...)]` — avoiding the unsafe partial-key `OrderBy(x => x.<firstKey>)` that the previous fixer would silently offer. Single-key cases continue to register unchanged.

This closes the third and final High target from the 2026-05-14 fine-comb re-audit (LC018 → 5.4.5, LC006 → 5.4.6, LC015 → 5.4.7). The Planning Shortlist `High` row is now `None`.

## Validation

- `dotnet build LinqContraband.sln --configuration Release` clean.
- `dotnet test LinqContraband.sln --framework net10.0` — 809/809 passing.
- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.7` produced `LinqContraband.5.4.7.nupkg`.
- `codex review --uncommitted` clean on staged content; meaningful-improvement judgment positive — "publishes PR #122's actual LC015 behaviour change from commit `62ba410`: the fixer now refuses composite-key entities... avoiding an unsafe partial-key `OrderBy` while leaving valid single-key fixes unchanged."

## Post-merge

GitHub release for `v5.4.7` triggers `publish.yml` and pushes the package to NuGet.