### PR TITLE
fix(LC002): stop misleading "redundant" message on ToDictionary/ToLookup sources (5.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.4] - 2026-06-04
+
+### Fixed
+- Stopped `LC002` from reporting a misleading "redundant" materialization when the **source** is a keyed (`ToDictionary`/`ToDictionaryAsync`) or grouped (`ToLookup`) materializer. `db.Users.ToDictionary(u => u.Id).ToList()` and `db.Users.ToLookup(u => u.Age).ToList()` were flagged as "`ToList` is redundant because `ToDictionary`/`ToLookup`", but the trailing call is a genuine shape change — it yields `List<KeyValuePair<,>>` and `List<IGrouping<,>>` respectively, not a redundant re-materialization of the same sequence, and removing the keyed/grouped source would change the result type. These sources are now treated like the existing de-duplicating set sources (`ToHashSet().ToList()`) and left quiet: no diagnostic and no fix are offered. Genuinely redundant non-keyed collapses (`ToArray().ToList()`, `ToList().ToHashSet()`) still report and fix, and the separate premature-materialization diagnostic for a keyed source feeding a query operator or terminal aggregate (`ToDictionary(...).Where(...)`, `ToDictionary(...).Count()`) is unaffected. Added `ToDictionary().ToList()` and `ToLookup().ToList()` no-diagnostic regression tests and documented the keyed/grouped-source exclusion
+
 ## [5.5.3] - 2026-06-04
 
 ### Fixed

