### PR TITLE
fix(LC035): recognise unconditional base filter with conditional narrowing (5.5.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.9] - 2026-06-04
+
+### Fixed
+- Stopped `LC035` from reporting the common "base filter + optional extra narrowing" shape. `var q = db.Users.Where(...); if (flag) q = q.Where(...); q.ExecuteDelete();` was flagged because the local-filter check inspected only the **latest** assignment before the bulk call — the conditional `q = q.Where(...)` inside the `if` — and bailed to "no filter" because it sat inside a branch, ignoring that the unconditional base already had a `Where` (a false positive: every path is filtered). The check now resolves the latest **unconditional** base assignment (which every control-flow path passes through) and treats the local as filtered only when that base **and** every later **conditional** reassignment are filtered. A conditional path that reassigns to an unfiltered query (`if (flag) q = db.Set<User>();`) still reports, as does an unfiltered base. Added the base-filter-plus-narrowing no-diagnostic test and an unfiltered-conditional-reassignment guardrail. (Found by an adversarial false-positive rescan; also closes the audit's LC035 filtered-local/reassignment follow-up.)
+
 ## [5.5.8] - 2026-06-04
 
 ### Fixed

--- a/docs/LC035_MissingWhereBeforeExecuteDeleteUpdate.md
+++ b/docs/LC035_MissingWhereBeforeExecuteDeleteUpdate.md
@@ -26,6 +26,14 @@ db.Users.Where(u => u.Age < 18).ExecuteDelete();
 ### Severity: `Info`
 
 ### Notes
-This rule is advisory only. There is no automatic fixer because adding a predicate speculatively would be unsafe. LC035 recognizes semantic LINQ filters in the direct fluent chain, query-syntax `where` clauses, simple local query initializers such as `var filtered = db.Users.Where(...); filtered.ExecuteDelete();`, and straight-line local reassignments such as `query = query.Where(...);`. Project-local methods merely named `Where` do not count as a proven filter, and conditional reassignments remain conservative.
+This rule is advisory only. There is no automatic fixer because adding a predicate speculatively would be unsafe. LC035 recognizes semantic LINQ filters in the direct fluent chain, query-syntax `where` clauses, simple local query initializers such as `var filtered = db.Users.Where(...); filtered.ExecuteDelete();`, and straight-line local reassignments such as `query = query.Where(...);`. A local with a **conditional** reassignment is treated as filtered only when the unconditional base assignment is filtered **and** every later conditional reassignment also adds a filter — so the common "base filter + optional extra narrowing" shape stays quiet:
+
+```csharp
+var q = db.Users.Where(u => u.Id > 10);
+if (flag) q = q.Where(u => u.Id < 100);   // every path is filtered
+q.ExecuteDelete();                         // not reported
+```
+
+while a conditional path that reassigns to an unfiltered query still reports. Project-local methods merely named `Where` do not count as a proven filter.
 
 LC035 only binds EF Core bulk execute methods from the real `Microsoft.EntityFrameworkCore` namespace. Same-name helpers in project-local or lookalike namespaces stay quiet.

--- a/src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/BulkOperationsAndSetBasedWrites/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateAnalyzer.cs
@@ -133,40 +133,44 @@ public sealed class MissingWhereBeforeExecuteDeleteUpdateAnalyzer : DiagnosticAn
         if (executableRoot == null)
             return false;
 
-        if (!TryGetLatestStraightLineAssignedValueBefore(
-                executableRoot,
-                localReference,
-                cancellationToken,
-                out var assignedValue))
-        {
-            return false;
-        }
-
-        return HasWhereInChain(assignedValue, cancellationToken, visitedLocals);
-    }
-
-    private static bool TryGetLatestStraightLineAssignedValueBefore(
-        IOperation executableRoot,
-        ILocalReferenceOperation localReference,
-        CancellationToken cancellationToken,
-        out IOperation assignedValue)
-    {
-        assignedValue = null!;
-        LocalAssignment? latest = null;
+        // Split the assignments before this use into the latest unconditional one — the "base" every
+        // control-flow path passes through — and the conditional reassignments after it, each taken
+        // only on some paths. The local is filtered on EVERY path iff the unconditional base is
+        // filtered AND every later conditional reassignment is also filtered. This stops a false
+        // positive on the common "base filter + optional extra narrowing" shape
+        //   var q = db.Set<User>().Where(...); if (flag) q = q.Where(...); q.ExecuteDelete();
+        // while still reporting when a conditional path reassigns to an UNfiltered query.
+        LocalAssignment? latestUnconditional = null;
+        var conditionalReassignments = new List<LocalAssignment>();
 
         foreach (var assignment in LocalAssignmentCache.GetAssignments(executableRoot, localReference.Local, cancellationToken))
         {
             if (assignment.SpanStart >= localReference.Syntax.SpanStart)
                 continue;
 
-            if (latest == null || assignment.SpanStart > latest.Value.SpanStart)
-                latest = assignment;
+            if (IsControlFlowConditionalAssignment(assignment.Value.Syntax))
+                conditionalReassignments.Add(assignment);
+            else if (latestUnconditional == null || assignment.SpanStart > latestUnconditional.Value.SpanStart)
+                latestUnconditional = assignment;
         }
 
-        if (latest == null || IsControlFlowConditionalAssignment(latest.Value.Value.Syntax))
+        if (latestUnconditional == null)
             return false;
 
-        assignedValue = latest.Value.Value.UnwrapConversions();
+        if (!HasWhereInChain(latestUnconditional.Value.Value.UnwrapConversions(), cancellationToken, visitedLocals))
+            return false;
+
+        foreach (var conditional in conditionalReassignments)
+        {
+            // Only reassignments after the dominating unconditional base can change the value on a path;
+            // earlier conditional assignments are overwritten by the base.
+            if (conditional.SpanStart <= latestUnconditional.Value.SpanStart)
+                continue;
+
+            if (!HasWhereInChain(conditional.Value.UnwrapConversions(), cancellationToken, visitedLocals))
+                return false;
+        }
+
         return true;
     }
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.8</Version>
+        <Version>5.5.9</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC007 now flags an N+1 inside a deconstruction foreach — foreach (var (a, b) in pairs) { db.Users.Find(a); }. That shape is a distinct syntax node (ForEachVariableStatementSyntax) from a regular foreach, so the per-iteration check previously skipped it even though the fluent equivalent fired. The check (and the loop-kind label) now match the shared CommonForEachStatementSyntax base, covering both the regular and deconstruction foreach shapes and their await forms. (Found by an adversarial false-negative rescan.)</PackageReleaseNotes>
+        <PackageReleaseNotes>LC035 no longer reports the common "base filter + optional extra narrowing" shape: var q = db.Users.Where(...); if (flag) q = q.Where(...); q.ExecuteDelete(). It previously inspected only the latest assignment (the conditional one inside the if) and bailed to no-filter, ignoring the filtered unconditional base — a false positive, since every path is filtered. The check now resolves the unconditional base assignment and requires it plus every later conditional reassignment to be filtered; a conditional path that reassigns to an unfiltered query still reports. (Found by an adversarial false-positive rescan.)</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateTests.cs
@@ -80,6 +80,60 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task ExecuteDelete_UnconditionalFilterThenOptionalNarrowing_ShouldNotTrigger()
+    {
+        // The base query is filtered on every path; the if only adds a further Where, so the delete
+        // can never affect the whole table.
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class User { public int Id { get; set; } }
+
+    public sealed class Program
+    {
+        public int Run(DbContext db, bool flag)
+        {
+            var q = db.Set<User>().Where(u => u.Id > 10);
+            if (flag)
+            {
+                q = q.Where(u => u.Id < 100);
+            }
+            return q.ExecuteDelete();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteDelete_ConditionalReassignToUnfiltered_ShouldTrigger()
+    {
+        // The if path reassigns q to an UNfiltered query, so on that path the delete affects the whole
+        // table — must still report (the unconditional base being filtered is not enough).
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class User { public int Id { get; set; } }
+
+    public sealed class Program
+    {
+        public int Run(DbContext db, bool flag)
+        {
+            var q = db.Set<User>().Where(u => u.Id > 10);
+            if (flag)
+            {
+                q = db.Set<User>();
+            }
+            return {|LC035:q.ExecuteDelete()|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task ExecuteDelete_WithWhere_ShouldNotTrigger()
     {
         var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"


### PR DESCRIPTION
## Summary

`LC035` flagged the common "base filter + optional extra narrowing" pattern:

```csharp
var q = db.Users.Where(u => u.Id > 10);
if (flag) q = q.Where(u => u.Id < 100);
q.ExecuteDelete();   // FP — every path is filtered
```

The local-filter check (`HasWhereInLocalInitializer`) inspected only the **latest** assignment before the bulk call — the conditional `q = q.Where(...)` inside the `if` — and bailed to "no filter" because it sat inside a branch, ignoring that the unconditional base already had a `Where`.

## Fix

The check now resolves the latest **unconditional** base assignment (which every control-flow path passes through) and treats the local as filtered only when that base **and** every later **conditional** reassignment are filtered. This is sound:

- `if (flag) q = db.Set<User>();` (reassign to **unfiltered**) → still reports (that path is unfiltered).
- unfiltered base → still reports.

## Tests

- Base-filter-plus-narrowing → no diagnostic; conditional-reassign-to-unfiltered → still reports.
- Full suite green in Release: **907 passed**.

Found by an adversarial false-positive rescan; also closes the audit's LC035 filtered-local/reassignment follow-up.

## Release

Bumps to **5.5.9** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)