### PR TITLE
fix(LC007): detect N+1 in deconstruction foreach (5.5.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.8] - 2026-06-04
+
+### Fixed
+- Closed an `LC007` false negative on the deconstruction `foreach` shape. `foreach (var (a, b) in pairs) { db.Users.Find(a); }` is a `ForEachVariableStatementSyntax` — a distinct syntax node from a regular `foreach` (`ForEachStatementSyntax`) — so the per-iteration check (and the loop-kind label) skipped it, and an N+1 inside a tuple/deconstruction loop was silently missed even though the fluent equivalent fired. The per-iteration check and the loop-kind helper now match the shared `CommonForEachStatementSyntax` base, covering both the regular and deconstruction `foreach` shapes (and their `await` forms). Added a deconstruction-foreach regression test. (Found by an adversarial false-negative rescan.)
+
 ## [5.5.7] - 2026-06-04
 
 ### Fixed

--- a/docs/LC007_NPlusOneLooper.md
+++ b/docs/LC007_NPlusOneLooper.md
@@ -6,7 +6,7 @@ Catch EF Core database execution that is provably performed once per loop iterat
 ## What LC007 Reports
 
 ### 1. Direct EF lookups inside loops
-`Find` and `FindAsync` on `DbSet<T>` are reported when they execute inside `for`, `foreach`, `await foreach`, `while`, or `do` loops.
+`Find` and `FindAsync` on `DbSet<T>` are reported when they execute inside `for`, `foreach` (including the deconstruction form `foreach (var (a, b) in …)`), `await foreach`, `while`, or `do` loops.
 
 ```csharp
 foreach (var id in ids)

--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalysis.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC007_NPlusOneLooper/NPlusOneLooperAnalysis.cs
@@ -117,7 +117,9 @@ internal static class NPlusOneLooperAnalysis
 
         return loop.Syntax switch
         {
-            ForEachStatementSyntax forEach => forEach.Statement.Span.Contains(spanStart),
+            // CommonForEachStatementSyntax covers both the regular `foreach (var x in xs)` and the
+            // deconstruction `foreach (var (a, b) in xs)` (ForEachVariableStatementSyntax) shapes.
+            CommonForEachStatementSyntax forEach => forEach.Statement.Span.Contains(spanStart),
             ForStatementSyntax forStatement =>
                 forStatement.Statement.Span.Contains(spanStart) ||
                 (forStatement.Condition?.Span.Contains(spanStart) == true) ||

--- a/src/LinqContraband/Extensions/OperationTraversalExtensions.cs
+++ b/src/LinqContraband/Extensions/OperationTraversalExtensions.cs
@@ -49,8 +49,8 @@ public static partial class AnalysisExtensions
     {
         return loop.Syntax switch
         {
-            ForEachStatementSyntax forEach when forEach.AwaitKeyword != default => "await foreach",
-            ForEachStatementSyntax => "foreach",
+            CommonForEachStatementSyntax forEach when forEach.AwaitKeyword != default => "await foreach",
+            CommonForEachStatementSyntax => "foreach",
             ForStatementSyntax => "for",
             WhileStatementSyntax => "while",
             DoStatementSyntax => "do",

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.7</Version>
+        <Version>5.5.8</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC040 and LC039 each shed a false positive from an unrecognized mutually-exclusive branch shape. LC040 (mixed tracking modes) now treats a ternary's two arms (cond ? AsNoTracking().ToList() : ToList()) as mutually exclusive, like if/else and switch. LC039 (repeated SaveChanges) now treats a save in a try block versus a save in a catch clause as mutually exclusive — the catch save is a compensating/retry save, not a batchable repeat. A ternary condition (LC040) and a finally save (LC039) still count, because they always run. (Found by an adversarial false-positive rescan.)</PackageReleaseNotes>
+        <PackageReleaseNotes>LC007 now flags an N+1 inside a deconstruction foreach — foreach (var (a, b) in pairs) { db.Users.Find(a); }. That shape is a distinct syntax node (ForEachVariableStatementSyntax) from a regular foreach, so the per-iteration check previously skipped it even though the fluent equivalent fired. The check (and the loop-kind label) now match the shared CommonForEachStatementSyntax base, covering both the regular and deconstruction foreach shapes and their await forms. (Found by an adversarial false-negative rescan.)</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC007_NPlusOneLooper/NPlusOneLooperTests.cs
@@ -151,6 +151,31 @@ class Program
     }
 
     [Fact]
+    public async Task Find_InDeconstructionForeach_TriggersDiagnostic()
+    {
+        // A deconstruction foreach (foreach (var (a, b) in xs)) is a ForEachVariableStatementSyntax —
+        // a distinct node from a regular foreach — so the per-iteration check must still recognise it.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var pairs = new List<(int, int)>();
+
+        foreach (var (a, b) in pairs)
+        {
+            var user = {|#0:db.Users.Find(a)|};
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = VerifyCS.Diagnostic("LC007").WithLocation(0).WithArguments("Find");
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task FindAsync_InForeachLoop_TriggersDiagnostic()
     {
         var test = Usings + @"


### PR DESCRIPTION
## Summary

`LC007` missed an N+1 written with a **deconstruction `foreach`**:

```csharp
foreach (var (a, b) in pairs)
{
    var user = db.Users.Find(a);   // N+1 — was NOT flagged
}
```

A deconstruction `foreach` is a `ForEachVariableStatementSyntax`, a distinct node from a regular `foreach` (`ForEachStatementSyntax`). The per-iteration check (`IsPerIterationInvocation`) and the loop-kind label (`GetLoopKind`) handled only the latter, so the loop body was never analyzed — even though the fluent equivalent `pairs.Where(...)...` fired.

## Fix

Both now match the shared base `CommonForEachStatementSyntax`, which has the `.Statement` and `.AwaitKeyword` members — covering the regular and deconstruction `foreach` shapes (and their `await` forms) uniformly.

## Tests

- Deconstruction-`foreach` regression test.
- Full suite green in Release: **905 passed** (the `GetLoopKind` change is shared; no regressions).

Found by an adversarial false-negative rescan.

## Release

Bumps to **5.5.8** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)