### PR TITLE
chore: prepare 5.4.12 release — LC014 method-argument case-conversion fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.12] - 2026-05-28
+
 ### Fixed
 - Taught `LC014` to detect case conversion on a value that depends on the query parameter through a method's **arguments**, not only its receiver. Previously `ReceiverDependsOnParameter` only followed an invocation's instance, so `db.Users.Where(u => string.Concat(u.First, u.Last).ToLower() == "x")` was missed — the `string.Concat(...)` is a static call with no instance, and its column-derived arguments were never inspected (a false negative; the `ToLower` still defeats sargability). The walk now also checks invocation arguments. Constant-only values such as `string.Concat("a", "b").ToLower()` stay quiet because no argument depends on the parameter. Added a positive regression test and a constant-argument guardrail
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -88,9 +88,9 @@ The next improvement batch should focus on rules where user impact and health ga
 
 ## Verification Baseline
 
-Package version: 5.4.11
+Package version: 5.4.12
 
-Base audited commit: a2bbefd
+Base audited commit: b783962
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
@@ -125,6 +125,6 @@ Current local verification:
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC040_MixedTrackingAndNoTracking` passed with 15 tests.
 - `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --filter FullyQualifiedName~LC031_UnboundedQueryMaterialization` passed with 17 tests.
 - `dotnet test LinqContraband.sln --framework net10.0 --no-restore` passed with 825 tests.
-- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.11` produced `LinqContraband.5.4.11.nupkg`.
+- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --output /tmp/linqcontraband-5.4.12` produced `LinqContraband.5.4.12.nupkg`.
 - `git diff --check` passed.
 - `dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so full multi-target verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.11</Version>
+        <Version>5.4.12</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Fixes an LC031 false negative: Chunk is no longer treated as a bounding operator. There is no Queryable.Chunk, so db.Users.Chunk(1000).ToList() binds to Enumerable.Chunk and materializes the entire table before partitioning — the size argument bounds the chunk size, not the rows fetched. Chunk was whitelisted alongside Take/First, suppressing the diagnostic on exactly the unbounded load LC031 exists to catch. A real bounding operator before the chunk (e.g. Take(100).Chunk(10)) still suppresses correctly.</PackageReleaseNotes>
+        <PackageReleaseNotes>Fixes an LC014 false negative: a string case conversion (ToLower/ToUpper) on a value that depends on the query parameter through a method's ARGUMENTS — not only its receiver — is now detected. Previously only an invocation's instance was followed, so db.Users.Where(u =&gt; string.Concat(u.First, u.Last).ToLower() == "x") was missed because string.Concat is static and its column-derived arguments were never inspected. The dependence walk now also checks invocation arguments and descends into the array that wraps params arguments (string.Join, string.Format). Constant-only values such as string.Concat("a", "b").ToLower() stay quiet.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

Release prep for **5.4.12**, which publishes the LC014 false-negative fix merged in #132 (`b783962`).

5.4.12 makes LC014 detect a case conversion on a value whose method **arguments** are column-derived (`string.Concat(u.A, u.B).ToLower()`, plus `string.Join`/`string.Format` params shapes), not just receiver-derived cases. Constant-only values stay quiet.

## Impact

- Patch bump (precision: closes a false negative; no new diagnostic IDs, severities, or config keys).
- `<Version>` 5.4.11 -> 5.4.12 and `<PackageReleaseNotes>` updated.
- `CHANGELOG.md` `[Unreleased]` promoted to `## [5.4.12] - 2026-05-28`.
- `docs/analyzer-health.md` verification baseline aligned (Package version 5.4.12, base audited commit `b783962`, pack-output line).

## Validation

- `dotnet pack` produced `LinqContraband.5.4.12.nupkg`; `RuleQualityContractTests` pass locally (PackageReleaseNotes ↔ CHANGELOG rule-ids aligned).
- LC014 behaviour change already validated and Codex-reviewed in #132 (825 tests green, sample diagnostics + rule-catalog verifiers pass).