### PR TITLE
fix(LC026): recognise field/property CancellationToken in scope (5.5.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.13] - 2026-06-04
+
+### Fixed
+- Closed an `LC026` false negative: a `CancellationToken` stored in a **field** or surfaced through a readable **property** is now recognised as an available token, so an EF async call (`ToListAsync`, `SaveChangesAsync`, …) that omits it is flagged and the fixer passes it by name. The scope lookup previously accepted only `ILocalSymbol`/`IParameterSymbol`, so the common injected-token (`private CancellationToken _ct;`) and `IHostApplicationLifetime.ApplicationStopping`-style patterns were silently missed even though the token is readily passable. The fixer references the member by bare name, which binds to `this.<member>`; write-only properties are skipped. Added field-token and property-token regression tests plus a fixer test confirming the field reference is inserted. (Found by a second adversarial false-negative rescan.)
+
 ## [5.5.12] - 2026-06-04
 
 ### Fixed

--- a/docs/LC026_MissingCancellationToken.md
+++ b/docs/LC026_MissingCancellationToken.md
@@ -35,7 +35,7 @@ public async Task<List<User>> GetUsers(CancellationToken ct)
 ### Algorithm
 1.  **Target Methods**: Intercept invocations of methods ending in `Async` that belong to `Microsoft.EntityFrameworkCore`.
 2.  **Parameter Check**: Check if the method signature accepts a `CancellationToken`.
-3.  **Scope Check**: Only report when a `CancellationToken` local or parameter is available at the call site.
+3.  **Scope Check**: Only report when a `CancellationToken` local, parameter, field, or readable property is available at the call site (the fixer references it by bare name, which binds to `this.<member>` for fields/properties).
 4.  **Argument Check**: Report when the target token parameter is omitted, passed `default`, or passed `CancellationToken.None`.
 5.  **Fix Strategy**: Prefer a variable named `cancellationToken`, then `ct`, then the first available token. The fixer appends the token when the optional argument was omitted and replaces an explicit `default`, named `cancellationToken: default`, or `CancellationToken.None` argument when one was already supplied.
 

--- a/src/LinqContraband/Analyzers/ExecutionAndAsync/LC026_MissingCancellationToken/MissingCancellationTokenScopeAnalysis.cs
+++ b/src/LinqContraband/Analyzers/ExecutionAndAsync/LC026_MissingCancellationToken/MissingCancellationTokenScopeAnalysis.cs
@@ -11,13 +11,21 @@ public sealed partial class MissingCancellationTokenAnalyzer
 
         foreach (var symbol in semanticModel.LookupSymbols(position))
         {
-            if (symbol is not ILocalSymbol and not IParameterSymbol)
+            // A CancellationToken stored in a field or surfaced through a readable property (e.g. an
+            // injected token or IHostApplicationLifetime.ApplicationStopping) is just as passable as a
+            // local/parameter one; the fixer references it by bare name, which binds to this.<member>.
+            if (symbol is not ILocalSymbol and not IParameterSymbol and not IFieldSymbol and not IPropertySymbol)
+                continue;
+
+            if (symbol is IPropertySymbol { GetMethod: null })
                 continue;
 
             var type = symbol switch
             {
                 ILocalSymbol local => local.Type,
                 IParameterSymbol parameter => parameter.Type,
+                IFieldSymbol field => field.Type,
+                IPropertySymbol property => property.Type,
                 _ => null
             };
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.12</Version>
+        <Version>5.5.13</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC041 no longer flags a primary-key lookup written with the key predicate on a Where step before First (the same single-row-by-key fetch as First with the predicate inline) — one of the most common EF read patterns. The key-lookup exemption previously inspected only the terminal operator's inline predicate; it now also walks the receiver chain for a Where whose predicate is a primary-key equality. A non-key Where still reports. (Found by a second adversarial false-positive rescan.)</PackageReleaseNotes>
+        <PackageReleaseNotes>LC026 now recognises a CancellationToken stored in a field or surfaced through a readable property as an available token, so an EF async call that omits it is flagged (and the fixer passes it by name) — previously only locals and parameters counted, silently missing the common injected-token / IHostApplicationLifetime.ApplicationStopping patterns. (Found by a second adversarial false-negative rescan.)</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC026_MissingCancellationToken/MissingCancellationTokenTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC026_MissingCancellationToken/MissingCancellationTokenTests.cs
@@ -61,6 +61,101 @@ namespace LinqContraband.Test
     }
 
     [Fact]
+    public async Task ToListAsync_WithFieldToken_ShouldTriggerLC026()
+    {
+        // A CancellationToken stored in a field is passable, so the unparameterized async call is flagged.
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        private CancellationToken _token;
+
+        public async Task TestMethod(DbSet<User> query)
+        {
+            var result = await {|LC026:query.ToListAsync()|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ToListAsync_WithPropertyToken_ShouldTriggerLC026()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        private CancellationToken Token { get; set; }
+
+        public async Task TestMethod(DbSet<User> query)
+        {
+            var result = await {|LC026:query.ToListAsync()|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task Fixer_PassesFieldToken()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        private CancellationToken _token;
+
+        public async Task TestMethod(DbSet<User> query)
+        {
+            var result = await {|LC026:query.ToListAsync()|};
+        }
+    }
+}";
+
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        private CancellationToken _token;
+
+        public async Task TestMethod(DbSet<User> query)
+        {
+            var result = await query.ToListAsync(_token);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
     public async Task ToListAsync_WithoutToken_WithoutTokenInScope_ShouldNotTrigger()
     {
         var test = @"using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
## Summary

`LC026` ignored a `CancellationToken` stored in a **field** or **property**, so an EF async call that omits it was silently not flagged:

```csharp
private CancellationToken _ct;                  // injected / lifetime token
public async Task Run(DbSet<User> query)
{
    var result = await query.ToListAsync();     // was NOT flagged
}
```

`FindCancellationTokenInScope` accepted only `ILocalSymbol`/`IParameterSymbol`, missing the common injected-token and `IHostApplicationLifetime.ApplicationStopping` patterns.

## Fix

The scope lookup now also accepts `IFieldSymbol` and readable `IPropertySymbol` (write-only properties skipped). Since the **fixer re-uses the same lookup** and inserts the token by bare name (which binds to `this.<member>`), both detection **and** the fix work end to end — `query.ToListAsync(_ct)`.

## Tests

- Field-token + property-token analyzer tests; a fixer test confirming `query.ToListAsync(_token)` is produced.
- Full suite green in Release: **919 passed**.

Found by a second adversarial false-negative rescan.

## Release

Bumps to **5.5.13** and syncs `CHANGELOG.md` + `PackageReleaseNotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)