### PR TITLE
fix(LC037): cover SqlQueryRaw as a constructed-SQL injection sink (5.5.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.5] - 2026-06-04
+
+### Fixed
+- Closed a raw-SQL injection false negative: `LC037` now treats `SqlQueryRaw<T>` (the EF7+ scalar/keyless raw-SQL query on `DbContext.Database`, `db.Database.SqlQueryRaw<T>(sql)`) as a construction sink. A SQL string built with `string.Format(...)`, `string.Concat(...)`, a `StringBuilder`, or an aliased local and passed to `SqlQueryRaw` was invisible to the entire Raw SQL neighborhood — `LC018` covers only its interpolation and `+` concatenation (added in 5.4.13), and `LC037` did not list `SqlQueryRaw` among its sinks (it had only `FromSqlRaw`/`ExecuteSqlRaw`/`ExecuteSqlRawAsync`). `SqlQueryRaw` is now in `LC037`'s target set, and LC037's existing deferral keeps interpolation and `+` concatenation owned by `LC018` (no double-report). Added `string.Format` and `string.Concat` positive tests for the facade `SqlQueryRaw` sink plus interpolation-deferral and constant-SQL guardrails, and documented the new sink and the LC018/LC037 boundary
+
 ## [5.5.4] - 2026-06-04
 
 ### Fixed

--- a/docs/LC037_RawSqlStringConstruction.md
+++ b/docs/LC037_RawSqlStringConstruction.md
@@ -1,7 +1,7 @@
 # Spec: LC037 - Raw SQL String Construction
 
 ## Goal
-Detect string-built SQL before it reaches `FromSqlRaw(...)` or `ExecuteSqlRaw(...)`.
+Detect string-built SQL before it reaches `FromSqlRaw(...)`, `ExecuteSqlRaw(...)`, or `SqlQueryRaw<T>(...)` (the EF7+ scalar/keyless raw-SQL query on `DbContext.Database`).
 
 ## The Problem
 Concatenation, `string.Format(...)`, `string.Concat(...)`, and `StringBuilder` SQL assembly make it easy to smuggle unchecked values into raw SQL text.
@@ -29,7 +29,7 @@ var users = db.Users.FromSqlRaw("SELECT * FROM Users WHERE Name = {0}", name).To
 This v1 surface is analyzer-only. It intentionally avoids speculative rewrites for complex SQL-building code.
 
 ## Rule Boundary
-- LC037 intentionally yields when the raw SQL argument is passed directly as an interpolated string or direct non-constant `+` concatenation. Those direct call-site patterns are owned by LC018 (`FromSqlRaw`) and LC034 (`ExecuteSqlRaw` / `ExecuteSqlRawAsync`).
-- LC037 still reports broader constructed-SQL shapes such as `string.Format(...)`, `string.Concat(...)`, `StringBuilder`, and local alias / variable flow into raw SQL APIs.
+- LC037 intentionally yields when the raw SQL argument is passed directly as an interpolated string or direct non-constant `+` concatenation. Those direct call-site patterns are owned by LC018 (`FromSqlRaw` and `SqlQueryRaw`) and LC034 (`ExecuteSqlRaw` / `ExecuteSqlRawAsync`).
+- LC037 still reports broader constructed-SQL shapes such as `string.Format(...)`, `string.Concat(...)`, `StringBuilder`, and local alias / variable flow into all three raw SQL sinks — including `SqlQueryRaw<T>` (`db.Database.SqlQueryRaw<T>(string.Format(...))`), whose interpolation/concatenation LC018 owns while its other construction shapes are LC037's.
 - For simple local variables, LC037 resolves the latest guaranteed declaration or assignment before the raw SQL call, so an earlier constructed value overwritten unconditionally by a constant is ignored while later constructed overwrites are still reported.
 - Conditional overwrites are treated conservatively: a branch-only constant assignment does not suppress an earlier constructed SQL value, and a branch-only constructed assignment remains suspicious unless a later guaranteed assignment overwrites it.

