### PR TITLE
fix: preserve document line endings in four code fixers (5.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.1] - 2026-06-03
+
+### Fixed
+- Stopped four code fixers from injecting a lone `LF` line into a `CRLF` file. `LC010` (move `SaveChanges` after a do-while loop), `LC011` (insert a missing `Id` primary-key property), `LC016` (extract `DateTime.Now`/`UtcNow` to a local), and `LC027` (insert an explicit foreign-key property) each terminated the statement or member they add with a hard-coded line feed — `SyntaxFactory.ElasticLineFeed` or `SyntaxFactory.EndOfLine("\n")`. On a CRLF document that produced a single LF line amid CRLF lines (a mixed-line-ending file that surfaces as a spurious source-control diff and can trip formatters/linters), and it made every one of those fixer tests fail on a CRLF (Windows) checkout while passing on LF CI. The fixers now terminate the inserted/moved node with an end-of-line trivia harvested from the document itself (the new `SyntaxTriviaExtensions.GetDocumentEndOfLine`), so the applied fix preserves the file's existing line endings — CRLF or LF — on every platform. The two fixers that emit their newline as *leading* trivia after a warning comment already produce the platform newline through the formatter and are unaffected. Added a cross-platform `LC010` regression test that pins CRLF on both the source and the expected fix regardless of how the repository is checked out
+
 ## [5.5.0] - 2026-05-29
 
 ### Added

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC010_SaveChangesInLoop/SaveChangesInLoopFixer.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC010_SaveChangesInLoop/SaveChangesInLoopFixer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using LinqContraband.Extensions;
 
 namespace LinqContraband.Analyzers.LC010_SaveChangesInLoop;
 
@@ -55,10 +56,11 @@ public class SaveChangesInLoopFixer : CodeFixProvider
         // Find the expression statement containing SaveChanges
         if (!TryGetMovableSaveStatement(invocation, out var expressionStatement, out var loop)) return document;
 
-        // Create the new statement to insert after the loop (preserve the full statement including await if present)
+        // Create the new statement to insert after the loop (preserve the full statement including await if present).
+        // Terminate it with the document's own line ending so a CRLF file does not gain a lone LF line.
         var newStatement = expressionStatement
             .WithLeadingTrivia(loop.GetLeadingTrivia())
-            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
+            .WithTrailingTrivia(loop.GetDocumentEndOfLine());
 
         // Remove the statement from inside the loop
         editor.RemoveNode(expressionStatement);

--- a/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixer.cs
+++ b/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC016_AvoidDateTimeNow/AvoidDateTimeNowFixer.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using LinqContraband.Extensions;
 
 namespace LinqContraband.Analyzers.LC016_AvoidDateTimeNow;
 
@@ -75,7 +76,7 @@ public class AvoidDateTimeNowFixer : CodeFixProvider
                     )
                 )
             )
-        ).WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
+        ).WithTrailingTrivia(statement.GetDocumentEndOfLine());
 
         foreach (var access in FindMatchingClockAccesses(memberAccess, semanticModel, cancellationToken))
         {

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyFixer.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeyFixer.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using LinqContraband.Extensions;
 
 namespace LinqContraband.Analyzers.LC011_EntityMissingPrimaryKey;
 
@@ -93,7 +94,7 @@ public class EntityMissingPrimaryKeyFixer : CodeFixProvider
             .AddAccessorListAccessors(
                 SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)),
                 SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration).WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)))
-            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
+            .WithTrailingTrivia(entitySyntax.GetDocumentEndOfLine());
 
         editor.InsertMembers(entitySyntax, 0, new[] { idProperty });
 

--- a/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyFixer.cs
+++ b/src/LinqContraband/Analyzers/SchemaAndModeling/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeyFixer.cs
@@ -94,7 +94,7 @@ public class MissingExplicitForeignKeyFixer : CodeFixProvider
                     .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)))
             .NormalizeWhitespace()
             .WithLeadingTrivia(GetIndentationTrivia(navProperty))
-            .WithTrailingTrivia(SyntaxFactory.EndOfLine("\n"));
+            .WithTrailingTrivia(navProperty.GetDocumentEndOfLine());
 
         if (navProperty.Parent is not TypeDeclarationSyntax typeDeclaration)
             return document;

