### PR TITLE
fix(LC039,LC040): treat ternary arms and try/catch as mutually exclusive (5.5.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.7] - 2026-06-04
+
+### Fixed
+- Stopped two false positives caused by unrecognized mutually-exclusive branch shapes. `LC040` (mixed tracking modes) now treats the two arms of a ternary (`readOnly ? db.Users.AsNoTracking().ToList() : db.Users.ToList()`) as mutually exclusive, just like `if`/`else` and `switch` — only one arm materializes, so the scope never mixes tracking modes. `LC039` (repeated SaveChanges) now treats a `SaveChanges` in a `try` block and one in a `catch` clause as mutually exclusive: the catch save runs only if the try save threw (and so never completed), making it a compensating/retry save rather than a batchable repeat (two different `catch` clauses are likewise exclusive). A materializer in a ternary's **condition** (LC040) and a `finally` save (LC039) are deliberately still counted, because they always run. Added ternary (LC040), try/catch (LC039), and a try/finally-still-fires guardrail (LC039) regression tests and documented both boundaries. (Found by an adversarial false-positive rescan.)
+
 ## [5.5.6] - 2026-06-04
 
 ### Fixed

--- a/docs/LC039_NestedSaveChanges.md
+++ b/docs/LC039_NestedSaveChanges.md
@@ -19,6 +19,6 @@ db.SaveChanges();
 ### Severity: `Info`
 
 ### Notes
-The rule suppresses obvious EF Core transaction-boundary cases, repeated saves inside the same explicit transaction `using` block, repeated saves inside a C# 8+ `using`/`await using` local declaration of an EF Core transaction, mutually exclusive `if`/`else` branches, and mutually exclusive `switch` sections, then reports on a per-context basis within the same executable root.
+The rule suppresses obvious EF Core transaction-boundary cases, repeated saves inside the same explicit transaction `using` block, repeated saves inside a C# 8+ `using`/`await using` local declaration of an EF Core transaction, mutually exclusive `if`/`else` branches, mutually exclusive `switch` sections, and a `try` block versus a `catch` clause (a `catch` save is a compensating/retry save, not a batchable repeat — but a `finally` save still counts because it always runs), then reports on a per-context basis within the same executable root.
 
 Only EF Core transaction APIs on `DatabaseFacade` or `IDbContextTransaction`-style receivers count as boundaries. Unrelated helper methods named `Commit`, `Rollback`, or similar do not suppress the diagnostic. A `using` declaration of an unrelated disposable (for example a `MemoryStream`) does not suppress the diagnostic, and a transaction `using` declaration introduced after the first save does not retroactively cover saves that preceded it.