--- a/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC037_RawSqlStringConstruction/RawSqlStringConstructionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/RawSqlAndSecurity/LC037_RawSqlStringConstruction/RawSqlStringConstructionAnalyzer.cs
@@ -32,7 +32,12 @@ public sealed partial class RawSqlStringConstructionAnalyzer : DiagnosticAnalyze
     private static readonly ImmutableHashSet<string> TargetMethods = ImmutableHashSet.Create(
         "FromSqlRaw",
         "ExecuteSqlRaw",
-        "ExecuteSqlRawAsync");
+        "ExecuteSqlRawAsync",
+        // SqlQueryRaw<T> is the scalar/keyless raw-SQL query on the DatabaseFacade
+        // (db.Database.SqlQueryRaw<T>(sql)); it takes a raw `string sql` and is an equal injection
+        // sink. LC018 owns its interpolation and `+` concatenation; LC037 covers the remaining
+        // construction shapes (String.Format/Concat, StringBuilder, aliased locals).
+        "SqlQueryRaw");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.4</Version>
+        <Version>5.5.5</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC002 no longer reports a misleading "redundant" materialization when the source is a keyed (ToDictionary) or grouped (ToLookup) materializer. A trailing ToList after ToDictionary/ToLookup is a genuine shape change (it yields a List of KeyValuePair / List of IGrouping), not a redundant re-materialization, so it is now left quiet — matching the existing de-duplicating-set exclusion. Genuinely redundant non-keyed collapses such as ToArray().ToList() still report and fix.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC037 now treats SqlQueryRaw&lt;T&gt; (the EF7+ scalar/keyless raw-SQL query on DbContext.Database) as a construction sink, closing an injection false negative: a SQL string built with string.Format, string.Concat, a StringBuilder, or an aliased local and passed to SqlQueryRaw was previously caught by neither LC037 (which omitted the sink) nor LC018 (which covers only its interpolation and concatenation). LC037's existing deferral keeps interpolation/concatenation owned by LC018, so there is no double-report.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC037_RawSqlStringConstruction/RawSqlStringConstructionTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC037_RawSqlStringConstruction/RawSqlStringConstructionTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore
         public static IQueryable<TEntity> FromSqlRaw<TEntity>(this IQueryable<TEntity> source, string sql, params object[] parameters) => source;
         public static int ExecuteSqlRaw(this DatabaseFacade databaseFacade, string sql, params object[] parameters) => 0;
         public static Task<int> ExecuteSqlRawAsync(this DatabaseFacade databaseFacade, string sql, params object[] parameters) => Task.FromResult(0);
+        public static IQueryable<TResult> SqlQueryRaw<TResult>(this DatabaseFacade databaseFacade, string sql, params object[] parameters) => Enumerable.Empty<TResult>().AsQueryable();
     }
 }
 ";
@@ -160,6 +161,87 @@ namespace TestApp
         {
             var sql = string.Format(""SELECT * FROM Users WHERE Id = {0}"", id);
             var result = query.FromSqlRaw({|LC037:sql|});
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task SqlQueryRaw_WithStringFormat_ShouldTrigger()
+    {
+        // SqlQueryRaw is the DatabaseFacade scalar/keyless raw-SQL sink; String.Format construction
+        // is LC037's territory (LC018 owns only interpolation and '+' concatenation).
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var sql = string.Format(""SELECT Name FROM Users WHERE Id = {0}"", id);
+            var result = db.Database.SqlQueryRaw<string>({|LC037:sql|});
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task SqlQueryRaw_WithStringConcatMethod_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, string name)
+        {
+            var result = db.Database.SqlQueryRaw<string>({|LC037:string.Concat(""SELECT Name FROM Users WHERE Name = '"", name, ""'"")|});
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task SqlQueryRaw_WithInterpolatedString_ShouldNotTrigger_OwnedByLC018()
+    {
+        // Interpolation is owned by LC018 (which now covers SqlQueryRaw); LC037 must defer so the
+        // sink is not double-reported.
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db, int id)
+        {
+            var result = db.Database.SqlQueryRaw<int>($""SELECT Id FROM Users WHERE Id = {id}"");
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task SqlQueryRaw_WithConstantString_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class Program
+    {
+        public void Run(DbContext db)
+        {
+            var result = db.Database.SqlQueryRaw<string>(""SELECT Name FROM Users"");
         }
     }
 }";


### PR DESCRIPTION
## Summary

A SQL string built with `string.Format(...)`, `string.Concat(...)`, a `StringBuilder`, or an aliased local and passed to **`db.Database.SqlQueryRaw<T>(...)`** was a SQL-injection sink visible to **no** rule:

- `LC018` covers only `SqlQueryRaw` **interpolation** and **`+` concatenation** (added in 5.4.13).
- `LC037` (constructed-SQL) listed only `FromSqlRaw`/`ExecuteSqlRaw`/`ExecuteSqlRawAsync` as sinks.

So `db.Database.SqlQueryRaw<string>(string.Format("… {0}", input))` slipped through entirely — a security false negative.

## Fix

`SqlQueryRaw` is added to `LC037`'s target set. The namespace gate (`Microsoft.EntityFrameworkCore`) and the `sql` parameter already fit. LC037's existing **deferral** (`IsOwnedBySpecificRawSqlAnalyzer`) keeps interpolation and `+` concatenation owned by `LC018`, so there is **no double-report** — the two rules partition the `SqlQueryRaw` surface exactly as they do for `FromSqlRaw`.

## Tests

- Positives: `SqlQueryRaw` with `string.Format` and `string.Concat`.
- Guardrails: `SqlQueryRaw` with an interpolated string (deferred to LC018 → no LC037 diagnostic) and with a constant string (safe).
- Doc updated with the new sink and the LC018/LC037 boundary.
- Full suite green in Release: **897 passed**.

> The `SqlQueryRaw` → `SqlQuery` auto-fix remains a documented follow-up (the diagnostic is report-only by design, which is safe); this PR closes the **detection** gap.

## Release

Bumps to **5.5.5** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)