--- a/src/LinqContraband/Extensions/SyntaxTriviaExtensions.cs
+++ b/src/LinqContraband/Extensions/SyntaxTriviaExtensions.cs
@@ -1,0 +1,43 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace LinqContraband.Extensions;
+
+/// <summary>
+/// Trivia helpers shared by code-fix providers.
+/// </summary>
+internal static class SyntaxTriviaExtensions
+{
+    /// <summary>
+    /// Returns an end-of-line trivia matching the document's existing line endings
+    /// (CRLF on Windows checkouts, LF on Unix), harvested from <paramref name="node"/>
+    /// or, failing that, from the syntax tree root.
+    /// <para>
+    /// Fixers that insert or move a statement should terminate it with this rather than a
+    /// hard-coded <see cref="SyntaxFactory.ElasticLineFeed"/> or <c>EndOfLine("\n")</c>:
+    /// those emit a lone LF, which leaves a single LF line inside an otherwise CRLF file
+    /// (mixed line endings that show up as a spurious source-control diff and can trip
+    /// formatters/linters) and makes fixer tests fail on CRLF checkouts.
+    /// </para>
+    /// </summary>
+    public static SyntaxTrivia GetDocumentEndOfLine(this SyntaxNode node)
+    {
+        var local = FirstEndOfLine(node);
+        if (local.IsKind(SyntaxKind.EndOfLineTrivia))
+            return local;
+
+        var root = node.SyntaxTree?.GetRoot();
+        if (root is not null)
+        {
+            var fromRoot = FirstEndOfLine(root);
+            if (fromRoot.IsKind(SyntaxKind.EndOfLineTrivia))
+                return fromRoot;
+        }
+
+        return SyntaxFactory.ElasticLineFeed;
+    }
+
+    private static SyntaxTrivia FirstEndOfLine(SyntaxNode node) =>
+        node.DescendantTrivia().FirstOrDefault(static trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia));
+}

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.0</Version>
+        <Version>5.5.1</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC032 now ships an automatic code fixer. It rewrites a tracked bulk-update loop (a foreach over an EF query that assigns scalar properties, immediately followed by SaveChanges) into a single set-based ExecuteUpdate/ExecuteUpdateAsync call, collapsing N tracked updates and N UPDATE statements into one server-side UPDATE. The fix is conservative: it leaves the trailing SaveChanges in place with a warning comment, prefers the awaited ExecuteUpdateAsync overload and carries the cancellation token onto it, strips inline materializers (including awaited ToListAsync), and collapses duplicate writes last-write-wins. It declines local-variable sources, an observed SaveChanges result, a value that reads a property written earlier in the same loop, and async contexts without a suitable ExecuteUpdateAsync overload, so it never emits a blocking, uncompilable, or behaviour-changing rewrite.</PackageReleaseNotes>
+        <PackageReleaseNotes>Four code fixers (LC010, LC011, LC016, LC027) no longer inject a lone LF line into a CRLF file. Each terminated the statement or member it inserts or moves with a hard-coded line feed, leaving mixed line endings in a CRLF document (a spurious source-control diff that can trip formatters) and failing those fixer tests on CRLF (Windows) checkouts while passing on LF CI. They now harvest the document's own end-of-line trivia, so the applied fix preserves the file's existing line endings — CRLF or LF — on every platform.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC010_SaveChangesInLoop/SaveChangesInLoopFixerTests.cs
@@ -161,6 +161,48 @@ class Program
     }
 
     [Fact]
+    public async Task SaveChangesInDoWhile_MovedStatement_KeepsCrlfLineEndings()
+    {
+        // Forces CRLF on both the source and the expected fix regardless of the checkout's
+        // line endings, so this guards cross-platform against the fixer terminating the moved
+        // statement with a lone LF — which would leave mixed line endings inside a CRLF file.
+        // See SyntaxTriviaExtensions.GetDocumentEndOfLine.
+        var test = ToCrlf(Usings + @"
+class Program
+{
+    void Main()
+    {
+        using var db = new MyDbContext();
+        int i = 0;
+        do
+        {
+            i++;
+            {|LC010:db.SaveChanges()|};
+        }
+        while (i < 10);
+    }
+}" + MockNamespace);
+
+        var fixedCode = ToCrlf(Usings + @"
+class Program
+{
+    void Main()
+    {
+        using var db = new MyDbContext();
+        int i = 0;
+        do
+        {
+            i++;
+        }
+        while (i < 10);
+        db.SaveChanges();
+    }
+}" + MockNamespace);
+
+        await VerifyFix(test, fixedCode);
+    }
+
+    [Fact]
     public async Task SaveChanges_WithControlFlowInsideLoop_HasNoFix()
     {
         var test = Usings + @"
@@ -360,6 +402,11 @@ class Program
 
         await VerifyFix(test, fixedCode);
     }
+
+    // Normalizes every line ending to CRLF so a test can assert line-ending behaviour
+    // independently of how the repository is checked out (autocrlf on Windows, LF on Unix).
+    private static string ToCrlf(string value) =>
+        value.Replace("\r\n", "\n").Replace("\n", "\r\n");
 
     private static async Task VerifyFix(string test, string fixedCode)
     {


### PR DESCRIPTION
## Summary

Four code fixers terminated the statement/member they insert or move with a **hard-coded line feed** (`SyntaxFactory.ElasticLineFeed` or `EndOfLine("\n")`):

- **LC010** — move `SaveChanges` after a do-while loop
- **LC011** — insert a missing `Id` primary-key property
- **LC016** — extract `DateTime.Now`/`UtcNow` to a local
- **LC027** — insert an explicit foreign-key property

On a **CRLF** document this produced a single LF line amid CRLF lines — a mixed-line-ending file that shows up as a spurious source-control diff and can trip formatters/linters. It also made every one of those fixer tests fail on a CRLF (Windows) checkout while passing on LF CI (so the bug was invisible to CI).

## Fix

The fixers now terminate the inserted/moved node with an end-of-line trivia **harvested from the document itself** via the new `SyntaxTriviaExtensions.GetDocumentEndOfLine`, so the applied fix preserves the file's existing line endings — CRLF or LF — on every platform.

The two fixers that emit their newline as *leading* trivia after a warning comment (`LC012`, `LC032`) already produce the platform newline through the formatter and are unaffected (left untouched).

## Tests

- Adds a cross-platform `LC010` regression test that pins CRLF on both the source and the expected fix regardless of how the repository is checked out.
- Full suite green in Release: **880 passed, 0 failed** (was 11 failing on this CRLF checkout before the fix).

## Release

Bumps the package to **5.5.1** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)