### PR TITLE
fix(LC025,LC044): honour AsTracking override in chain scans (5.5.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.6] - 2026-06-04
+
+### Fixed
+- Stopped `LC025` and `LC044` from firing on a query whose tracking is restored by a trailing `AsTracking()`. Both rules scanned the query chain for `AsNoTracking()` but ignored a later `AsTracking()`, so `db.Users.AsNoTracking().AsTracking().First()` followed by `Update()` (LC025) or a property mutation + `SaveChanges()` (LC044) was wrongly flagged — even though EF Core applies the **last** tracking directive (`AsTracking()` overwrites the earlier `AsNoTracking()`), leaving the entity tracked so the write is correct. Both chain scans now honour the last directive: the first directive encountered walking up the receiver chain (the one applied last) decides the effective mode. `AsNoTracking().AsTracking()` no longer reports; the reverse `AsTracking().AsNoTracking()` (untracked) and a plain `AsNoTracking()` still report. Added override and reverse-order regression tests to both rules and documented the last-directive-wins behavior. (Found by an adversarial false-positive rescan.)
+
 ## [5.5.5] - 2026-06-04
 
 ### Fixed

--- a/docs/LC025_AsNoTrackingWithUpdate.md
+++ b/docs/LC025_AsNoTrackingWithUpdate.md
@@ -70,6 +70,8 @@ The rule is order-aware. It does not report when a local is reassigned from a tr
 
 LC025 stays quiet when the **outermost** `Select` (the projection nearest the materializer, which determines the result shape) projects to a **newly-constructed object** (for example `Select(u => new User { ... })` or an anonymous type). EF Core never change-tracks instances you construct in a projection, so they are untracked regardless of `AsNoTracking()` — the anti-pattern simply does not apply, and removing `AsNoTracking()` would not change anything. Identity and navigation projections (`Select(u => u)`, `Select(u => u.Manager)`) return the materialized entity itself, whose tracking state *is* governed by `AsNoTracking()`, so those continue to report. Only the outermost projection counts: a constructed wrapper that is later unwrapped back to the entity (`Select(u => new { E = u }).Select(x => x.E)`) still materializes the untracked entity and continues to report.
 
+LC025 honours the **last** tracking directive in a chain, because each `AsTracking()`/`AsNoTracking()` overwrites the query's `QueryTrackingBehavior`. A trailing `AsTracking()` therefore makes the entity tracked again: `db.Users.AsNoTracking().AsTracking().First()` returns a tracked entity, so `Update()` on it is correct and the rule stays quiet. The reverse, `AsTracking().AsNoTracking()`, leaves the entity untracked and still reports.
+
 ## Code Fix
 The fixer removes the `AsNoTracking()` call from direct local declarations, simple assignments, and foreach collection expressions when that is the origin of the diagnostic.
 

--- a/docs/LC044_AsNoTrackingThenModifySilentWrite.md
+++ b/docs/LC044_AsNoTrackingThenModifySilentWrite.md
@@ -38,7 +38,7 @@ db.SaveChanges();
 ### Algorithm
 1. **Anchor**: register on every `DbContext.SaveChanges` / `SaveChangesAsync` invocation.
 2. **Context symbol**: resolve the instance symbol of the SaveChanges call.
-3. **Origin scan**: in the same executable root, collect local declarations whose initializer is a materializer invocation (`First`, `FirstOrDefault`, `Single`, `ToList`, async variants, …) and whose chain contains `AsNoTracking`. Collect `foreach` loops whose collection chain contains `AsNoTracking`.
+3. **Origin scan**: in the same executable root, collect local declarations whose initializer is a materializer invocation (`First`, `FirstOrDefault`, `Single`, `ToList`, async variants, …) and whose chain contains `AsNoTracking`. Collect `foreach` loops whose collection chain contains `AsNoTracking`. The chain scan honours the **last** tracking directive (each `AsTracking()`/`AsNoTracking()` overwrites `QueryTrackingBehavior`): `AsNoTracking().AsTracking()` is tracked and does **not** report, while `AsTracking().AsNoTracking()` is untracked and does.
 4. **Same-context gate**: extract the DbSet-owner context symbol from the query chain and require `SymbolEqualityComparer` match against the SaveChanges context symbol.
 5. **Single-assignment gate**: skip locals that are assigned more than once (ambiguous dataflow).
 6. **Mutation scan**: find the first `ISimpleAssignmentOperation` whose target is an `IPropertyReferenceOperation` instance-referencing the local, positioned between the local's declaration and the SaveChanges.

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateAnalyzer.cs
@@ -247,7 +247,6 @@ public sealed class AsNoTrackingWithUpdateAnalyzer : DiagnosticAnalyzer
     private bool HasAsNoTrackingInChain(IOperation operation)
     {
         var current = operation.UnwrapConversions();
-        var foundAsNoTracking = false;
         var outermostSelectChecked = false;
         while (current is IInvocationOperation inv)
         {
@@ -266,14 +265,21 @@ public sealed class AsNoTrackingWithUpdateAnalyzer : DiagnosticAnalyzer
                     return false;
             }
 
+            // The last tracking directive applied wins — each AsTracking/AsNoTracking overwrites the
+            // query's QueryTrackingBehavior. Walking up the receiver chain, the first directive
+            // encountered is the one applied last, so it decides the effective mode:
+            // AsNoTracking().AsTracking() is tracked (AsTracking overrides) and must NOT fire, while
+            // AsTracking().AsNoTracking() is untracked and still fires.
             if (IsEfCoreAsNoTracking(inv.TargetMethod))
-                foundAsNoTracking = true;
+                return true;
+            if (IsEfCoreAsTracking(inv.TargetMethod))
+                return false;
 
             var next = inv.GetInvocationReceiver();
             if (next == null) break;
             current = next.UnwrapConversions();
         }
