### PR TITLE
chore: prepare 5.5.0 release — LC032 ExecuteUpdate auto-fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.0] - 2026-05-29
+
+### Added
+- Added an automatic code fixer for `LC032` (previously report-only). It rewrites a *proven* tracked bulk-update loop — a `foreach` over an EF query that assigns only scalar properties on the iteration variable, immediately followed by `SaveChanges`/`SaveChangesAsync` on the same context — into a single set-based `ExecuteUpdate`/`ExecuteUpdateAsync` call, collapsing N materialized-and-tracked rows and N `UPDATE` statements into one server-side `UPDATE`. The fixer builds one `SetProperty` per assigned property by reusing the loop variable name as the lambda parameter (so each assignment's target and value transplant verbatim) and prepends a `// Warning: ExecuteUpdate runs immediately and bypasses change tracking and entity callbacks.` comment. It mirrors the bulk-delete (`ExecuteDelete`) fixer's safety model: the trailing `SaveChanges` is left in place (it commits nothing for the converted rows but still flushes unrelated pending changes), inside an `async` context it prefers the awaited `ExecuteUpdateAsync` overload and carries the cancellation token from the awaited `SaveChangesAsync(token)` onto it, inline materializers (`ToList`/`ToArray`/`ToListAsync`/`ToArrayAsync`, including the awaited form) are stripped, and duplicate property writes collapse last-write-wins. The fixer declines — leaving the advisory diagnostic to a manual rewrite — for local-variable sources (which would orphan the local or produce a type-invalid receiver), an observed `SaveChanges` result (`return`/assignment, which the rewrite would change), a value that reads a property written earlier in the same iteration (`ExecuteUpdate` evaluates every value against the original row), and an async context with no suitable `ExecuteUpdateAsync` overload, so it never emits a blocking, uncompilable, or behaviour-changing rewrite. Added 23 fixer tests across the rewrite and decline shapes (incl. token propagation, top-level programs, and write-then-read dependencies)
+
 ## [5.4.13] - 2026-05-29
 
 ### Fixed

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.4.13</Version>
+        <Version>5.5.0</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Precision and security hardening from a deep adversarial rescan. LC005: fixed an analyzer crash (AD0001) on query-comprehension 'orderby a orderby b' clauses; the reset is now reported there. LC014: fixed a 5.4.12 false positive where a column reaching a numeric/positional argument (e.g. PadRight/Substring length) wrongly flagged a case conversion on a constant receiver. LC002: stopped an unsafe code fix that silently dropped de-duplication when a set materializer (ToHashSet) was the source of a second materializer. LC006: fixed a false positive that flagged an effective AsSplitQuery() hoisted into a local variable. LC024: stopped three false positives on EF Core 9 translatable group aggregates (g.Any(), filtered Count, projected Sum). LC015: stopped the code fix from offering a partial-key OrderBy on a [Keyless] entity. LC018 (security): now detects SqlQueryRaw raw SQL on the DbContext.Database facade, an injection sink previously invisible to the rule.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC032 now ships an automatic code fixer. It rewrites a tracked bulk-update loop (a foreach over an EF query that assigns scalar properties, immediately followed by SaveChanges) into a single set-based ExecuteUpdate/ExecuteUpdateAsync call, collapsing N tracked updates and N UPDATE statements into one server-side UPDATE. The fix is conservative: it leaves the trailing SaveChanges in place with a warning comment, prefers the awaited ExecuteUpdateAsync overload and carries the cancellation token onto it, strips inline materializers (including awaited ToListAsync), and collapses duplicate writes last-write-wins. It declines local-variable sources, an observed SaveChanges result, a value that reads a property written earlier in the same loop, and async contexts without a suitable ExecuteUpdateAsync overload, so it never emits a blocking, uncompilable, or behaviour-changing rewrite.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
Release-prep PR for **5.5.0** (follows the merged feature PR #142).

**Minor bump** (5.4.13 → 5.5.0): adding an auto-fixer to a rule that had none is new, backward-compatible functionality — no new diagnostics, no breaking changes — so semver minor rather than patch.

- `<Version>` → `5.5.0`
- `<PackageReleaseNotes>` updated (references `LC032`)
- `CHANGELOG.md` `## [5.5.0]` entry under `### Added` (references `LC032`)

`RuleQualityContractTests` (release-notes ↔ CHANGELOG LC-id parity) passes. Publishing the GitHub Release after merge triggers `publish.yml` → pack → `dotnet nuget push`.