### PR TITLE
chore: prepare 5.4.9 release — LC009 Set<T>() AsNoTracking source detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.9] - 2026-05-28
+
 ### Changed
 - Taught `LC009` to recognise the generic-repository `context.Set<T>()` read path as an EF source. The chain walker previously stepped past a `DbSet`-returning invocation to the `DbContext` receiver, so `db.Set<User>().ToList()` (and `Set<T>().Where(...).ToList()`) never got the AsNoTracking suggestion — a false negative on one of the most common EF read patterns. The code fix now finds the EF source by its semantic type instead of by syntax, so `AsNoTracking()` is placed on the `Set<User>()` call rather than mis-placed onto the `DbContext` (which would not compile). Added analyzer regression tests for the `Set<T>()` source (with and without `Where`) plus guardrails that `Set<T>()` with `AsNoTracking()`/`Select(...)` stays quiet, a fixer test for the `Set<T>()` placement, and expanded the LC009 doc and README to cover the recognised sources and when `AsNoTracking()` is unsafe (identity resolution, deferred/cross-method mutation, re-attach)
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -88,9 +88,9 @@ The next improvement batch should focus on rules where user impact and health ga
 
 ## Verification Baseline
 
-Package version: 5.4.8
+Package version: 5.4.9
 
-Base audited commit: 17bcf3c
+Base audited commit: 39b06ff
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
@@ -122,6 +122,6 @@ Current local verification:
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC039_NestedSaveChanges` passed with 19 tests.
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC040_MixedTrackingAndNoTracking` passed with 15 tests.
 - `dotnet test LinqContraband.sln --framework net10.0 --no-restore` passed with 817 tests.
-- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.8` produced `LinqContraband.5.4.8.nupkg`.
+- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.9` produced `LinqContraband.5.4.9.nupkg`.
 - `git diff --check` passed.
 - `dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.8</Version>
+        <Version>5.4.9</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Hardens the LC012 code fix so it no longer injects a sync-over-async call. Previously the fixer rewrote RemoveRange(query) to a synchronous query.ExecuteDelete() even inside async methods — a blocking sync-over-async database call, the exact smell LC008 flags. The fixer now chooses the rewrite by the nearest enclosing function: async contexts get await query.ExecuteDeleteAsync(), synchronous contexts keep query.ExecuteDelete(), and an async context with no ExecuteDeleteAsync overload available declines the fix rather than emit a blocking call. A synchronous local function nested inside an async method correctly stays sync because await would be illegal there. Documents the code-fix behaviour and the ExecuteDelete safety contract (change-tracking bypass, cascade/interceptor loss, unit-of-work timing) in the LC012 doc and README.</PackageReleaseNotes>
+        <PackageReleaseNotes>Teaches LC009 to recognise the generic-repository context.Set&lt;T&gt;() read path as an EF source. Previously the chain walker stepped past the DbSet-returning invocation to the DbContext receiver, so db.Set&lt;User&gt;().ToList() (and Set&lt;T&gt;().Where(...).ToList()) never got the AsNoTracking suggestion — a false negative on one of the most common EF read patterns. The code fix now resolves the EF source by semantic type, so AsNoTracking() is placed on the Set&lt;User&gt;() call rather than mis-placed onto the DbContext (which would not compile). Expands the LC009 doc and README to enumerate the recognised sources, the quiet shapes, and when AsNoTracking is unsafe (identity resolution, deferred/cross-method mutation, re-attach).</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

Release prep for **5.4.9**, which publishes the LC009 hardening merged in #126 (`39b06ff`).

5.4.9 teaches LC009 to recognise the generic-repository `context.Set<T>()` read path as an EF source (previously a false negative — the chain walker stepped past the `DbSet`-returning invocation to the `DbContext`), and makes the code fix resolve the EF source by semantic type so `AsNoTracking()` is placed on the `Set<User>()` call rather than mis-placed onto the `DbContext`.

## Impact

- Patch bump (precision: closes a false negative + a latent invalid-code fix; no new diagnostic IDs, severities, or config keys).
- `<Version>` 5.4.8 -> 5.4.9 and `<PackageReleaseNotes>` updated.
- `CHANGELOG.md` `[Unreleased]` promoted to `## [5.4.9] - 2026-05-28`.
- `docs/analyzer-health.md` verification baseline aligned (Package version 5.4.9, base audited commit `39b06ff`, pack-output line).

## Validation

- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release` produced `LinqContraband.5.4.9.nupkg`.
- LC009 behaviour change already validated and Codex-reviewed in #126 (817 tests green, sample diagnostics + rule-catalog verifiers pass).