### PR TITLE
fix(LC020): detect argument-derived StringComparison crimes (5.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.2] - 2026-06-04
+
+### Fixed
+- Taught `LC020` to flag a `StringComparison` overload whose query column flows through a method **argument**, not only its receiver. The check only inspected the call's receiver, so `db.Users.Where(u => "admin".Contains(u.Name, StringComparison.OrdinalIgnoreCase))` — where the constant is the receiver and the column `u.Name` is the searched-for argument — was missed even though EF Core cannot translate the overload and throws at runtime on the default relational providers (a false negative; the same class as a column reaching the comparison through the receiver). Detection now considers the receiver **and every argument** for query-parameter dependence, so the argument-derived form reports and the existing fixer drops the `StringComparison` argument (`"admin".Contains(u.Name)`). Constant and captured-local arguments stay quiet (the comparison is parameter-independent), as do in-memory/`IEnumerable` calls and custom `IQueryable` helpers that take delegate predicates. Added an argument-derived positive test, a captured-local-argument guardrail, and a fixer test; the rule doc now documents the argument-derived shape and the verified provider behavior (default providers throw; Npgsql maps `OrdinalIgnoreCase` to `ILIKE`; Pomelo MySQL opts in via `EnableStringComparisonTranslations`)
+
 ## [5.5.1] - 2026-06-03
 
 ### Fixed

--- a/docs/LC020_StringContainsWithComparison.md
+++ b/docs/LC020_StringContainsWithComparison.md
@@ -6,6 +6,8 @@ Detect `string.Contains(...)`, `StartsWith(...)`, and `EndsWith(...)` overloads 
 ## The Problem
 EF Core's SQL translation logic is optimized for simple string predicate overloads such as `Contains(string)`, `StartsWith(string)`, and `EndsWith(string)`. Passing `StringComparison` asks for .NET comparison semantics that many database providers cannot express directly. Depending on the provider and EF Core version, the query may fail translation or use semantics that are not what the application intended.
 
+On the default EF Core relational providers — including SQL Server — these `StringComparison` overloads are **not translated and throw `InvalidOperationException` at runtime** (this is by design: SQL string comparison is collation-driven and EF will not guess). A few providers translate a subset: Npgsql maps `StringComparison.OrdinalIgnoreCase` to `ILIKE`, and Pomelo MySQL translates them only when `EnableStringComparisonTranslations` is opted in. The rule therefore stays provider-agnostic and flags the overload whenever the searched value is column-derived, which is the case the default provider rejects.
+
 ### Example Violation
 ```csharp
 // Violation: likely to fail translation or depend on provider-specific behavior
@@ -36,7 +38,7 @@ var users = db.Users.Where(u => needle.Contains("a", StringComparison.OrdinalIgn
 1. **Target methods**: inspect `string.Contains`, `string.StartsWith`, and `string.EndsWith`.
 2. **Overload check**: require an argument or bound parameter of type `System.StringComparison`.
 3. **Queryable context check**: require an enclosing lambda passed to a `System.Linq.Queryable` invocation over an `IQueryable` source.
-4. **Parameter-dependency check**: require the string receiver to depend on a query lambda parameter, such as `u.Name.Contains(...)` or a nested collection predicate like `u.Orders.Any(o => o.Number.Contains(...))`. Nested local enumerable predicates, captured locals, constants, and other client-side strings are ignored.
+4. **Parameter-dependency check**: require either the string receiver *or* a method argument to depend on a query lambda parameter — `u.Name.Contains("admin", ...)` (column receiver), `"admin".Contains(u.Name, ...)` (column argument), or a nested collection predicate like `u.Orders.Any(o => o.Number.Contains(...))`. The searched value is column-derived in each case, so the overload cannot translate. Nested local enumerable predicates, captured locals, constants, and other client-side strings are ignored.
 
 ### Exceptions
 - Calls on in-memory strings or `IEnumerable`.
@@ -52,6 +54,7 @@ db.Users.Where(x => x.Name.Contains("abc", StringComparison.OrdinalIgnoreCase));
 db.Users.Any(x => x.Email.StartsWith("test", StringComparison.CurrentCulture));
 db.Users.Where(x => x.Name.EndsWith(".org", StringComparison.OrdinalIgnoreCase));
 db.Users.Where(x => x.Orders.Any(o => o.Number.Contains("rush", StringComparison.OrdinalIgnoreCase)));
+db.Users.Where(u => "admin".Contains(u.Name, StringComparison.OrdinalIgnoreCase)); // column flows through the argument
 ```
 
 ### Valid

--- a/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC020_StringContainsWithComparison/StringContainsWithComparisonAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC020_StringContainsWithComparison/StringContainsWithComparisonAnalyzer.cs
@@ -52,7 +52,13 @@ public sealed class StringContainsWithComparisonAnalyzer : DiagnosticAnalyzer
         if (!hasStringComparison) return;
 
         var lambdaParameters = GetQueryableExpressionLambdaParameters(invocation);