-        return foundAsNoTracking;
+        return false;
     }
 
     private static bool IsProjectionToConstructedObject(IInvocationOperation invocation)
@@ -315,6 +321,16 @@ public sealed class AsNoTrackingWithUpdateAnalyzer : DiagnosticAnalyzer
     private static bool IsEfCoreAsNoTracking(IMethodSymbol method)
     {
         if (method.Name != "AsNoTracking")
+            return false;
+
+        var namespaceName = method.ContainingNamespace?.ToString();
+        return namespaceName == "Microsoft.EntityFrameworkCore" ||
+               namespaceName?.StartsWith("Microsoft.EntityFrameworkCore.", System.StringComparison.Ordinal) == true;
+    }
+
+    private static bool IsEfCoreAsTracking(IMethodSymbol method)
+    {
+        if (method.Name != "AsTracking")
             return false;
 
         var namespaceName = method.ContainingNamespace?.ToString();

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzer.cs
@@ -318,12 +318,23 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
     {
         rootReceiver = null;
         var current = operation.UnwrapConversions();
-        var sawAsNoTracking = false;
+
+        // The last tracking directive applied wins (each AsTracking/AsNoTracking overwrites the
+        // query's QueryTrackingBehavior). Walking up the receiver chain, the first directive
+        // encountered is the one applied last, so it decides the effective mode: a trailing
+        // AsTracking() (AsNoTracking().AsTracking()) makes the entity tracked, so the mutation
+        // persists and LC044 must not fire. Keep walking to the root receiver regardless.
+        bool? effectiveNoTracking = null;
 
         while (current is IInvocationOperation inv)
         {
-            if (inv.TargetMethod.Name == "AsNoTracking")
-                sawAsNoTracking = true;
+            if (effectiveNoTracking is null)
+            {
+                if (inv.TargetMethod.Name == "AsNoTracking")
+                    effectiveNoTracking = true;
+                else if (inv.TargetMethod.Name == "AsTracking")
+                    effectiveNoTracking = false;
+            }
 
             var next = inv.GetInvocationReceiver();
             if (next == null)
@@ -335,7 +346,7 @@ public sealed class AsNoTrackingThenModifyAnalyzer : DiagnosticAnalyzer
             current = next.UnwrapConversions();
         }
 
-        if (!sawAsNoTracking) return false;
+        if (effectiveNoTracking != true) return false;
 
         if (rootReceiver == null) rootReceiver = current;
         return true;

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.5</Version>
+        <Version>5.5.6</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC037 now treats SqlQueryRaw&lt;T&gt; (the EF7+ scalar/keyless raw-SQL query on DbContext.Database) as a construction sink, closing an injection false negative: a SQL string built with string.Format, string.Concat, a StringBuilder, or an aliased local and passed to SqlQueryRaw was previously caught by neither LC037 (which omitted the sink) nor LC018 (which covers only its interpolation and concatenation). LC037's existing deferral keeps interpolation/concatenation owned by LC018, so there is no double-report.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC025 and LC044 no longer fire when a trailing AsTracking() restores tracking. Both rules scanned the query chain for AsNoTracking() but ignored a later AsTracking(), so AsNoTracking().AsTracking() followed by Update (LC025) or a property mutation + SaveChanges (LC044) was wrongly flagged — even though EF Core applies the last tracking directive, leaving the entity tracked so the write is correct. Both scans now honour the last directive: AsNoTracking().AsTracking() is quiet, while AsTracking().AsNoTracking() and a plain AsNoTracking() still report. (Found by an adversarial false-positive rescan.)</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateEdgeCasesTests.cs
@@ -30,9 +30,61 @@ namespace Microsoft.EntityFrameworkCore
     public static class EntityFrameworkQueryableExtensions
     {
         public static IQueryable<TSource> AsNoTracking<TSource>(this IQueryable<TSource> source) => source;
+        public static IQueryable<TSource> AsTracking<TSource>(this IQueryable<TSource> source) => source;
     }
 }
 ";
+
+    [Fact]
+    public async Task AsNoTrackingThenAsTracking_ShouldNotTrigger()
+    {
+        // AsTracking() overrides the earlier AsNoTracking() (last tracking directive wins), so the
+        // entity is tracked and Update is correct — LC025 must stay quiet.
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            foreach (var user in users.AsNoTracking().AsTracking().ToList())
+            {
+                users.Update(user);
+            }
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsTrackingThenAsNoTracking_ShouldTrigger()
+    {
+        // AsNoTracking() is applied last, so the entity is untracked and Update is the smell.
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(DbSet<User> users)
+        {
+            foreach (var user in users.AsTracking().AsNoTracking().ToList())
+            {
+                users.Update({|LC025:user|});
+            }
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
 
     [Fact]
     public async Task ForeachVariable_FromAsNoTrackingCollection_ShouldTrigger()

--- a/tests/LinqContraband.Tests/Analyzers/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifyAnalyzerTests.cs
@@ -45,6 +45,7 @@ namespace Microsoft.EntityFrameworkCore
     public static class EntityFrameworkQueryableExtensions
     {
         public static IQueryable<TSource> AsNoTracking<TSource>(this IQueryable<TSource> source) where TSource : class => source;
+        public static IQueryable<TSource> AsTracking<TSource>(this IQueryable<TSource> source) where TSource : class => source;
         public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken ct = default) => Task.FromResult(default(TSource));
         public static Task<TSource> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, bool>> predicate, CancellationToken ct = default) => Task.FromResult(default(TSource));
         public static Task<TSource> SingleOrDefaultAsync<TSource>(this IQueryable<TSource> source, CancellationToken ct = default) => Task.FromResult(default(TSource));
@@ -70,6 +71,51 @@ namespace Test
         public void M(TestCtx ctx)
         {
             var user = ctx.Users.AsNoTracking().FirstOrDefault(u => u.Id == 1);
+            {|LC044:user.Name|} = ""new"";
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsNoTrackingThenAsTracking_ThenMutate_ThenSave_DoesNotTrigger()
+    {
+        // AsTracking() overrides the earlier AsNoTracking() (last tracking directive wins), so the
+        // entity is tracked and the mutation DOES persist — LC044 must stay quiet.
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var user = ctx.Users.AsNoTracking().AsTracking().FirstOrDefault(u => u.Id == 1);
+            user.Name = ""new"";
+            ctx.SaveChanges();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task AsTrackingThenAsNoTracking_ThenMutate_ThenSave_Triggers()
+    {
+        // AsNoTracking() is applied last, so the entity is untracked and the mutation is silently lost.
+        var test = Preamble + EfCoreMock + @"
+namespace Test
+{
+    public class User { public int Id { get; set; } public string Name { get; set; } }
+    public class TestCtx : DbContext { public DbSet<User> Users { get; set; } }
+    public class C
+    {
+        public void M(TestCtx ctx)
+        {
+            var user = ctx.Users.AsTracking().AsNoTracking().FirstOrDefault(u => u.Id == 1);
             {|LC044:user.Name|} = ""new"";
             ctx.SaveChanges();
         }


### PR DESCRIPTION
## Summary

`LC025` and `LC044` both scan the query chain for `AsNoTracking()` but **ignored a later `AsTracking()`**. So these compiled, correct queries were wrongly flagged:

```csharp
db.Users.AsNoTracking().AsTracking().First();   // tracked! AsTracking overrides
```
- **LC025**: `Update()` on the above → false "AsNoTracking entity passed to Update".
- **LC044**: mutate a property + `SaveChanges()` → false "change will not persist".

EF Core applies the **last** tracking directive (each `AsTracking`/`AsNoTracking` overwrites `QueryTrackingBehavior`), so a trailing `AsTracking()` leaves the entity tracked and the write is correct.

## Fix

Both chain scans now honour the last directive: the **first directive encountered walking up the receiver chain** (= the one applied last) decides the effective mode. LC044's scan still walks to the root receiver for context resolution.

- `AsNoTracking().AsTracking()` → quiet (tracked).
- `AsTracking().AsNoTracking()` → still reports (untracked).
- plain `AsNoTracking()` → still reports.

## Tests

- Override + reverse-order regression tests for both rules; docs updated with last-directive-wins.
- Full suite green in Release: **901 passed**.

Found by an adversarial false-positive rescan.

## Release

Bumps to **5.5.6** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)