### PR TITLE
fix(LC041): exempt primary-key lookup via a Where step (5.5.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.12] - 2026-06-04
+
+### Fixed
+- Stopped `LC041` from flagging a primary-key lookup written as `users.Where(x => x.Id == id).First()`. The single-entity over-fetch exemption for a key lookup only inspected the **terminal** operator's inline predicate (`First(x => x.Id == id)`), so the equivalent form with the key predicate on an upstream `Where` step — one of the most common EF read patterns — was reported even though it is the same single-row-by-key fetch. The exemption now also walks the receiver chain for a `Where` whose predicate is a primary-key equality. A non-key `Where` (e.g. `Where(x => x.IsActive)`) is not exempt and still reports. Added a `Where`-step PK no-trigger test and a non-key-`Where` still-fires guardrail. (Found by a second adversarial false-positive rescan; the rarer hoisted-`Expression`-predicate form remains a documented follow-up.)
+
 ## [5.5.11] - 2026-06-04
 
 ### Fixed

--- a/docs/LC041_SingleEntityScalarProjection.md
+++ b/docs/LC041_SingleEntityScalarProjection.md
@@ -32,4 +32,6 @@ Console.WriteLine(user);
 ### Notes
 The analyzer reports only when a `var` local is consumed through one scalar property read in the same executable scope. It stays silent when the entity escapes, multiple properties are read, or the property is written.
 
+A primary-key lookup is exempt: `users.First(x => x.Id == id)` and the equivalent `users.Where(x => x.Id == id).First()` are both treated as a single-row-by-key fetch (not an over-fetch), so neither is reported regardless of how the key predicate is written. A non-key `Where` (e.g. `Where(x => x.IsActive)`) is not exempt and still reports.
+
 The fixer is intentionally narrower than the analyzer. It appears for `First`, `FirstAsync`, `Single`, and `SingleAsync` because those rewrites preserve no-row behavior. It does not rewrite `FirstOrDefault`, `FirstOrDefaultAsync`, `SingleOrDefault`, or `SingleOrDefaultAsync`; projecting before those calls can turn an entity-null property access into a scalar default/null value instead of preserving the original runtime behavior.

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionAnalyzer.cs
@@ -91,8 +91,7 @@ public sealed partial class SingleEntityScalarProjectionAnalyzer : DiagnosticAna
         if (HasSelectInChain(receiver))
             return;
 
-        if (TryGetPredicateLambda(invocation, out var lambda) &&
-            IsPrimaryKeyLookup(lambda, entityType))
+        if (IsPrimaryKeyLookupInChain(invocation, receiver, entityType))
         {
             return;
         }

--- a/src/LinqContraband/Analyzers/MaterializationAndProjection/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionQueryAnalysis.cs
+++ b/src/LinqContraband/Analyzers/MaterializationAndProjection/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionQueryAnalysis.cs
@@ -108,6 +108,44 @@ public sealed partial class SingleEntityScalarProjectionAnalyzer
         return false;
     }
 