-        if (lambdaParameters.Any(parameter => ReceiverDependsOnParameter(invocation.Instance, parameter)))
+
+        // The query column can reach the comparison through the receiver (u.Name.Contains("x", cmp))
+        // or through an argument ("admin".Contains(u.Name, cmp)). Either column-derived operand
+        // defeats SQL translation of the StringComparison overload (EF throws at runtime), so both
+        // must be considered — passing the whole invocation reuses the IInvocationOperation arm of
+        // ReceiverDependsOnParameter, which walks the instance and every argument.
+        if (lambdaParameters.Any(parameter => ReceiverDependsOnParameter(invocation, parameter)))
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), method.Name));
         }

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.1</Version>
+        <Version>5.5.2</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Four code fixers (LC010, LC011, LC016, LC027) no longer inject a lone LF line into a CRLF file. Each terminated the statement or member it inserts or moves with a hard-coded line feed, leaving mixed line endings in a CRLF document (a spurious source-control diff that can trip formatters) and failing those fixer tests on CRLF (Windows) checkouts while passing on LF CI. They now harvest the document's own end-of-line trivia, so the applied fix preserves the file's existing line endings — CRLF or LF — on every platform.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC020 now flags a StringComparison overload whose query column flows through a method argument, not only its receiver. The constant-receiver, column-argument form (for example "admin".Contains(u.Name, StringComparison.OrdinalIgnoreCase) inside a Where) was previously missed even though EF Core cannot translate the overload and throws at runtime on the default relational providers. Detection now considers the receiver and every argument for query-parameter dependence; constant and captured-local arguments stay quiet, and the existing fixer drops the StringComparison argument.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC020_StringContainsWithComparison/StringContainsWithComparisonTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC020_StringContainsWithComparison/StringContainsWithComparisonTests.cs
@@ -308,4 +308,100 @@ namespace LinqContraband.Test
 
         await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
     }
+
+    [Fact]
+    public async Task StringContains_WithComparison_ConstantReceiverColumnArgument_ShouldTriggerLC020()
+    {
+        // The searched-for value is the column while the receiver is a constant
+        // (""admin"".Contains(u.Name, cmp)). EF still cannot translate the StringComparison
+        // overload (it throws at runtime), so this must report just like the column-receiver form.
+        var test = Usings + @"
+namespace LinqContraband.Test
+{
+    public class User
+    {
+        public string Name { get; set; } = """";
+    }
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new List<User>().AsQueryable();
+            var result = query.Where(u => {|LC020:""admin"".Contains(u.Name, StringComparison.OrdinalIgnoreCase)|}).ToList();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task StringContains_WithComparison_ConstantReceiverCapturedLocalArgument_ShouldNotTrigger()
+    {
+        // Neither operand is column-derived (constant receiver, captured-local argument), so the
+        // comparison is parameter-independent and stays quiet, matching the captured-local receiver case.
+        var test = Usings + @"
+namespace LinqContraband.Test
+{
+    public class User
+    {
+        public string Name { get; set; } = """";
+    }
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var needle = ""x"";
+            var query = new List<User>().AsQueryable();
+            var result = query.Where(u => ""admin"".Contains(needle, StringComparison.OrdinalIgnoreCase)).ToList();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Fixer_ForConstantReceiverColumnArgument_ShouldRemoveStringComparison()
+    {
+        var test = Usings + @"
+namespace LinqContraband.Test
+{
+    public class User
+    {
+        public string Name { get; set; } = """";
+    }
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new List<User>().AsQueryable();
+            var result = query.Where(u => {|LC020:""admin"".Contains(u.Name, StringComparison.OrdinalIgnoreCase)|}).ToList();
+        }
+    }
+}";
+
+        var fixedCode = Usings + @"
+namespace LinqContraband.Test
+{
+    public class User
+    {
+        public string Name { get; set; } = """";
+    }
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var query = new List<User>().AsQueryable();
+            var result = query.Where(u => ""admin"".Contains(u.Name)).ToList();
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
 }


### PR DESCRIPTION
## Summary

`LC020` flags `Contains`/`StartsWith`/`EndsWith` `StringComparison` overloads inside `IQueryable` lambdas, but it only inspected the call's **receiver**. So a column reaching the comparison through an **argument** was missed:

```csharp
db.Users.Where(u => "admin".Contains(u.Name, StringComparison.OrdinalIgnoreCase)); // FN: not flagged
```

This is a false negative — EF Core **does not translate** `StringComparison` overloads and **throws at runtime** on the default relational providers (verified against the [EF Core collations docs](https://learn.microsoft.com/en-us/ef/core/miscellaneous/collations-and-case-sensitivity); only Npgsql `OrdinalIgnoreCase`→`ILIKE` and opt-in Pomelo MySQL translate them). It is the same class as the column-receiver form the rule already catches.

> Note: the audit also listed an `Ordinal`/`OrdinalIgnoreCase` *false positive* for this rule. Verification showed that claim is incorrect for the default provider (it throws), so flagging those is correct — **not changed**, to avoid introducing false negatives for the majority of users.

## Fix

Detection now passes the whole invocation to `ReceiverDependsOnParameter`, reusing its existing `IInvocationOperation` arm so the **receiver and every argument** are checked for query-parameter dependence. The change is additive: all existing no-trigger behavior is preserved (constant and captured-local arguments stay quiet, since neither operand is column-derived). The existing fixer already drops the `StringComparison` argument regardless of position → `"admin".Contains(u.Name)`.

## Tests

- Argument-derived positive (FN now caught), captured-local-argument guardrail, and a fixer test.
- Rule doc updated with the argument-derived shape and the verified provider behavior.
- Full suite green in Release: **883 passed**.

## Release

Bumps to **5.5.2** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)