### PR TITLE
fix(LC001): flag local methods in Sum/Average/Min/Max selectors (5.5.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.11] - 2026-06-04
+
+### Fixed
+- Closed an `LC001` false negative on aggregate selectors. A local (non-translatable) method inside a `Sum`/`Average`/`Min`/`Max` selector — `db.Users.Sum(u => Weight(u.Age))` — was not flagged because those four operators were missing from the rule's translation-critical method set, even though `Queryable.Sum`/`Average`/`Min`/`Max(source, selector)` translate to SQL `SUM`/`AVG`/`MIN`/`MAX(expr)` and a source-defined method in the selector forces client evaluation (or throws) — the same smell LC001 already catches in `Where`/`OrderBy`/`GroupBy`/predicates. The four aggregate operators are now in the set. Added a parameterized regression test across all four. (Found by a second adversarial false-negative rescan.)
+
 ## [5.5.10] - 2026-06-04
 
 ### Fixed

--- a/docs/LC001_LocalMethod.md
+++ b/docs/LC001_LocalMethod.md
@@ -34,7 +34,7 @@ var users = db.Users.Where(u => u.DateOfBirth <= minDob).ToList();
 1.  **Target**: Invocations within a lambda expression.
 2.  **Context**: Ensure the lambda is an argument to an `IQueryable` method.
 3.  **Dependency**: Require the method call to depend on the query lambda parameter.
-4.  **Query position**: Report only translation-critical positions such as filters, ordering, joins, grouping keys, and predicates.
+4.  **Query position**: Report only translation-critical positions such as filters, ordering, joins, grouping keys, predicates, and aggregate selectors (`Sum`/`Average`/`Min`/`Max`).
 5.  **Check**: Skip known framework methods, trusted provider methods, and methods explicitly marked with
     `[DbFunction]` or `[Projectable]`.
 6.  **Report**: If none of those exemptions apply, flag the invocation.

--- a/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/QueryShapeAndTranslation/LC001_LocalMethod/LocalMethodAnalyzer.cs
@@ -51,7 +51,14 @@ public sealed class LocalMethodAnalyzer : DiagnosticAnalyzer
         "Last",
         "LastOrDefault",
         "SkipWhile",
-        "TakeWhile");
+        "TakeWhile",
+        // Aggregate operators with a selector: Queryable.Sum/Average/Min/Max(source, selector)
+        // translate to SQL SUM/AVG/MIN/MAX(expr); a local/source method inside the selector cannot
+        // translate and forces client evaluation (or throws), the exact LC001 smell.
+        "Sum",
+        "Average",
+        "Min",
+        "Max");
 
     private static readonly DiagnosticDescriptor Rule = new(
         DiagnosticId,

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.10</Version>
+        <Version>5.5.11</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Two false negatives closed by the adversarial rescan. LC004 (IQueryable leak) now follows a C# query expression (from u in users where ... select ...) back to its source parameter — query-syntax enumeration of an IEnumerable parameter was silently exempt while the fluent equivalent fired, because a query expression surfaces as an ITranslatedQueryOperation the parameter-source walk did not unwrap. LC044 (AsNoTracking entity mutated then SaveChanges) now treats a compound assignment (entity.Prop += 1) and an increment/decrement (entity.Prop++) as a mutation, not only a plain assignment — each is silently lost on an untracked entity. (Found by an adversarial false-negative rescan.)</PackageReleaseNotes>
+        <PackageReleaseNotes>LC001 now flags a local (non-translatable) method inside a Sum/Average/Min/Max selector — db.Users.Sum(u => Weight(u.Age)). These aggregate operators translate to SQL SUM/AVG/MIN/MAX, so a source-defined method in the selector forces client evaluation or throws, the same client-eval smell LC001 already catches in Where/OrderBy/etc.; the four aggregate operators were simply missing from the translation-critical set. (Found by a second adversarial false-negative rescan.)</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC001_LocalMethod/LocalMethodSmugglerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC001_LocalMethod/LocalMethodSmugglerTests.cs
@@ -51,6 +51,31 @@ class Program
         await VerifyCS.VerifyAnalyzerAsync(test, expected);
     }
 
+    [Theory]
+    [InlineData("Sum")]
+    [InlineData("Average")]
+    [InlineData("Min")]
+    [InlineData("Max")]
+    public async Task TestCrime_LocalMethodInAggregateSelector_ShouldTriggerLC001(string aggregate)
+    {
+        // Queryable.Sum/Average/Min/Max(source, selector) translate to SQL aggregates; a local method
+        // in the selector cannot translate (client eval / throws) — the LC001 smell.
+        var test = (Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new DbContext();
+        var result = db.Users.AGG(u => {|LC001:Weight(u.Age)|});
+    }
+
+    int Weight(int age) => age * 2;
+}
+" + MockNamespace).Replace("AGG", aggregate);
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
     [Fact]
     public async Task TestInnocent_PropertyAccess_ShouldNotTrigger()
     {


### PR DESCRIPTION
## Summary

`LC001` (local method in `IQueryable`) missed a local method inside an **aggregate selector**:

```csharp
db.Users.Sum(u => Weight(u.Age));   // Weight is a source method — was NOT flagged
int Weight(int age) => age * 2;
```

`Queryable.Sum`/`Average`/`Min`/`Max(source, selector)` translate to SQL `SUM`/`AVG`/`MIN`/`MAX(expr)`, so a source-defined method in the selector forces client evaluation (or throws at runtime) — exactly the smell LC001 catches in `Where`/`OrderBy`/`GroupBy`/predicates. The four aggregate operators were just absent from the `TranslationCriticalQueryMethods` set.

## Fix

Add `Sum`, `Average`, `Min`, `Max` to the set. No FP risk: the rule still only fires when the selector contains a source method (`Sum(u => u.Age)` stays quiet).

## Tests

- Parameterized `[Theory]` across `Sum`/`Average`/`Min`/`Max`.
- Full suite green in Release: **914 passed**.

Found by a second adversarial false-negative rescan.

## Release

Bumps to **5.5.11** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)