### PR TITLE
chore: prepare 5.4.8 release — LC012 async-aware ExecuteDelete fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.8] - 2026-05-28
+
 ### Changed
 - Made the `LC012` code fix async-aware: inside an `async` method, lambda, or local function it now rewrites `RemoveRange(query)` to `await query.ExecuteDeleteAsync()` instead of the synchronous `query.ExecuteDelete()`, which would have injected a blocking sync-over-async database call — the exact smell `LC008` flags. The synchronous rewrite is unchanged when the nearest enclosing function is synchronous (including a sync local function nested inside an async method), and in an async context where no `ExecuteDeleteAsync` overload is available the fix is withheld rather than emit a blocking call. Added regression tests for the async-await rewrite, the sync-local-function-inside-async boundary, and the no-async-overload refusal, and documented the code-fix behaviour and `ExecuteDelete` safety contract in the LC012 doc and README
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -88,9 +88,9 @@ The next improvement batch should focus on rules where user impact and health ga
 
 ## Verification Baseline
 
-Package version: 5.4.7
+Package version: 5.4.8
 
-Base audited commit: 62ba410
+Base audited commit: 17bcf3c
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
@@ -121,6 +121,6 @@ Current local verification:
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC039_NestedSaveChanges` passed with 19 tests.
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC040_MixedTrackingAndNoTracking` passed with 15 tests.
 - `dotnet test LinqContraband.sln --framework net10.0 --no-restore` passed with 812 tests.
-- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.7` produced `LinqContraband.5.4.7.nupkg`.
+- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.8` produced `LinqContraband.5.4.8.nupkg`.
 - `git diff --check` passed.
 - `dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.7</Version>
+        <Version>5.4.8</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Hardens the LC015 fixer so it no longer registers on composite-keyed entities. Previously the fixer would silently offer a partial-key OrderBy on entities with multiple [Key] property attributes or an EF Core 7+ class-level [PrimaryKey(...)] declaring two or more named parts — a partial-key sort does not guarantee deterministic pagination, which is the exact failure LC015 exists to surface. Single-key cases ([Key] on one property, Id convention, EntityTypeId convention) continue to register unchanged. Widens the LC015 doc to enumerate exactly when the fixer registers, when it does not, and how to choose a stable key in the no-fix case (composite keys, time-series tiebreakers, floating-point and case-insensitive collation anti-patterns). The 2026-05-14 fine-comb re-audit High shortlist is now empty.</PackageReleaseNotes>
+        <PackageReleaseNotes>Hardens the LC012 code fix so it no longer injects a sync-over-async call. Previously the fixer rewrote RemoveRange(query) to a synchronous query.ExecuteDelete() even inside async methods — a blocking sync-over-async database call, the exact smell LC008 flags. The fixer now chooses the rewrite by the nearest enclosing function: async contexts get await query.ExecuteDeleteAsync(), synchronous contexts keep query.ExecuteDelete(), and an async context with no ExecuteDeleteAsync overload available declines the fix rather than emit a blocking call. A synchronous local function nested inside an async method correctly stays sync because await would be illegal there. Documents the code-fix behaviour and the ExecuteDelete safety contract (change-tracking bypass, cascade/interceptor loss, unit-of-work timing) in the LC012 doc and README.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

Release prep for **5.4.8**, which publishes the LC012 code-fix hardening merged in #124 (`17bcf3c`).

5.4.8 ships an async-aware LC012 code fix: it no longer rewrites `RemoveRange(query)` to a synchronous `query.ExecuteDelete()` inside async methods (a blocking sync-over-async call — the smell `LC008` flags). It now emits `await query.ExecuteDeleteAsync()` in async contexts, keeps the sync rewrite in sync contexts (including a sync local function nested in an async method), and declines when an async context has no `ExecuteDeleteAsync` overload.

## Impact

- Patch bump (behaviour-only code-fix tightening; no new diagnostic IDs, severities, or config keys).
- `<Version>` 5.4.7 -> 5.4.8 and `<PackageReleaseNotes>` updated.
- `CHANGELOG.md` `[Unreleased]` promoted to `## [5.4.8] - 2026-05-28`.
- `docs/analyzer-health.md` verification baseline aligned (Package version 5.4.8, base audited commit `17bcf3c`, pack-output line).

## Validation

- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release` produced `LinqContraband.5.4.8.nupkg`.
- LC012 behaviour change already validated and Codex-reviewed in #124 (812 tests green, sample diagnostics + rule-catalog verifiers pass).