+    // A primary-key lookup is exempt whether the key predicate sits on the terminal operator
+    // (First(x => x.Id == id)) or on a Where step in the receiver chain
+    // (Where(x => x.Id == id).First()) — the two are the same single-row-by-key fetch, so flagging
+    // only the terminal form is a false positive on one of the most common EF read patterns.
+    private static bool IsPrimaryKeyLookupInChain(IInvocationOperation terminal, IOperation receiver, ITypeSymbol entityType)
+    {
+        if (TryGetPredicateLambda(terminal, out var terminalLambda) &&
+            IsPrimaryKeyLookup(terminalLambda, entityType))
+        {
+            return true;
+        }
+
+        var current = receiver;
+        while (current != null)
+        {
+            current = current.UnwrapConversions();
+            if (current is not IInvocationOperation invocation)
+                break;
+
+            if (invocation.TargetMethod.Name == "Where" &&
+                TryGetPredicateLambda(invocation, out var whereLambda) &&
+                IsPrimaryKeyLookup(whereLambda, entityType))
+            {
+                return true;
+            }
+
+            if (QuerySteps.Contains(invocation.TargetMethod.Name))
+            {
+                current = invocation.GetInvocationReceiver();
+                continue;
+            }
+
+            break;
+        }
+
+        return false;
+    }
+
     private static bool IsPrimaryKeyLookup(IAnonymousFunctionOperation lambda, ITypeSymbol entityType)
     {
         var primaryKey = entityType.TryFindPrimaryKey();

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.11</Version>
+        <Version>5.5.12</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC001 now flags a local (non-translatable) method inside a Sum/Average/Min/Max selector — db.Users.Sum(u => Weight(u.Age)). These aggregate operators translate to SQL SUM/AVG/MIN/MAX, so a source-defined method in the selector forces client evaluation or throws, the same client-eval smell LC001 already catches in Where/OrderBy/etc.; the four aggregate operators were simply missing from the translation-critical set. (Found by a second adversarial false-negative rescan.)</PackageReleaseNotes>
+        <PackageReleaseNotes>LC041 no longer flags a primary-key lookup written with the key predicate on a Where step before First (the same single-row-by-key fetch as First with the predicate inline) — one of the most common EF read patterns. The key-lookup exemption previously inspected only the terminal operator's inline predicate; it now also walks the receiver chain for a Where whose predicate is a primary-key equality. A non-key Where still reports. (Found by a second adversarial false-positive rescan.)</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionTests.cs
@@ -270,6 +270,61 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task PrimaryKeyLookupViaWhereStep_ShouldNotTrigger()
+    {
+        // Where(x => x.Id == id).First() is the same single-row-by-key fetch as First(x => x.Id == id),
+        // which is already exempt — the PK guard must inspect the Where step in the chain too.
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfCoreMock + @"
+namespace TestApp
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class TestClass
+    {
+        public void Run(DbSet<User> users)
+        {
+            var user = users.Where(x => x.Id == 1).First();
+            System.Console.WriteLine(user.Name);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NonKeyWhereStepThenFirst_ShouldStillTrigger()
+    {
+        // A non-key Where (x.IsActive) is not a primary-key lookup, so the single-property over-fetch
+        // is still reported — guards against over-suppressing the new Where-chain PK exemption.
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfCoreMock + @"
+namespace TestApp
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public bool IsActive { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class TestClass
+    {
+        public void Run(DbSet<User> users)
+        {
+            var user = {|LC041:users.Where(x => x.IsActive).First()|};
+            System.Console.WriteLine(user.Name);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task MultiplePropertyUsage_ShouldNotTrigger()
     {
         var test = @"using Microsoft.EntityFrameworkCore;" + EfCoreMock + @"


### PR DESCRIPTION
## Summary

`LC041` flagged the **most common EF single-row read pattern**:

```csharp
var user = users.Where(x => x.Id == id).First();   // FP
System.Console.WriteLine(user.Name);
```

The key-lookup exemption only inspected the **terminal** operator's inline predicate (`First(x => x.Id == id)` *is* exempt), so the equivalent form with the key predicate on an upstream `Where` was reported — even though it's the same single-row-by-key fetch.

## Fix

`IsPrimaryKeyLookupInChain` now checks the terminal predicate **and** walks the receiver chain for a `Where` whose predicate is a primary-key equality.

- `Where(x => x.Id == id).First()` → exempt (no diagnostic).
- `Where(x => x.IsActive).First()` (non-key) → still reports.

## Tests

- PK-via-`Where` no-trigger + non-key-`Where` still-fires guardrail.
- Full suite green in Release: **916 passed**.

Found by a second adversarial false-positive rescan. The rarer hoisted-`Expression<Func<>>`-predicate form (`First(byId)`) remains a documented follow-up.

## Release

Bumps to **5.5.12** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)