### PR TITLE
chore: prepare 5.4.10 release — LC025 constructed-projection false-positive fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.10] - 2026-05-28
+
 ### Fixed
 - Stopped `LC025` from firing on entities that come from a `Select` projecting to a newly-constructed object (e.g. `AsNoTracking().Select(u => new User { ... }).First()` followed by `Update`/`Remove`). EF Core never change-tracks instances constructed in a projection, so they are untracked regardless of `AsNoTracking()` — the anti-pattern does not apply and the suggested "remove `AsNoTracking()`" fix would not have helped. Only the outermost projection (the one that determines the materialized result) is considered, so identity and navigation projections (`Select(u => u)`, `Select(u => u.Manager)`) and a constructed wrapper that is later unwrapped back to the entity (`Select(u => new { E = u }).Select(x => x.E)`) all continue to report. Added regression tests for the constructed-projection false positive, the identity-Select guardrail, and the wrap-then-unwrap shape
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -88,9 +88,9 @@ The next improvement batch should focus on rules where user impact and health ga
 
 ## Verification Baseline
 
-Package version: 5.4.9
+Package version: 5.4.10
 
-Base audited commit: 39b06ff
+Base audited commit: eab9446
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
@@ -123,6 +123,6 @@ Current local verification:
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC039_NestedSaveChanges` passed with 19 tests.
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC040_MixedTrackingAndNoTracking` passed with 15 tests.
 - `dotnet test LinqContraband.sln --framework net10.0 --no-restore` passed with 820 tests.
-- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.9` produced `LinqContraband.5.4.9.nupkg`.
+- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.10` produced `LinqContraband.5.4.10.nupkg`.
 - `git diff --check` passed.
 - `dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.9</Version>
+        <Version>5.4.10</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Teaches LC009 to recognise the generic-repository context.Set&lt;T&gt;() read path as an EF source. Previously the chain walker stepped past the DbSet-returning invocation to the DbContext receiver, so db.Set&lt;User&gt;().ToList() (and Set&lt;T&gt;().Where(...).ToList()) never got the AsNoTracking suggestion — a false negative on one of the most common EF read patterns. The code fix now resolves the EF source by semantic type, so AsNoTracking() is placed on the Set&lt;User&gt;() call rather than mis-placed onto the DbContext (which would not compile). Expands the LC009 doc and README to enumerate the recognised sources, the quiet shapes, and when AsNoTracking is unsafe (identity resolution, deferred/cross-method mutation, re-attach).</PackageReleaseNotes>
+        <PackageReleaseNotes>Fixes an LC025 false positive: the rule no longer flags a subsequent Update/Remove when the entity came from a Select projecting to a newly-constructed object (e.g. AsNoTracking().Select(u =&gt; new User { ... }).First()). EF Core never change-tracks instances constructed in a projection, so they are untracked regardless of AsNoTracking — the anti-pattern does not apply and the suggested "remove AsNoTracking()" fix would not have helped. Only the outermost projection is considered, so identity and navigation projections (Select(u =&gt; u), Select(u =&gt; u.Manager)) and a constructed wrapper later unwrapped back to the entity all continue to report.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

Release prep for **5.4.10**, which publishes the LC025 false-positive fix merged in #128 (`eab9446`).

5.4.10 stops LC025 from flagging `Update`/`Remove` on an entity that came from a `Select` projecting to a newly-constructed object (`AsNoTracking().Select(u => new User { ... }).First()`) — EF never change-tracks constructed instances, so `AsNoTracking()` is irrelevant. Only the outermost projection is considered, so identity/navigation projections and wrap-then-unwrap chains still report.

## Impact

- Patch bump (precision: closes a false positive; no new diagnostic IDs, severities, or config keys).
- `<Version>` 5.4.9 -> 5.4.10 and `<PackageReleaseNotes>` updated.
- `CHANGELOG.md` `[Unreleased]` promoted to `## [5.4.10] - 2026-05-28`.
- `docs/analyzer-health.md` verification baseline aligned (Package version 5.4.10, base audited commit `eab9446`, pack-output line).

## Validation

- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release` produced `LinqContraband.5.4.10.nupkg`.
- LC025 behaviour change already validated and Codex-reviewed in #128 (820 tests green, sample diagnostics + rule-catalog verifiers pass).