--- a/docs/LC002_PrematureMaterialization.md
+++ b/docs/LC002_PrematureMaterialization.md
@@ -30,12 +30,20 @@ var distinctList = db.Users.ToHashSet().ToList();                               
 var ci = db.Users.Select(u => u.Name).ToHashSet(StringComparer.OrdinalIgnoreCase).ToHashSet(); // NOT reported — comparer would be lost
 ```
 
+A keyed (`ToDictionary`) or grouped (`ToLookup`) materializer as the **source** of a second materializer is likewise **not** redundant: the source produces a structure whose element type differs from the sequence, so the trailing call transforms its shape rather than re-materializing the same data. Removing the source would change the result type, so these are left quiet:
+
+```csharp
+var pairs = db.Users.ToDictionary(u => u.Id).ToList();   // NOT reported — yields List<KeyValuePair<int, User>>
+var groups = db.Users.ToLookup(u => u.Age).ToList();     // NOT reported — yields List<IGrouping<int, User>>
+```
+
 ## What LC002 Intentionally Ignores
 - Ambiguous provenance such as multiple local assignments or control-flow-dependent sources
 - Already materialized locals, aliases, constructors, arrays, DTO lists, fields, properties, and other post-processing shapes where in-memory work may be intentional
 - `AsEnumerable()` by itself when it is used only as an explicit client boundary
 - Overloads or lambdas that do not have a clear `IQueryable`-safe equivalent, such as index-aware predicates/selectors, comparer-based overloads, delegated predicates, local/source methods, `Regex`, or `StringComparison` string calls
 - A de-duplicating set materializer (`ToHashSet`, `ToImmutableHashSet`, `ToImmutableSortedSet`) used as the source of a second materializer (`ToHashSet().ToList()`, `ToImmutableHashSet().ToArray()`, `ToHashSet(comparer).ToHashSet()`), where removing the source would drop de-duplication or a custom comparer
+- A keyed (`ToDictionary`) or grouped (`ToLookup`) materializer used as the source of a second materializer (`ToDictionary().ToList()`, `ToLookup().ToList()`), where the trailing call transforms the keyed/grouped shape and is not a redundant re-materialization
 - Pure in-memory sequences that never came from `IQueryable`
 
 ## Fixer Behavior

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationMethodRules.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationMethodRules.cs
@@ -117,6 +117,20 @@ public sealed partial class PrematureMaterializationAnalyzer
             "ToImmutableSortedSet";
     }
 
+    // A keyed (Dictionary) or grouped (Lookup) materializer produces a structure whose element type
+    // differs from the source sequence, so a trailing materializer transforms its shape rather than
+    // re-materialising the same sequence: ToDictionary().ToList() yields List<KeyValuePair<,>> and
+    // ToLookup().ToList() yields List<IGrouping<,>>. The trailing call is therefore never redundant,
+    // and removing the keyed/grouped source would change the result type — so such a source is not
+    // treated as a redundant materialization (the "redundant" message would be misleading).
+    private static bool IsKeyedOrGroupedMaterializer(string methodName)
+    {
+        return methodName is
+            "ToDictionary" or
+            "ToDictionaryAsync" or
+            "ToLookup";
+    }
+
     private static bool IsMaterializingConstructor(IMethodSymbol constructor)
     {
         var type = constructor.ContainingType;

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationOriginAnalysis.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC002_PrematureMaterialization/PrematureMaterializationOriginAnalysis.cs
@@ -40,6 +40,15 @@ public sealed partial class PrematureMaterializationAnalyzer
             return false;
         }
 
+        // A Dictionary/Lookup source is a keyed/grouped structure; a trailing materializer transforms
+        // its shape (ToDictionary().ToList() -> List<KeyValuePair<,>>, ToLookup().ToList() ->
+        // List<IGrouping<,>>) rather than redundantly re-materialising the sequence. Reporting the
+        // trailing call as "redundant because ToDictionary/ToLookup" is misleading, so skip it.
+        if (IsKeyedOrGroupedMaterializer(previousMaterialization.MaterializerName))
+        {
+            return false;
+        }
+
         var properties = CreateProperties(
             RedundantDiagnosticKind,
             previousMaterialization.OriginKind,

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.3</Version>
+        <Version>5.5.4</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC015 now flags three more ordering-dependent operators that were silently missed: ElementAt/ElementAtOrDefault (EF Core 6+ translates these to OFFSET/FETCH, non-deterministic without an ordering), their async forms, and the async LastAsync/LastOrDefaultAsync (twins of the already-flagged Last/LastOrDefault). The code fix offers an OrderBy on the primary key for them under the same single-detectable-key safety gate. TakeLast/SkipLast are deliberately not flagged because EF Core cannot translate them at all, so an add-OrderBy suggestion would be wrong.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC002 no longer reports a misleading "redundant" materialization when the source is a keyed (ToDictionary) or grouped (ToLookup) materializer. A trailing ToList after ToDictionary/ToLookup is a genuine shape change (it yields a List of KeyValuePair / List of IGrouping), not a redundant re-materialization, so it is now left quiet — matching the existing de-duplicating-set exclusion. Genuinely redundant non-keyed collapses such as ToArray().ToList() still report and fix.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC002_PrematureMaterialization/PrematureMaterializationTests.cs
@@ -356,6 +356,47 @@ public class PrematureMaterializationTests
     }
 
     [Fact]
+    public async Task DoesNotReport_Redundant_ToDictionaryThenToList()
+    {
+        // ToDictionary() produces a Dictionary<,>; the trailing ToList() yields List<KeyValuePair<,>>,
+        // a genuine shape change, not a redundant re-materialization. Reporting "ToList redundant
+        // because ToDictionary" would be misleading, so the analyzer stays quiet.
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main()
+                {
+                    var db = new DbContext();
+                    var pairs = db.Users.ToDictionary(u => u.Id).ToList();
+                }
+            }
+            """ + MockTypes;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task DoesNotReport_Redundant_ToLookupThenToList()
+    {
+        // ToLookup() produces an ILookup<,>; the trailing ToList() yields List<IGrouping<,>>,
+        // a genuine shape change, not a redundant re-materialization.
+        var test = CommonUsings + """
+
+            class Program
+            {
+                void Main()
+                {
+                    var db = new DbContext();
+                    var groups = db.Users.ToLookup(u => u.Age).ToList();
+                }
+            }
+            """ + MockTypes;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task DoesNotReport_WhenWhereRunsBeforeToList()
     {
         var test = CommonUsings + """


### PR DESCRIPTION
## Summary

`LC002`'s redundant-materialization sub-rule reported `db.Users.ToDictionary(u => u.Id).ToList()` and `db.Users.ToLookup(u => u.Age).ToList()` as **"`ToList` is redundant because `ToDictionary`/`ToLookup`"**. That message is misleading: the trailing call is a genuine **shape change** —

- `Dictionary<,>.ToList()` → `List<KeyValuePair<,>>`
- `ILookup<,>.ToList()` → `List<IGrouping<,>>`

— not a redundant re-materialization, and removing the keyed/grouped source would change the result type. No fix was offered (correctly), but the message remained.

## Fix

Keyed (`ToDictionary`/`ToDictionaryAsync`) and grouped (`ToLookup`) **source** materializers are now treated like the existing de-duplicating-set exclusion (`ToHashSet().ToList()`) and left quiet — no diagnostic, no fix.

Unaffected:
- Genuinely redundant non-keyed collapses (`ToArray().ToList()`, `ToList().ToHashSet()`) still report and fix.
- The separate premature-materialization diagnostic for a keyed source feeding a query operator or aggregate (`ToDictionary(...).Where(...)`, `ToDictionary(...).Count()`) still fires — that path requires a non-materializing continuation, which this change does not touch.

## Tests

- `ToDictionary().ToList()` and `ToLookup().ToList()` no-diagnostic regression tests.
- Doc updated with the keyed/grouped-source exclusion alongside the set-source one.
- Full suite green in Release: **893 passed**.

## Release

Bumps to **5.5.4** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)