### PR TITLE
chore: prepare 5.4.11 release — LC031 Chunk false-negative fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.4.11] - 2026-05-28
 
 ### Fixed
-- Stopped `LC031` from treating `Chunk` as a bounding operator. There is no `Queryable.Chunk`, so `db.Users.Chunk(1000).ToList()` binds to `Enumerable.Chunk` and materializes the entire table before partitioning — the `size` argument bounds the chunk size, not the rows fetched. `Chunk` was whitelisted alongside `Take`/`First`, suppressing the diagnostic on exactly the unbounded load LC031 exists to catch (a false negative). Real bounding operators before the chunk (e.g. `Take(100).Chunk(10)`) still suppress correctly. Added a false-negative regression test plus a `Take`-then-`Chunk` guardrail, and updated the LC015 sample expectations (its `users.Chunk(5).ToList()` now also reports LC031, as it should)
+- Stopped `LC031` from treating `Chunk` as a bounding operator. There is no `Queryable.Chunk`, so `db.Users.Chunk(1000).ToList()` binds to `Enumerable.Chunk` and materializes the entire table before partitioning — the `size` argument bounds the chunk size, not the rows fetched. `Chunk` was whitelisted alongside `Take`/`First`, suppressing the diagnostic on exactly the unbounded load LC031 exists to catch (a false negative). Real bounding operators before the chunk (e.g. `Take(100).Chunk(10)`) still suppress correctly. Added a false-negative regression test plus a `Take`-then-`Chunk` guardrail, and refreshed the affected sample's expected diagnostics (a `users.Chunk(5).ToList()` sample now also reports `LC031`, as it should)
 
 ## [5.4.10] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.11] - 2026-05-28
+
 ### Fixed
 - Stopped `LC031` from treating `Chunk` as a bounding operator. There is no `Queryable.Chunk`, so `db.Users.Chunk(1000).ToList()` binds to `Enumerable.Chunk` and materializes the entire table before partitioning — the `size` argument bounds the chunk size, not the rows fetched. `Chunk` was whitelisted alongside `Take`/`First`, suppressing the diagnostic on exactly the unbounded load LC031 exists to catch (a false negative). Real bounding operators before the chunk (e.g. `Take(100).Chunk(10)`) still suppress correctly. Added a false-negative regression test plus a `Take`-then-`Chunk` guardrail, and updated the LC015 sample expectations (its `users.Chunk(5).ToList()` now also reports LC031, as it should)
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -88,9 +88,9 @@ The next improvement batch should focus on rules where user impact and health ga
 
 ## Verification Baseline
 
-Package version: 5.4.10
+Package version: 5.4.11
 
-Base audited commit: eab9446
+Base audited commit: a2bbefd
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
@@ -124,6 +124,6 @@ Current local verification:
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC040_MixedTrackingAndNoTracking` passed with 15 tests.
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC031_UnboundedQueryMaterialization` passed with 17 tests.
 - `dotnet test LinqContraband.sln --framework net10.0 --no-restore` passed with 822 tests.
-- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.10` produced `LinqContraband.5.4.10.nupkg`.
+- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.11` produced `LinqContraband.5.4.11.nupkg`.
 - `git diff --check` passed.
 - `dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.10</Version>
+        <Version>5.4.11</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Fixes an LC025 false positive: the rule no longer flags a subsequent Update/Remove when the entity came from a Select projecting to a newly-constructed object (e.g. AsNoTracking().Select(u =&gt; new User { ... }).First()). EF Core never change-tracks instances constructed in a projection, so they are untracked regardless of AsNoTracking — the anti-pattern does not apply and the suggested "remove AsNoTracking()" fix would not have helped. Only the outermost projection is considered, so identity and navigation projections (Select(u =&gt; u), Select(u =&gt; u.Manager)) and a constructed wrapper later unwrapped back to the entity all continue to report.</PackageReleaseNotes>
+        <PackageReleaseNotes>Fixes an LC031 false negative: Chunk is no longer treated as a bounding operator. There is no Queryable.Chunk, so db.Users.Chunk(1000).ToList() binds to Enumerable.Chunk and materializes the entire table before partitioning — the size argument bounds the chunk size, not the rows fetched. Chunk was whitelisted alongside Take/First, suppressing the diagnostic on exactly the unbounded load LC031 exists to catch. A real bounding operator before the chunk (e.g. Take(100).Chunk(10)) still suppresses correctly.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

Release prep for **5.4.11**, which publishes the LC031 false-negative fix merged in #130 (`a2bbefd`).

5.4.11 stops LC031 from treating `Chunk` as a bounding operator. `db.Users.Chunk(1000).ToList()` binds to `Enumerable.Chunk` and materializes the entire table (Chunk bounds chunk size, not rows fetched), so it is now correctly flagged. A real bound before the chunk (`Take(100).Chunk(10)`) still suppresses.

## Impact

- Patch bump (precision: closes a false negative; no new diagnostic IDs, severities, or config keys).
- `<Version>` 5.4.10 -> 5.4.11 and `<PackageReleaseNotes>` updated.
- `CHANGELOG.md` `[Unreleased]` promoted to `## [5.4.11] - 2026-05-28`.
- `docs/analyzer-health.md` verification baseline aligned (Package version 5.4.11, base audited commit `a2bbefd`, pack-output line).

## Validation

- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release` produced `LinqContraband.5.4.11.nupkg`.
- LC031 behaviour change already validated and Codex-reviewed in #130 (822 tests green, sample diagnostics + rule-catalog verifiers pass).