--- a/docs/LC040_MixedTrackingAndNoTracking.md
+++ b/docs/LC040_MixedTrackingAndNoTracking.md
@@ -25,4 +25,4 @@ Only EF Core `EntityFrameworkQueryableExtensions.AsNoTracking`, `AsNoTrackingWit
 
 Straight-line local query aliases are resolved at the materialization point. A local reassigned from tracked to no-tracking queries on the same context can report, while a reassignment from a different context or inside conditional control flow stays quiet.
 
-Mutually exclusive `if`/`else` branches and `switch` sections are not treated as mixed tracking evidence by themselves. Later materialization still compares against every reachable earlier tracking mode so split branches followed by shared work can be reported when one path really mixes modes.
+Mutually exclusive `if`/`else` branches, `switch` sections, and ternary (`cond ? a : b`) arms are not treated as mixed tracking evidence by themselves. Later materialization still compares against every reachable earlier tracking mode so split branches followed by shared work can be reported when one path really mixes modes.

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC039_NestedSaveChanges/NestedSaveChangesBoundaryAnalysis.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC039_NestedSaveChanges/NestedSaveChangesBoundaryAnalysis.cs
@@ -56,7 +56,44 @@ public sealed partial class NestedSaveChangesAnalyzer
                 }
             }
 
+            // A SaveChanges in a try block and one in a catch clause are mutually exclusive: the
+            // catch body only runs if the try threw, in which case the try's SaveChanges never
+            // completed — this is a compensating/retry save, not a batchable repeat. Two different
+            // catch clauses are likewise exclusive. A `finally` save is NOT exclusive (finally always
+            // runs), so GetContainingTryBranch deliberately returns null for the finally block.
+            foreach (var tryStatement in left.AncestorsAndSelf().OfType<TryStatementSyntax>())
+            {
+                if (!tryStatement.Span.Contains(right.SpanStart))
+                    continue;
+
+                var leftTryBranch = GetContainingTryBranch(tryStatement, left);
+                var rightTryBranch = GetContainingTryBranch(tryStatement, right);
+
+                if (leftTryBranch != null &&
+                    rightTryBranch != null &&
+                    leftTryBranch != rightTryBranch)
+                {
+                    return true;
+                }
+            }
+
             return false;
+        }
+
+        private static SyntaxNode? GetContainingTryBranch(TryStatementSyntax tryStatement, SyntaxNode node)
+        {
+            if (tryStatement.Block.Span.Contains(node.SpanStart))
+                return tryStatement.Block;
+
+            foreach (var catchClause in tryStatement.Catches)
+            {
+                if (catchClause.Block.Span.Contains(node.SpanStart))
+                    return catchClause;
+            }
+
+            // A node in the finally block (or in a nested try handled by an outer iteration) is not
+            // treated as a mutually exclusive branch: finally always runs.
+            return null;
         }
 
         private static bool AreInsideSameTransactionUsing(SyntaxNode left, SyntaxNode right, int[] transactionBoundaries)

--- a/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingBranchAnalysis.cs
+++ b/src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingBranchAnalysis.cs
@@ -42,7 +42,38 @@ public sealed partial class MixedTrackingAndNoTrackingAnalyzer
                 }
             }
 
+            // A ternary's two arms are mutually exclusive just like if/else: only one materializes
+            // at runtime, so `cond ? db.Users.AsNoTracking().ToList() : db.Users.ToList()` never
+            // mixes tracking modes. A materializer in the condition (which always runs) returns null
+            // from GetContainingTernaryArm and is intentionally not treated as exclusive.
+            foreach (var ternary in left.AncestorsAndSelf().OfType<ConditionalExpressionSyntax>())
+            {
+                if (!ternary.Span.Contains(right.SpanStart))
+                    continue;
+
+                var leftArm = GetContainingTernaryArm(ternary, left);
+                var rightArm = GetContainingTernaryArm(ternary, right);
+
+                if (leftArm != null &&
+                    rightArm != null &&
+                    leftArm != rightArm)
+                {
+                    return true;
+                }
+            }
+
             return false;
+        }
+
+        private static ExpressionSyntax? GetContainingTernaryArm(ConditionalExpressionSyntax ternary, SyntaxNode node)
+        {
+            if (ternary.WhenTrue.Span.Contains(node.SpanStart))
+                return ternary.WhenTrue;
+
+            if (ternary.WhenFalse.Span.Contains(node.SpanStart))
+                return ternary.WhenFalse;
+
+            return null;
         }
 
         private static StatementSyntax? GetContainingBranch(IfStatementSyntax ifStatement, SyntaxNode node)

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.6</Version>
+        <Version>5.5.7</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC025 and LC044 no longer fire when a trailing AsTracking() restores tracking. Both rules scanned the query chain for AsNoTracking() but ignored a later AsTracking(), so AsNoTracking().AsTracking() followed by Update (LC025) or a property mutation + SaveChanges (LC044) was wrongly flagged — even though EF Core applies the last tracking directive, leaving the entity tracked so the write is correct. Both scans now honour the last directive: AsNoTracking().AsTracking() is quiet, while AsTracking().AsNoTracking() and a plain AsNoTracking() still report. (Found by an adversarial false-positive rescan.)</PackageReleaseNotes>
+        <PackageReleaseNotes>LC040 and LC039 each shed a false positive from an unrecognized mutually-exclusive branch shape. LC040 (mixed tracking modes) now treats a ternary's two arms (cond ? AsNoTracking().ToList() : ToList()) as mutually exclusive, like if/else and switch. LC039 (repeated SaveChanges) now treats a save in a try block versus a save in a catch clause as mutually exclusive — the catch save is a compensating/retry save, not a batchable repeat. A ternary condition (LC040) and a finally save (LC039) still count, because they always run. (Found by an adversarial false-positive rescan.)</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC039_NestedSaveChanges/NestedSaveChangesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC039_NestedSaveChanges/NestedSaveChangesTests.cs
@@ -270,6 +270,58 @@ class Program
     }
 
     [Fact]
+    public async Task TryCatchCompensatingSaveChanges_DoNotTrigger()
+    {
+        // The catch save runs only if the try save threw (and so never completed): the two are
+        // mutually exclusive — a compensating/retry save, not a batchable repeat.
+        var test = EFCoreMock + Types + @"
+
+class Program
+{
+    void Run()
+    {
+        var db = new TestApp.AppDbContext();
+        try
+        {
+            db.SaveChanges();
+        }
+        catch
+        {
+            db.SaveChanges();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TryFinallySaveChanges_Triggers()
+    {
+        // A finally save ALWAYS runs, so it is NOT mutually exclusive with the try save — still a
+        // repeated save on the same context (guards against over-suppressing try/finally).
+        var test = EFCoreMock + Types + @"
+
+class Program
+{
+    void Run()
+    {
+        var db = new TestApp.AppDbContext();
+        try
+        {
+            db.SaveChanges();
+        }
+        finally
+        {
+            {|LC039:db.SaveChanges()|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task ElseIfSaveChangesBranches_DoNotTrigger()
     {
         var test = EFCoreMock + Types + @"

--- a/tests/LinqContraband.Tests/Analyzers/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingTests.cs
@@ -88,6 +88,26 @@ class Program
     }
 
     [Fact]
+    public async Task TernaryTrackedAndNoTrackingArms_DoNotTrigger()
+    {
+        // The two ternary arms are mutually exclusive — only one materializes at runtime — so no
+        // scope actually mixes tracking modes (matches the if/else contract).
+        var test = EFCoreMock + Types + @"
+
+class Program
+{
+    void Run(TestApp.AppDbContext db, bool readOnly)
+    {
+        var list = readOnly
+            ? db.Users.AsNoTracking().ToList()
+            : db.Users.ToList();
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task AsNoTrackingWithIdentityResolution_CountsAsNoTracking()
     {
         var test = EFCoreMock + Types + @"


### PR DESCRIPTION
## Summary

Two false positives from branch shapes that `AreMutuallyExclusiveBranches` didn't recognize:

- **LC040** (mixed tracking modes) flagged a ternary whose arms each materialize in a different mode:
  ```csharp
  var list = readOnly ? db.Users.AsNoTracking().ToList() : db.Users.ToList();  // FP
  ```
  Only one arm ever materializes, so the scope never mixes modes — exactly like the `if`/`else` form the rule already exempts.

- **LC039** (repeated SaveChanges) flagged a compensating/retry save:
  ```csharp
  try { db.SaveChanges(); } catch { db.SaveChanges(); }  // FP
  ```
  The catch save runs only if the try save threw (so it never completed) — not a batchable repeat.

## Fix

`AreMutuallyExclusiveBranches` now also recognizes:
- **LC040**: ternary `WhenTrue` vs `WhenFalse` arms.
- **LC039**: `try` block vs `catch` clause (and two different `catch` clauses).

Deliberately still counted (they always run): a materializer in a ternary's **condition** (LC040) and a **`finally`** save (LC039).

## Tests

- LC040 ternary-arms negative; LC039 try/catch negative + a **try/finally-still-fires** guardrail.
- Docs updated for both boundaries.
- Full suite green in Release: **904 passed**.

Found by an adversarial false-positive rescan.

## Release

Bumps to **5.5.7** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)