### PR TITLE
feat(LC045): Missing Include — navigation accessed on materialized entity (analyzer + fixer)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -207,3 +207,6 @@ indent_size = 2
 
 # LC044: AsNoTracking Entity Mutated - Silent write lost before SaveChanges
 # dotnet_diagnostic.LC044.severity = warning
+
+# LC045: Missing Include - Navigation accessed on materialized entity without eager loading
+# dotnet_diagnostic.LC045.severity = warning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # LinqContraband — Project Guide for Claude Code
 
 **LinqContraband** is a Roslyn analyzer (NuGet package, id `LinqContraband`) that catches EF Core
-query anti-patterns at compile time. 44 rules (`LC001`–`LC044`) across 8 "neighborhoods", each
+query anti-patterns at compile time. 45 rules (`LC001`–`LC045`) across 8 "neighborhoods", each
 shipped with an analyzer, tests, a sample, a doc page, and a central catalog entry.
 
 - Analyzer project targets **`netstandard2.0`**; tests/samples multi-target **net8.0/9.0/10.0**.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The analyzer will immediately start scanning your code for contraband.
 
 ## 👮‍♂️ The Rules
 
-> **44 rules** covering performance, correctness, and design pitfalls in Entity Framework Core queries.
+> **45 rules** covering performance, correctness, and design pitfalls in Entity Framework Core queries.
 
 ## 🗺️ Rule Neighborhoods
 
@@ -49,7 +49,7 @@ The repository keeps the familiar `LC001`-style rule numbering, but the rules no
 | --- | --- |
 | Query Shape & Translation | LC001, LC004, LC005, LC014, LC015, LC016, LC020, LC024 |
 | Materialization & Projection | LC002, LC003, LC017, LC022, LC023, LC029, LC031, LC033, LC041 |
-| Loading & Includes | LC006, LC019, LC028, LC038, LC042 |
+| Loading & Includes | LC006, LC019, LC028, LC038, LC042, LC045 |
 | Execution & Async | LC007, LC008, LC026, LC036, LC043 |
 | Change Tracking & Context Lifetime | LC009, LC010, LC013, LC025, LC030, LC039, LC040, LC044 |
 | Bulk Operations & Set-Based Writes | LC012, LC032, LC035 |
@@ -1630,6 +1630,49 @@ db.SaveChanges();
   provable inside one method and no re-attach (`Update`, `Attach`, `Entry(entity).State = Modified|Added`) intervenes.
 - Ambiguous dataflow, mutations in branches that never reach `SaveChanges`, and entities that arrive as parameters are
   intentionally skipped to keep false positives at zero.
+
+---
+
+### LC045: Missing Include
+
+If you materialize a query (`ToList`, `FirstOrDefault`, …) and then read a navigation property the query never
+`Include`d, one of two bugs ships: with lazy-loading proxies every access fires an extra query (the classic read-side
+N+1); without proxies the navigation is silently `null` or an empty collection.
+
+**👶 Explain it like I'm a ten year old:** You ordered a burger but didn't ask for fries. Now either the kitchen makes
+a separate trip for every single fry you reach for (slow!), or there are simply no fries on your plate and you go
+hungry (null!).
+
+**❌ The Crime:**
+
+```csharp
+var orders = db.Orders.ToList();
+foreach (var o in orders)
+{
+    Console.WriteLine(o.Customer.Name); // N+1 query per order, or NullReferenceException
+}
+```
+
+**✅ The Fix:**
+Eagerly load the navigation (the code fix does this for you), or project exactly what you need.
+
+```csharp
+// Option A: eager load
+var orders = db.Orders.Include(o => o.Customer).ToList();
+
+// Option B: project
+var rows = db.Orders.Select(o => new { o.Id, CustomerName = o.Customer.Name }).ToList();
+```
+
+**🛡️ Reliability Notes:**
+- LC045 only fires when the whole story is provable inside one method: a DbSet-rooted chain of shape-preserving
+  operators (`Where`, `OrderBy`, `Include`, …), a single-assignment result local, and a navigation access on it.
+- Any `Select`/`Join`/custom operator, a reassigned local, a dynamic `Include(variable)`, or the result escaping
+  (returned, passed to a method, captured by a lambda) makes the rule stay quiet.
+- Navigation setters (`o.Customer = c`) and collection mutations (`o.Items.Add(...)`) are recognized write patterns
+  and are not flagged.
+- Null-guarded reads still fire deliberately: under proxies the null check itself triggers the N+1, and without
+  proxies the guard is dead code hiding the missing `Include`.
 
 ---
 

--- a/docs/LC045_MissingInclude.md
+++ b/docs/LC045_MissingInclude.md
@@ -1,0 +1,85 @@
+# Spec: LC045 - Missing Include: navigation accessed on materialized entity
+
+## Goal
+Detect the canonical EF Core read-side bug: a DbSet-rooted query is materialized (`ToList`, `FirstOrDefault`, …) and a navigation property of the result is then read without a matching `Include`/`ThenInclude` in the chain. With lazy-loading proxies every access fires an extra query (the classic N+1); without proxies the navigation is silently `null` or an empty collection. Both ship invisibly and only surface as production slowness or missing data.
+
+## The Problem
+EF Core never loads navigations implicitly when the entity is materialized eagerly. The query below compiles, runs, and looks correct — but `o.Customer` was never loaded:
+
+### Example Violation
+```csharp
+var orders = db.Orders.ToList();
+foreach (var o in orders)
+{
+    Console.WriteLine(o.Customer.Name); // N+1 per order with proxies; NullReferenceException without
+}
+```
+
+### Fixes
+Eagerly load the navigation:
+```csharp
+var orders = db.Orders.Include(o => o.Customer).ToList();
+foreach (var o in orders)
+{
+    Console.WriteLine(o.Customer.Name);
+}
+```
+…or project exactly the data the code needs (often the better query):
+```csharp
+var rows = db.Orders.Select(o => new { o.Id, CustomerName = o.Customer.Name }).ToList();
+```
+
+## Code Fix
+The code fix inserts the missing eager load immediately before the materializer — `recv.ToList()` becomes `recv.Include(x => x.Nav).ToList()`. Nested paths become `Include`/`ThenInclude` chains: a flagged `Customer.Address` produces `.Include(x => x.Customer).ThenInclude(x => x.Address)`. FixAll applies the same navigation across the document/project.
+
+## Analyzer Logic
+
+### ID: `LC045`
+### Category: `Reliability`
+### Severity: `Warning`
+
+### Algorithm
+1. **Anchor**: register on entity-producing materializers only — `ToList`/`ToArray` (+`Async`) and `First`/`Single`/`Last` (`OrDefault`, `Async`) framework methods. Aggregates (`Count`, `Any`, …) never materialize entities and are ignored.
+2. **Chain proof**: walk the receiver chain back to a `DbSet<T>` property/field on a `DbContext`. Only shape-preserving operators are allowed (`Where`, `OrderBy*`, `Skip`, `Take`, `Distinct`, `AsNoTracking*`, `AsTracking`, `AsSplitQuery`, `AsSingleQuery`, `TagWith*`, `IgnoreQueryFilters`, `Include`, `ThenInclude`). Anything else — `Select`, `Join`, `GroupBy`, custom extensions — bails. The chain may be hoisted across a single-assignment local (`var q = db.Orders.Where(…); q.ToList()`).
+3. **Included paths**: parse every `Include`/`ThenInclude` (lambda, filtered-lambda, and constant-string overloads) into navigation paths and record every prefix (`Include(o => o.A.B)` covers `A` and `A.B`). If any Include cannot be parsed (dynamic string), the whole query is skipped — it could cover anything.
+4. **Navigation classification**: a property is a navigation when its type (or collection element type) has a `DbSet` on the same context. Owned and unmapped types have no `DbSet` and are never flagged.
+5. **Usage scan**: resolve the result into a single-assignment local (or a direct inline access for single-entity materializers) and track entity-bearing locals — `foreach` iteration variables and indexer-initialized locals. Record each navigation read, including nested reference-navigation paths (`o.Customer.Address` → `Customer.Address`).
+6. **Emit**: one diagnostic per distinct missing navigation path, at the first access site, carrying the materializer location and the dotted path for the code fix. Only maximal paths are reported — fixing `Customer.Address` eagerly loads `Customer` too.
+
+## False-Positive Disciplines
+- Any non-shape-preserving operator in the chain (`Select`, `Join`, custom extensions) silences the query.
+- The result (or any entity drawn from it) escaping — returned, passed as an argument (including `db.Entry(e)`), captured by a lambda, or stored outside a local — silences the query: a helper might explicitly load the navigation.
+- A reassigned result local silences the query.
+- Navigation writes are not reads: `o.Customer = c` and `o.Items.Add(x)` are recognized relationship-fix-up patterns and stay quiet.
+- Properties whose type has no `DbSet` (owned/unmapped types) are never navigations.
+- Non-EF sources (`List<T>` LINQ) never match the DbSet root proof.
+
+## Deliberate Decisions & Known Limits
+- **Null-guarded access still fires.** `if (o.Customer != null)` is flagged on purpose: with proxies the null check itself triggers the N+1 load, and without proxies the navigation is always null, so the guard is dead code hiding the bug. Suppress with `#pragma warning disable LC045` if the guard is intentional.
+- Model-level `AutoInclude()` configuration is invisible to the analyzer; if you rely on it, suppress LC045 at the access site or project instead.
+- v1 scope is intra-procedural and local-based. Out of scope (quiet, not flagged): second-level access through collection navigations (`foreach (var i in o.Items) i.Product`), accesses inside lambdas over the result, `Entry(...).Reference/Collection(...).Load()` recognition, `IQueryable` parameters or repository-returned queries as roots, and `foreach` directly over an inline materializer.
+
+## Test Cases
+
+### Violations
+```csharp
+var orders = db.Orders.ToList();
+foreach (var o in orders) Console.WriteLine(o.Customer.Name);   // LC045: Customer
+
+var order = db.Orders.FirstOrDefault();
+Console.WriteLine(order.Customer.Name);                          // LC045: Customer
+
+var withCustomer = db.Orders.Include(o => o.Customer).ToList();
+foreach (var o in withCustomer) Console.WriteLine(o.Customer.Address.City); // LC045: Customer.Address
+```
+
+### Valid
+```csharp
+var orders = db.Orders.Include(o => o.Customer).ToList();
+foreach (var o in orders) Console.WriteLine(o.Customer.Name);
+
+var names = db.Orders.Select(o => o.Customer.Name).ToList();     // projection — out of scope
+
+var list = db.Orders.ToList();
+return list;                                                     // escapes — caller may hydrate
+```

--- a/docs/LC045_MissingInclude.md
+++ b/docs/LC045_MissingInclude.md
@@ -49,15 +49,17 @@ The code fix inserts the missing eager load immediately before the materializer 
 ## False-Positive Disciplines
 - Any non-shape-preserving operator in the chain (`Select`, `Join`, custom extensions) silences the query.
 - The result (or any entity drawn from it) escaping — returned, passed as an argument (including `db.Entry(e)`), captured by a lambda, or stored outside a local — silences the query: a helper might explicitly load the navigation.
-- A reassigned result local silences the query.
-- Navigation writes are not reads: `o.Customer = c` and `o.Items.Add(x)` are recognized relationship-fix-up patterns and stay quiet.
+- A reassigned result local (or a repointed entity local) silences the query.
+- Navigation writes are not reads: `o.Customer = c` (including compound, `??=`, and deconstruction assignments) and `o.Items.Add(x)` are recognized relationship-fix-up patterns and stay quiet. A navigation assigned in memory also satisfies later reads of that path.
+- Mid-path casts and null-forgiving operators in Include lambdas (`Include(o => o.Customer!.Address)`, `Include(o => ((Derived)o.Nav).Child)`) parse as the full path; an Include shape the parser cannot prove silences the whole query.
+- `nameof(o.Customer)` evaluates nothing and is never flagged.
 - Properties whose type has no `DbSet` (owned/unmapped types) are never navigations.
 - Non-EF sources (`List<T>` LINQ) never match the DbSet root proof.
 
 ## Deliberate Decisions & Known Limits
-- **Null-guarded access still fires.** `if (o.Customer != null)` is flagged on purpose: with proxies the null check itself triggers the N+1 load, and without proxies the navigation is always null, so the guard is dead code hiding the bug. Suppress with `#pragma warning disable LC045` if the guard is intentional.
+- **Null-guarded access still fires.** `if (o.Customer != null)` and `order?.Customer` are flagged on purpose: with proxies the null check itself triggers the N+1 load, and without proxies the navigation is always null, so the guard is dead code hiding the bug. Suppress with `#pragma warning disable LC045` if the guard is intentional.
 - Model-level `AutoInclude()` configuration is invisible to the analyzer; if you rely on it, suppress LC045 at the access site or project instead.
-- v1 scope is intra-procedural and local-based. Out of scope (quiet, not flagged): second-level access through collection navigations (`foreach (var i in o.Items) i.Product`), accesses inside lambdas over the result, `Entry(...).Reference/Collection(...).Load()` recognition, `IQueryable` parameters or repository-returned queries as roots, and `foreach` directly over an inline materializer.
+- v1 scope is intra-procedural and local-based (methods and constructors). Out of scope (quiet, not flagged): second-level access through collection navigations (`foreach (var i in o.Items) i.Product`), accesses inside lambdas over the result, property patterns (`order is { Customer: null }`), `Entry(...).Reference/Collection(...).Load()` recognition, `db.Set<T>()` / `IQueryable` parameters / repository-returned queries as roots, and `foreach` directly over an inline materializer.
 
 ## Test Cases
 

--- a/docs/rule-catalog.md
+++ b/docs/rule-catalog.md
@@ -43,6 +43,7 @@ This page is generated from that catalog and grouped by domain.
 | `LC028` Deep ThenInclude Chain | `Warning` | `Performance` | Manual only | [`LC028_DeepThenInclude`](./LC028_DeepThenInclude.md) | `Samples/LC028_DeepThenInclude/` |
 | `LC038` Avoid excessive eager loading | `Info` | `Performance` | Manual only | [`LC038_ExcessiveEagerLoading`](./LC038_ExcessiveEagerLoading.md) | `Samples/LC038_ExcessiveEagerLoading/` |
 | `LC042` Complex query should be tagged | `Info` | `Performance` | Manual only | [`LC042_MissingQueryTags`](./LC042_MissingQueryTags.md) | `Samples/LC042_MissingQueryTags/` |
+| `LC045` Missing Include: navigation accessed on materialized entity | `Warning` | `Reliability` | Code fix | [`LC045_MissingInclude`](./LC045_MissingInclude.md) | `Samples/LC045_MissingInclude/` |
 
 ## Materialization & Projection
 

--- a/samples/LinqContraband.Sample/Program.cs
+++ b/samples/LinqContraband.Sample/Program.cs
@@ -34,6 +34,7 @@ using LinqContraband.Sample.Samples.LC041_SingleEntityScalarProjection;
 using LinqContraband.Sample.Samples.LC042_MissingQueryTags;
 using LinqContraband.Sample.Samples.LC043_AsyncEnumerableBuffering;
 using LinqContraband.Sample.Samples.LC044_AsNoTrackingThenModify;
+using LinqContraband.Sample.Samples.LC045_MissingInclude;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
 
@@ -94,5 +95,6 @@ internal class Program
         MissingQueryTagsSample.Run(db);
         await AsyncEnumerableBufferingSample.RunAsync(db);
         AsNoTrackingThenModifySample.Run(db);
+        MissingIncludeSample.Run(db);
     }
 }

--- a/samples/LinqContraband.Sample/Samples/LC045_MissingInclude/MissingIncludeSample.cs
+++ b/samples/LinqContraband.Sample/Samples/LC045_MissingInclude/MissingIncludeSample.cs
@@ -1,0 +1,35 @@
+using LinqContraband.Sample.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace LinqContraband.Sample.Samples.LC045_MissingInclude;
+
+public class MissingIncludeSample
+{
+    public static void Run(AppDbContext db)
+    {
+        Console.WriteLine("Testing LC045...");
+
+        // VIOLATION: ShippingAddress is never Included. With lazy-loading proxies every
+        // iteration fires an extra query (read-side N+1); without proxies the navigation
+        // is silently null and this throws.
+        var customers = db.Customers.ToList();
+        foreach (var c in customers)
+        {
+            Console.WriteLine(c.ShippingAddress.Street);
+        }
+
+        // CORRECT: eagerly load the navigation the loop reads.
+        var loaded = db.Customers.Include(c => c.ShippingAddress).ToList();
+        foreach (var c in loaded)
+        {
+            Console.WriteLine(c.ShippingAddress.Street);
+        }
+
+        // CORRECT: project exactly the data the loop needs — no entity, no Include.
+        var streets = db.Customers.Select(c => c.ShippingAddress.Street).ToList();
+        foreach (var street in streets)
+        {
+            Console.WriteLine(street);
+        }
+    }
+}

--- a/samples/LinqContraband.Sample/sample-diagnostics.json
+++ b/samples/LinqContraband.Sample/sample-diagnostics.json
@@ -4,49 +4,448 @@
     "Samples/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersSafeSample.cs"
   ],
   "expectations": [
-    { "diagnosticPath": "Samples/LC001_LocalMethod/LocalMethodSample.cs", "samplePaths": ["Samples/LC001_LocalMethod/LocalMethodSample.cs"], "ruleIds": ["LC001"] },
-    { "diagnosticPath": "Samples/LC002_PrematureMaterialization/PrematureMaterializationSample.cs", "samplePaths": ["Samples/LC002_PrematureMaterialization/PrematureMaterializationSample.cs"], "ruleIds": ["LC002"] },
-    { "diagnosticPath": "Samples/LC003_AnyOverCount/AnyOverCountSample.cs", "samplePaths": ["Samples/LC003_AnyOverCount/AnyOverCountSample.cs"], "ruleIds": ["LC003"] },
-    { "diagnosticPath": "Samples/LC004_IQueryableLeak/IQueryableLeakSample.cs", "samplePaths": ["Samples/LC004_IQueryableLeak/IQueryableLeakSample.cs"], "ruleIds": ["LC004"] },
-    { "diagnosticPath": "Samples/LC005_MultipleOrderBy/MultipleOrderBySample.cs", "samplePaths": ["Samples/LC005_MultipleOrderBy/MultipleOrderBySample.cs"], "ruleIds": ["LC005"] },
-    { "diagnosticPath": "Samples/LC006_CartesianExplosion/CartesianExplosionSample.cs", "samplePaths": ["Samples/LC006_CartesianExplosion/CartesianExplosionSample.cs"], "ruleIds": ["LC006"] },
-    { "diagnosticPath": "Samples/LC007_NPlusOneLooper/NPlusOneLooperSample.cs", "samplePaths": ["Samples/LC007_NPlusOneLooper/NPlusOneLooperSample.cs"], "ruleIds": ["LC007"] },
-    { "diagnosticPath": "Samples/LC008_SyncBlocker/SyncBlockerSample.cs", "samplePaths": ["Samples/LC008_SyncBlocker/SyncBlockerSample.cs"], "ruleIds": ["LC008"] },
-    { "diagnosticPath": "Samples/LC009_MissingAsNoTracking/MissingAsNoTrackingSample.cs", "samplePaths": ["Samples/LC009_MissingAsNoTracking/MissingAsNoTrackingSample.cs"], "ruleIds": ["LC009", "LC015", "LC042"] },
-    { "diagnosticPath": "Samples/LC010_SaveChangesInLoop/SaveChangesInLoopSample.cs", "samplePaths": ["Samples/LC010_SaveChangesInLoop/SaveChangesInLoopSample.cs"], "ruleIds": ["LC010"] },
-    { "diagnosticPath": "Data/AppDbContext.cs", "samplePaths": ["Samples/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeySample.cs"], "ruleIds": ["LC011"] },
-    { "diagnosticPath": "Samples/LC012_OptimizeRemoveRange/OptimizeRemoveRangeSample.cs", "samplePaths": ["Samples/LC012_OptimizeRemoveRange/OptimizeRemoveRangeSample.cs"], "ruleIds": ["LC012"] },
-    { "diagnosticPath": "Samples/LC013_DisposedContextQuery/DisposedContextQuerySample.cs", "samplePaths": ["Samples/LC013_DisposedContextQuery/DisposedContextQuerySample.cs"], "ruleIds": ["LC009", "LC013", "LC031"] },
-    { "diagnosticPath": "Samples/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionSample.cs", "samplePaths": ["Samples/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionSample.cs"], "ruleIds": ["LC014", "LC031"] },
-    { "diagnosticPath": "Samples/LC015_MissingOrderBy/MissingOrderBySample.cs", "samplePaths": ["Samples/LC015_MissingOrderBy/MissingOrderBySample.cs"], "ruleIds": ["LC015", "LC031"] },
-    { "diagnosticPath": "Samples/LC016_AvoidDateTimeNow/AvoidDateTimeNowSample.cs", "samplePaths": ["Samples/LC016_AvoidDateTimeNow/AvoidDateTimeNowSample.cs"], "ruleIds": ["LC016", "LC042"] },
-    { "diagnosticPath": "Samples/LC017_WholeEntityProjection/WholeEntityProjectionSample.cs", "samplePaths": ["Samples/LC017_WholeEntityProjection/WholeEntityProjectionSample.cs"], "ruleIds": ["LC009", "LC017", "LC031"] },
-    { "diagnosticPath": "Samples/LC018_AvoidFromSqlRawWithInterpolation/AvoidFromSqlRawWithInterpolationSample.cs", "samplePaths": ["Samples/LC018_AvoidFromSqlRawWithInterpolation/AvoidFromSqlRawWithInterpolationSample.cs"], "ruleIds": ["LC009", "LC018", "LC031"] },
-    { "diagnosticPath": "Samples/LC019_ConditionalInclude/ConditionalIncludeSample.cs", "samplePaths": ["Samples/LC019_ConditionalInclude/ConditionalIncludeSample.cs"], "ruleIds": ["LC019"] },
-    { "diagnosticPath": "Samples/LC020_StringContainsWithComparison/StringContainsWithComparisonSample.cs", "samplePaths": ["Samples/LC020_StringContainsWithComparison/StringContainsWithComparisonSample.cs"], "ruleIds": ["LC020", "LC042"] },
-    { "diagnosticPath": "Samples/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersSample.cs", "samplePaths": ["Samples/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersSample.cs"], "ruleIds": ["LC021", "LC042"] },
-    { "diagnosticPath": "Samples/LC022_ToListInSelectProjection/ToListInSelectProjectionSample.cs", "samplePaths": ["Samples/LC022_ToListInSelectProjection/ToListInSelectProjectionSample.cs"], "ruleIds": ["LC022"] },
-    { "diagnosticPath": "Samples/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultSample.cs", "samplePaths": ["Samples/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultSample.cs"], "ruleIds": ["LC009", "LC023"] },
-    { "diagnosticPath": "Samples/LC024_GroupByNonTranslatable/GroupByNonTranslatableSample.cs", "samplePaths": ["Samples/LC024_GroupByNonTranslatable/GroupByNonTranslatableSample.cs"], "ruleIds": ["LC024"] },
-    { "diagnosticPath": "Samples/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateSample.cs", "samplePaths": ["Samples/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateSample.cs"], "ruleIds": ["LC023", "LC025", "LC031", "LC040"] },
-    { "diagnosticPath": "Samples/LC026_MissingCancellationToken/MissingCancellationTokenSample.cs", "samplePaths": ["Samples/LC026_MissingCancellationToken/MissingCancellationTokenSample.cs"], "ruleIds": ["LC026", "LC031", "LC039"] },
-    { "diagnosticPath": "Data/AppDbContext.cs", "samplePaths": ["Samples/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeySample.cs"], "ruleIds": ["LC027"] },
-    { "diagnosticPath": "Samples/LC028_DeepThenInclude/DeepThenIncludeSample.cs", "samplePaths": ["Samples/LC028_DeepThenInclude/DeepThenIncludeSample.cs"], "ruleIds": ["LC028"] },
-    { "diagnosticPath": "Samples/LC029_RedundantIdentitySelect/RedundantIdentitySelectSample.cs", "samplePaths": ["Samples/LC029_RedundantIdentitySelect/RedundantIdentitySelectSample.cs"], "ruleIds": ["LC029"] },
-    { "diagnosticPath": "Samples/LC030_DbContextInSingleton/DbContextInSingletonSample.cs", "samplePaths": ["Samples/LC030_DbContextInSingleton/DbContextInSingletonSample.cs"], "ruleIds": ["LC030"] },
-    { "diagnosticPath": "Samples/LC031_UnboundedQueryMaterialization/UnboundedQueryMaterializationSample.cs", "samplePaths": ["Samples/LC031_UnboundedQueryMaterialization/UnboundedQueryMaterializationSample.cs"], "ruleIds": ["LC009", "LC031", "LC042"] },
-    { "diagnosticPath": "Samples/LC032_ExecuteUpdateForBulkUpdates/ExecuteUpdateForBulkUpdatesSample.cs", "samplePaths": ["Samples/LC032_ExecuteUpdateForBulkUpdates/ExecuteUpdateForBulkUpdatesSample.cs"], "ruleIds": ["LC032"] },
-    { "diagnosticPath": "Samples/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesSample.cs", "samplePaths": ["Samples/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesSample.cs"], "ruleIds": ["LC033"] },
-    { "diagnosticPath": "Samples/LC034_AvoidExecuteSqlRawWithInterpolation/ExecuteSqlRawInterpolationSample.cs", "samplePaths": ["Samples/LC034_AvoidExecuteSqlRawWithInterpolation/ExecuteSqlRawInterpolationSample.cs"], "ruleIds": ["LC034"] },
-    { "diagnosticPath": "Samples/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateSample.cs", "samplePaths": ["Samples/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateSample.cs"], "ruleIds": ["LC035"] },
-    { "diagnosticPath": "Samples/LC036_DbContextCapturedAcrossThreads/DbContextCapturedAcrossThreadsSample.cs", "samplePaths": ["Samples/LC036_DbContextCapturedAcrossThreads/DbContextCapturedAcrossThreadsSample.cs"], "ruleIds": ["LC009", "LC031", "LC036"] },
-    { "diagnosticPath": "Samples/LC037_RawSqlStringConstruction/RawSqlStringConstructionSample.cs", "samplePaths": ["Samples/LC037_RawSqlStringConstruction/RawSqlStringConstructionSample.cs"], "ruleIds": ["LC009", "LC037"] },
-    { "diagnosticPath": "Samples/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingSample.cs", "samplePaths": ["Samples/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingSample.cs"], "ruleIds": ["LC009", "LC031", "LC038", "LC042"] },
-    { "diagnosticPath": "Samples/LC039_NestedSaveChanges/NestedSaveChangesSample.cs", "samplePaths": ["Samples/LC039_NestedSaveChanges/NestedSaveChangesSample.cs"], "ruleIds": ["LC039"] },
-    { "diagnosticPath": "Samples/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingSample.cs", "samplePaths": ["Samples/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingSample.cs"], "ruleIds": ["LC009", "LC031", "LC040"] },
-    { "diagnosticPath": "Samples/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionSample.cs", "samplePaths": ["Samples/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionSample.cs"], "ruleIds": ["LC041"] },
-    { "diagnosticPath": "Samples/LC042_MissingQueryTags/MissingQueryTagsSample.cs", "samplePaths": ["Samples/LC042_MissingQueryTags/MissingQueryTagsSample.cs"], "ruleIds": ["LC009", "LC042"] },
-    { "diagnosticPath": "Samples/LC043_AsyncEnumerableBuffering/AsyncEnumerableBufferingSample.cs", "samplePaths": ["Samples/LC043_AsyncEnumerableBuffering/AsyncEnumerableBufferingSample.cs"], "ruleIds": ["LC009", "LC031", "LC043"] },
-    { "diagnosticPath": "Samples/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifySample.cs", "samplePaths": ["Samples/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifySample.cs"], "ruleIds": ["LC023", "LC025", "LC039", "LC040", "LC044"] }
+    {
+      "diagnosticPath": "Samples/LC001_LocalMethod/LocalMethodSample.cs",
+      "samplePaths": [
+        "Samples/LC001_LocalMethod/LocalMethodSample.cs"
+      ],
+      "ruleIds": [
+        "LC001"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC002_PrematureMaterialization/PrematureMaterializationSample.cs",
+      "samplePaths": [
+        "Samples/LC002_PrematureMaterialization/PrematureMaterializationSample.cs"
+      ],
+      "ruleIds": [
+        "LC002"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC003_AnyOverCount/AnyOverCountSample.cs",
+      "samplePaths": [
+        "Samples/LC003_AnyOverCount/AnyOverCountSample.cs"
+      ],
+      "ruleIds": [
+        "LC003"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC004_IQueryableLeak/IQueryableLeakSample.cs",
+      "samplePaths": [
+        "Samples/LC004_IQueryableLeak/IQueryableLeakSample.cs"
+      ],
+      "ruleIds": [
+        "LC004"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC005_MultipleOrderBy/MultipleOrderBySample.cs",
+      "samplePaths": [
+        "Samples/LC005_MultipleOrderBy/MultipleOrderBySample.cs"
+      ],
+      "ruleIds": [
+        "LC005"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC006_CartesianExplosion/CartesianExplosionSample.cs",
+      "samplePaths": [
+        "Samples/LC006_CartesianExplosion/CartesianExplosionSample.cs"
+      ],
+      "ruleIds": [
+        "LC006"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC007_NPlusOneLooper/NPlusOneLooperSample.cs",
+      "samplePaths": [
+        "Samples/LC007_NPlusOneLooper/NPlusOneLooperSample.cs"
+      ],
+      "ruleIds": [
+        "LC007"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC008_SyncBlocker/SyncBlockerSample.cs",
+      "samplePaths": [
+        "Samples/LC008_SyncBlocker/SyncBlockerSample.cs"
+      ],
+      "ruleIds": [
+        "LC008"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC009_MissingAsNoTracking/MissingAsNoTrackingSample.cs",
+      "samplePaths": [
+        "Samples/LC009_MissingAsNoTracking/MissingAsNoTrackingSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC015",
+        "LC042"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC010_SaveChangesInLoop/SaveChangesInLoopSample.cs",
+      "samplePaths": [
+        "Samples/LC010_SaveChangesInLoop/SaveChangesInLoopSample.cs"
+      ],
+      "ruleIds": [
+        "LC010"
+      ]
+    },
+    {
+      "diagnosticPath": "Data/AppDbContext.cs",
+      "samplePaths": [
+        "Samples/LC011_EntityMissingPrimaryKey/EntityMissingPrimaryKeySample.cs"
+      ],
+      "ruleIds": [
+        "LC011"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC012_OptimizeRemoveRange/OptimizeRemoveRangeSample.cs",
+      "samplePaths": [
+        "Samples/LC012_OptimizeRemoveRange/OptimizeRemoveRangeSample.cs"
+      ],
+      "ruleIds": [
+        "LC012"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC013_DisposedContextQuery/DisposedContextQuerySample.cs",
+      "samplePaths": [
+        "Samples/LC013_DisposedContextQuery/DisposedContextQuerySample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC013",
+        "LC031"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionSample.cs",
+      "samplePaths": [
+        "Samples/LC014_AvoidStringCaseConversion/AvoidStringCaseConversionSample.cs"
+      ],
+      "ruleIds": [
+        "LC014",
+        "LC031"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC015_MissingOrderBy/MissingOrderBySample.cs",
+      "samplePaths": [
+        "Samples/LC015_MissingOrderBy/MissingOrderBySample.cs"
+      ],
+      "ruleIds": [
+        "LC015",
+        "LC031"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC016_AvoidDateTimeNow/AvoidDateTimeNowSample.cs",
+      "samplePaths": [
+        "Samples/LC016_AvoidDateTimeNow/AvoidDateTimeNowSample.cs"
+      ],
+      "ruleIds": [
+        "LC016",
+        "LC042"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC017_WholeEntityProjection/WholeEntityProjectionSample.cs",
+      "samplePaths": [
+        "Samples/LC017_WholeEntityProjection/WholeEntityProjectionSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC017",
+        "LC031"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC018_AvoidFromSqlRawWithInterpolation/AvoidFromSqlRawWithInterpolationSample.cs",
+      "samplePaths": [
+        "Samples/LC018_AvoidFromSqlRawWithInterpolation/AvoidFromSqlRawWithInterpolationSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC018",
+        "LC031"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC019_ConditionalInclude/ConditionalIncludeSample.cs",
+      "samplePaths": [
+        "Samples/LC019_ConditionalInclude/ConditionalIncludeSample.cs"
+      ],
+      "ruleIds": [
+        "LC019"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC020_StringContainsWithComparison/StringContainsWithComparisonSample.cs",
+      "samplePaths": [
+        "Samples/LC020_StringContainsWithComparison/StringContainsWithComparisonSample.cs"
+      ],
+      "ruleIds": [
+        "LC020",
+        "LC042"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersSample.cs",
+      "samplePaths": [
+        "Samples/LC021_AvoidIgnoreQueryFilters/AvoidIgnoreQueryFiltersSample.cs"
+      ],
+      "ruleIds": [
+        "LC021",
+        "LC042"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC022_ToListInSelectProjection/ToListInSelectProjectionSample.cs",
+      "samplePaths": [
+        "Samples/LC022_ToListInSelectProjection/ToListInSelectProjectionSample.cs"
+      ],
+      "ruleIds": [
+        "LC022"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultSample.cs",
+      "samplePaths": [
+        "Samples/LC023_FindInsteadOfFirstOrDefault/FindInsteadOfFirstOrDefaultSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC023"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC024_GroupByNonTranslatable/GroupByNonTranslatableSample.cs",
+      "samplePaths": [
+        "Samples/LC024_GroupByNonTranslatable/GroupByNonTranslatableSample.cs"
+      ],
+      "ruleIds": [
+        "LC024"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateSample.cs",
+      "samplePaths": [
+        "Samples/LC025_AsNoTrackingWithUpdate/AsNoTrackingWithUpdateSample.cs"
+      ],
+      "ruleIds": [
+        "LC023",
+        "LC025",
+        "LC031",
+        "LC040"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC026_MissingCancellationToken/MissingCancellationTokenSample.cs",
+      "samplePaths": [
+        "Samples/LC026_MissingCancellationToken/MissingCancellationTokenSample.cs"
+      ],
+      "ruleIds": [
+        "LC026",
+        "LC031",
+        "LC039"
+      ]
+    },
+    {
+      "diagnosticPath": "Data/AppDbContext.cs",
+      "samplePaths": [
+        "Samples/LC027_MissingExplicitForeignKey/MissingExplicitForeignKeySample.cs"
+      ],
+      "ruleIds": [
+        "LC027"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC028_DeepThenInclude/DeepThenIncludeSample.cs",
+      "samplePaths": [
+        "Samples/LC028_DeepThenInclude/DeepThenIncludeSample.cs"
+      ],
+      "ruleIds": [
+        "LC028"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC029_RedundantIdentitySelect/RedundantIdentitySelectSample.cs",
+      "samplePaths": [
+        "Samples/LC029_RedundantIdentitySelect/RedundantIdentitySelectSample.cs"
+      ],
+      "ruleIds": [
+        "LC029"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC030_DbContextInSingleton/DbContextInSingletonSample.cs",
+      "samplePaths": [
+        "Samples/LC030_DbContextInSingleton/DbContextInSingletonSample.cs"
+      ],
+      "ruleIds": [
+        "LC030"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC031_UnboundedQueryMaterialization/UnboundedQueryMaterializationSample.cs",
+      "samplePaths": [
+        "Samples/LC031_UnboundedQueryMaterialization/UnboundedQueryMaterializationSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC031",
+        "LC042"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC032_ExecuteUpdateForBulkUpdates/ExecuteUpdateForBulkUpdatesSample.cs",
+      "samplePaths": [
+        "Samples/LC032_ExecuteUpdateForBulkUpdates/ExecuteUpdateForBulkUpdatesSample.cs"
+      ],
+      "ruleIds": [
+        "LC032"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesSample.cs",
+      "samplePaths": [
+        "Samples/LC033_UseFrozenSetForStaticMembershipCaches/UseFrozenSetForStaticMembershipCachesSample.cs"
+      ],
+      "ruleIds": [
+        "LC033"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC034_AvoidExecuteSqlRawWithInterpolation/ExecuteSqlRawInterpolationSample.cs",
+      "samplePaths": [
+        "Samples/LC034_AvoidExecuteSqlRawWithInterpolation/ExecuteSqlRawInterpolationSample.cs"
+      ],
+      "ruleIds": [
+        "LC034"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateSample.cs",
+      "samplePaths": [
+        "Samples/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateSample.cs"
+      ],
+      "ruleIds": [
+        "LC035"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC036_DbContextCapturedAcrossThreads/DbContextCapturedAcrossThreadsSample.cs",
+      "samplePaths": [
+        "Samples/LC036_DbContextCapturedAcrossThreads/DbContextCapturedAcrossThreadsSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC031",
+        "LC036"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC037_RawSqlStringConstruction/RawSqlStringConstructionSample.cs",
+      "samplePaths": [
+        "Samples/LC037_RawSqlStringConstruction/RawSqlStringConstructionSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC037"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingSample.cs",
+      "samplePaths": [
+        "Samples/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC031",
+        "LC038",
+        "LC042"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC039_NestedSaveChanges/NestedSaveChangesSample.cs",
+      "samplePaths": [
+        "Samples/LC039_NestedSaveChanges/NestedSaveChangesSample.cs"
+      ],
+      "ruleIds": [
+        "LC039"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingSample.cs",
+      "samplePaths": [
+        "Samples/LC040_MixedTrackingAndNoTracking/MixedTrackingAndNoTrackingSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC031",
+        "LC040"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionSample.cs",
+      "samplePaths": [
+        "Samples/LC041_SingleEntityScalarProjection/SingleEntityScalarProjectionSample.cs"
+      ],
+      "ruleIds": [
+        "LC041"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC042_MissingQueryTags/MissingQueryTagsSample.cs",
+      "samplePaths": [
+        "Samples/LC042_MissingQueryTags/MissingQueryTagsSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC042"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC043_AsyncEnumerableBuffering/AsyncEnumerableBufferingSample.cs",
+      "samplePaths": [
+        "Samples/LC043_AsyncEnumerableBuffering/AsyncEnumerableBufferingSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC031",
+        "LC043"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifySample.cs",
+      "samplePaths": [
+        "Samples/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifySample.cs"
+      ],
+      "ruleIds": [
+        "LC023",
+        "LC025",
+        "LC039",
+        "LC040",
+        "LC044"
+      ]
+    },
+    {
+      "diagnosticPath": "Samples/LC045_MissingInclude/MissingIncludeSample.cs",
+      "samplePaths": [
+        "Samples/LC045_MissingInclude/MissingIncludeSample.cs"
+      ],
+      "ruleIds": [
+        "LC009",
+        "LC031",
+        "LC045"
+      ]
+    }
   ]
 }

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionAnalyzer.cs
@@ -85,35 +85,6 @@ public sealed partial class CartesianExplosionAnalyzer : DiagnosticAnalyzer
         Single
     }
 
-    private readonly struct NavigationSegment
-    {
-        public NavigationSegment(string name, bool isCollection)
-        {
-            Name = name;
-            IsCollection = isCollection;
-        }
-
-        public string Name { get; }
-        public bool IsCollection { get; }
-    }
-
-    private sealed class IncludePath
-    {
-        public IncludePath(ImmutableArray<NavigationSegment> segments)
-        {
-            Segments = segments;
-        }
-
-        public ImmutableArray<NavigationSegment> Segments { get; }
-
-        public string Key => string.Join(".", Segments.Select(segment => segment.Name));
-
-        public IncludePath Append(IncludePath childPath)
-        {
-            return new IncludePath(Segments.AddRange(childPath.Segments));
-        }
-    }
-
     private sealed class IncludeChainAnalysis
     {
         private readonly System.Collections.Generic.List<IncludePath> includePaths = new();

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionChainAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC006_CartesianExplosion/CartesianExplosionChainAnalysis.cs
@@ -38,7 +38,7 @@ public sealed partial class CartesianExplosionAnalyzer
                 continue;
             }
 
-            if (!TryGetIncludePath(invocation, semanticModel, currentIncludePath, out var includePath))
+            if (!IncludePathParser.TryGetIncludePath(invocation, semanticModel, currentIncludePath, out var includePath))
                 continue;
 
             foundInclude = true;

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeAnalyzer.cs
@@ -1,0 +1,134 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC045_MissingInclude;
+
+/// <summary>
+/// Detects navigation properties accessed on materialized entities that the query never
+/// eagerly loaded with Include. Diagnostic ID: LC045
+/// </summary>
+/// <remarks>
+/// <para><b>Why this matters:</b> When a DbSet-rooted query is materialized (ToList, First, …)
+/// and a navigation property of the result is then read without a matching Include, one of two
+/// bugs ships: with lazy-loading proxies every access fires an extra query (the classic read-side
+/// N+1); without proxies the navigation is silently null or an empty collection. Both are invisible
+/// at compile time and only surface as production slowness or missing data.</para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed partial class MissingIncludeAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "LC045";
+    internal const string NavigationPathProperty = "NavigationPath";
+    private const string Category = "Reliability";
+
+    private static readonly LocalizableString Title = "Missing Include: navigation accessed on materialized entity";
+
+    private static readonly LocalizableString MessageFormat =
+        "Navigation '{0}' on '{1}' is accessed after the query is materialized, but the query never Includes it. " +
+        "Without Include it is null/empty (or triggers N+1 lazy loading). Add .Include() or project the data you need.";
+
+    private static readonly LocalizableString Description =
+        "Reading a navigation property that the query did not eagerly load is either a silent null/empty " +
+        "collection (no lazy loading) or an N+1 query per access (lazy-loading proxies). " +
+        "Add .Include()/.ThenInclude() for the navigation, or project exactly the data you need with Select().";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        Title,
+        MessageFormat,
+        Category,
+        DiagnosticSeverity.Warning,
+        true,
+        Description,
+        helpLinkUri: "https://github.com/georgepwall1991/LinqContraband/blob/master/docs/LC045_MissingInclude.md");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+
+        if (!IsEntityMaterializer(invocation.TargetMethod, out var returnsCollection))
+            return;
+
+        if (!TryAnalyzeQueryChain(invocation, context.CancellationToken, out var query))
+            return;
+
+        var entityTypes = CollectDbSetEntityTypes(query.ContextType);
+        if (!entityTypes.Contains(query.EntityType))
+            return;
+
+        var accesses = CollectNavigationAccesses(
+            invocation,
+            returnsCollection,
+            query.EntityType,
+            entityTypes,
+            context.CancellationToken);
+        if (accesses == null || accesses.Count == 0)
+            return;
+
+        // First access site per distinct missing path.
+        var firstAccessByPath = new System.Collections.Generic.Dictionary<string, NavigationAccess>(System.StringComparer.Ordinal);
+        foreach (var access in accesses)
+        {
+            if (query.IncludedPrefixes.Contains(access.Path))
+                continue;
+
+            if (!firstAccessByPath.TryGetValue(access.Path, out var existing) ||
+                access.Syntax.SpanStart < existing.Syntax.SpanStart)
+            {
+                firstAccessByPath[access.Path] = access;
+            }
+        }
+
+        if (firstAccessByPath.Count == 0)
+            return;
+
+        var materializerLocation = new[] { invocation.Syntax.GetLocation() };
+
+        foreach (var pair in firstAccessByPath.OrderBy(entry => entry.Value.Syntax.SpanStart))
+        {
+            // Only maximal paths: fixing "Customer.Address" eagerly loads "Customer" too.
+            if (HasLongerMissingPath(firstAccessByPath, pair.Key))
+                continue;
+
+            var properties = ImmutableDictionary<string, string?>.Empty
+                .Add(NavigationPathProperty, pair.Key);
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                Rule,
+                pair.Value.Syntax.GetLocation(),
+                additionalLocations: materializerLocation,
+                properties: properties,
+                pair.Key,
+                query.EntityType.Name));
+        }
+    }
+
+    private static bool HasLongerMissingPath(
+        System.Collections.Generic.Dictionary<string, NavigationAccess> missingPaths,
+        string path)
+    {
+        foreach (var candidate in missingPaths.Keys)
+        {
+            if (candidate.Length > path.Length &&
+                candidate.StartsWith(path, System.StringComparison.Ordinal) &&
+                candidate[path.Length] == '.')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeAnalyzer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeAnalyzer.cs
@@ -51,10 +51,20 @@ public sealed partial class MissingIncludeAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            // The DbSet entity-type set is a per-context-type fact; cache it for the
+            // compilation instead of re-walking the context's members per materializer.
+            var entityTypeCache = new System.Collections.Concurrent.ConcurrentDictionary<INamedTypeSymbol, System.Collections.Generic.HashSet<INamedTypeSymbol>>(SymbolEqualityComparer.Default);
+            compilationContext.RegisterOperationAction(
+                operationContext => AnalyzeInvocation(operationContext, entityTypeCache),
+                OperationKind.Invocation);
+        });
     }
 
-    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    private static void AnalyzeInvocation(
+        OperationAnalysisContext context,
+        System.Collections.Concurrent.ConcurrentDictionary<INamedTypeSymbol, System.Collections.Generic.HashSet<INamedTypeSymbol>> entityTypeCache)
     {
         var invocation = (IInvocationOperation)context.Operation;
 
@@ -64,7 +74,7 @@ public sealed partial class MissingIncludeAnalyzer : DiagnosticAnalyzer
         if (!TryAnalyzeQueryChain(invocation, context.CancellationToken, out var query))
             return;
 
-        var entityTypes = CollectDbSetEntityTypes(query.ContextType);
+        var entityTypes = entityTypeCache.GetOrAdd(query.ContextType, static contextType => CollectDbSetEntityTypes(contextType));
         if (!entityTypes.Contains(query.EntityType))
             return;
 

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeFixer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeFixer.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LinqContraband.Extensions;
@@ -32,29 +31,31 @@ public sealed class MissingIncludeFixer : CodeFixProvider
     public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        var diagnostic = context.Diagnostics.First();
 
-        if (!diagnostic.Properties.TryGetValue(MissingIncludeAnalyzer.NavigationPathProperty, out var navigationPath) ||
-            string.IsNullOrWhiteSpace(navigationPath))
+        foreach (var diagnostic in context.Diagnostics)
         {
-            return;
+            if (!diagnostic.Properties.TryGetValue(MissingIncludeAnalyzer.NavigationPathProperty, out var navigationPath) ||
+                string.IsNullOrWhiteSpace(navigationPath))
+            {
+                continue;
+            }
+
+            if (diagnostic.AdditionalLocations.Count == 0)
+                continue;
+
+            var materializerNode = root?.FindNode(diagnostic.AdditionalLocations[0].SourceSpan, getInnermostNodeForTie: true);
+            var materializer = materializerNode as InvocationExpressionSyntax ??
+                               materializerNode?.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (materializer?.Expression is not MemberAccessExpressionSyntax)
+                continue;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    $"Add .Include() for '{navigationPath}'",
+                    c => ApplyFixAsync(context.Document, materializer, navigationPath!, c),
+                    "LC045_AddInclude:" + navigationPath),
+                diagnostic);
         }
-
-        if (diagnostic.AdditionalLocations.Count == 0)
-            return;
-
-        var materializerNode = root?.FindNode(diagnostic.AdditionalLocations[0].SourceSpan, getInnermostNodeForTie: true);
-        var materializer = materializerNode as InvocationExpressionSyntax ??
-                           materializerNode?.FirstAncestorOrSelf<InvocationExpressionSyntax>();
-        if (materializer?.Expression is not MemberAccessExpressionSyntax)
-            return;
-
-        context.RegisterCodeFix(
-            CodeAction.Create(
-                $"Add .Include() for '{navigationPath}'",
-                c => ApplyFixAsync(context.Document, materializer, navigationPath!, c),
-                "LC045_AddInclude:" + navigationPath),
-            diagnostic);
     }
 
     private static async Task<Document> ApplyFixAsync(

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeFixer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeFixer.cs
@@ -77,7 +77,7 @@ public sealed class MissingIncludeFixer : CodeFixProvider
         foreach (var segment in navigationPath.Split('.'))
         {
             var methodName = first ? "Include" : "ThenInclude";
-            var lambda = SyntaxFactory.ParseExpression($"x => x.{segment}");
+            var lambda = SyntaxFactory.ParseExpression($"x => x.{EscapeIdentifier(segment)}");
             current = SyntaxFactory.InvocationExpression(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
@@ -90,6 +90,13 @@ public sealed class MissingIncludeFixer : CodeFixProvider
         editor.ReplaceNode(source, current.WithTriviaFrom(source));
 
         return editor.GetChangedDocument();
+    }
+
+    private static string EscapeIdentifier(string name)
+    {
+        // A navigation named after a reserved keyword (e.g. `@event`) is stored unescaped in
+        // the diagnostic path; emit it back with the verbatim prefix or the fix won't compile.
+        return SyntaxFacts.GetKeywordKind(name) == SyntaxKind.None ? name : "@" + name;
     }
 
     /// <summary>

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeFixer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeFixer.cs
@@ -1,0 +1,96 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace LinqContraband.Analyzers.LC045_MissingInclude;
+
+/// <summary>
+/// Provides code fixes for LC045. Inserts .Include(x => x.Nav) (and .ThenInclude for nested
+/// paths) immediately before the materializer so the accessed navigation is eagerly loaded.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MissingIncludeFixer))]
+[Shared]
+public sealed class MissingIncludeFixer : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(MissingIncludeAnalyzer.DiagnosticId);
+
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var diagnostic = context.Diagnostics.First();
+
+        if (!diagnostic.Properties.TryGetValue(MissingIncludeAnalyzer.NavigationPathProperty, out var navigationPath) ||
+            string.IsNullOrWhiteSpace(navigationPath))
+        {
+            return;
+        }
+
+        if (diagnostic.AdditionalLocations.Count == 0)
+            return;
+
+        var materializerNode = root?.FindNode(diagnostic.AdditionalLocations[0].SourceSpan, getInnermostNodeForTie: true);
+        var materializer = materializerNode as InvocationExpressionSyntax ??
+                           materializerNode?.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+        if (materializer?.Expression is not MemberAccessExpressionSyntax)
+            return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                $"Add .Include() for '{navigationPath}'",
+                c => ApplyFixAsync(context.Document, materializer, navigationPath!, c),
+                "LC045_AddInclude:" + navigationPath),
+            diagnostic);
+    }
+
+    private static async Task<Document> ApplyFixAsync(
+        Document document,
+        InvocationExpressionSyntax materializer,
+        string navigationPath,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        editor.EnsureUsing("Microsoft.EntityFrameworkCore");
+
+        if (materializer.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return document;
+
+        // Wrap the materializer's receiver: recv.ToList() => recv.Include(x => x.Nav).ToList().
+        // This is always a valid position for Include and lands after any existing Includes.
+        var source = memberAccess.Expression;
+        ExpressionSyntax current = source;
+        var first = true;
+
+        foreach (var segment in navigationPath.Split('.'))
+        {
+            var methodName = first ? "Include" : "ThenInclude";
+            var lambda = SyntaxFactory.ParseExpression($"x => x.{segment}");
+            current = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    current,
+                    SyntaxFactory.IdentifierName(methodName)),
+                SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(lambda))));
+            first = false;
+        }
+
+        editor.ReplaceNode(source, current.WithTriviaFrom(source));
+
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeFixer.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeFixer.cs
@@ -46,7 +46,7 @@ public sealed class MissingIncludeFixer : CodeFixProvider
             var materializerNode = root?.FindNode(diagnostic.AdditionalLocations[0].SourceSpan, getInnermostNodeForTie: true);
             var materializer = materializerNode as InvocationExpressionSyntax ??
                                materializerNode?.FirstAncestorOrSelf<InvocationExpressionSyntax>();
-            if (materializer?.Expression is not MemberAccessExpressionSyntax)
+            if (materializer == null)
                 continue;
 
             context.RegisterCodeFix(
@@ -68,12 +68,9 @@ public sealed class MissingIncludeFixer : CodeFixProvider
 
         editor.EnsureUsing("Microsoft.EntityFrameworkCore");
 
-        if (materializer.Expression is not MemberAccessExpressionSyntax memberAccess)
+        var source = await GetQuerySourceAsync(document, materializer, cancellationToken).ConfigureAwait(false);
+        if (source == null)
             return document;
-
-        // Wrap the materializer's receiver: recv.ToList() => recv.Include(x => x.Nav).ToList().
-        // This is always a valid position for Include and lands after any existing Includes.
-        var source = memberAccess.Expression;
         ExpressionSyntax current = source;
         var first = true;
 
@@ -93,5 +90,28 @@ public sealed class MissingIncludeFixer : CodeFixProvider
         editor.ReplaceNode(source, current.WithTriviaFrom(source));
 
         return editor.GetChangedDocument();
+    }
+
+    /// <summary>
+    /// The query expression to wrap with Include: the member-access receiver for reduced
+    /// extension syntax (q.ToList()), or the first argument for static syntax
+    /// (Enumerable.ToList(q)) — wrapping the type name there would produce invalid code.
+    /// </summary>
+    private static async Task<ExpressionSyntax?> GetQuerySourceAsync(
+        Document document,
+        InvocationExpressionSyntax materializer,
+        CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel?.GetSymbolInfo(materializer, cancellationToken).Symbol is not IMethodSymbol method)
+            return null;
+
+        if (method.MethodKind == MethodKind.ReducedExtension)
+            return (materializer.Expression as MemberAccessExpressionSyntax)?.Expression;
+
+        if (method.IsStatic && materializer.ArgumentList.Arguments.Count > 0)
+            return materializer.ArgumentList.Arguments[0].Expression;
+
+        return null;
     }
 }

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeNavigationAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeNavigationAnalysis.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+
+namespace LinqContraband.Analyzers.LC045_MissingInclude;
+
+public sealed partial class MissingIncludeAnalyzer
+{
+    private static HashSet<INamedTypeSymbol> CollectDbSetEntityTypes(INamedTypeSymbol contextType)
+    {
+        var entityTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        for (var current = contextType; current != null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if (member is not IPropertySymbol property) continue;
+                if (property.Type is not INamedTypeSymbol propertyType) continue;
+                if (!propertyType.IsDbSet()) continue;
+                if (propertyType.TypeArguments.Length > 0 && propertyType.TypeArguments[0] is INamedTypeSymbol entityType)
+                    entityTypes.Add(entityType);
+            }
+        }
+
+        return entityTypes;
+    }
+
+    /// <summary>
+    /// A property is a navigation when its type (or its collection element type) has a DbSet on
+    /// the same context. Owned and unmapped types have no DbSet, so EF loads them with the entity
+    /// (or never) and Include does not apply — they are deliberately never classified.
+    /// </summary>
+    private static bool TryGetNavigationTarget(
+        IPropertySymbol property,
+        HashSet<INamedTypeSymbol> entityTypes,
+        out INamedTypeSymbol targetEntity,
+        out bool isCollection)
+    {
+        targetEntity = null!;
+        isCollection = false;
+
+        if (property.IsStatic || property.Parameters.Length > 0)
+            return false;
+
+        if (property.Type is INamedTypeSymbol referenceTarget && entityTypes.Contains(referenceTarget))
+        {
+            targetEntity = referenceTarget;
+            return true;
+        }
+
+        if (IncludePathParser.TryGetCollectionElementType(property.Type, out var elementType) &&
+            elementType is INamedTypeSymbol collectionTarget &&
+            entityTypes.Contains(collectionTarget))
+        {
+            targetEntity = collectionTarget;
+            isCollection = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsPropertyOfEntity(IPropertySymbol property, INamedTypeSymbol entityType)
+    {
+        for (var current = (ITypeSymbol?)entityType; current != null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, property.ContainingType))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeNavigationAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeNavigationAnalysis.cs
@@ -14,10 +14,17 @@ public sealed partial class MissingIncludeAnalyzer
         {
             foreach (var member in current.GetMembers())
             {
-                if (member is not IPropertySymbol property) continue;
-                if (property.Type is not INamedTypeSymbol propertyType) continue;
-                if (!propertyType.IsDbSet()) continue;
-                if (propertyType.TypeArguments.Length > 0 && propertyType.TypeArguments[0] is INamedTypeSymbol entityType)
+                // TryGetDbSetRoot accepts both property and field DbSet roots, so both must
+                // contribute to the entity-type set.
+                var memberType = member switch
+                {
+                    IPropertySymbol property => property.Type as INamedTypeSymbol,
+                    IFieldSymbol field => field.Type as INamedTypeSymbol,
+                    _ => null
+                };
+
+                if (memberType == null || !memberType.IsDbSet()) continue;
+                if (memberType.TypeArguments.Length > 0 && memberType.TypeArguments[0] is INamedTypeSymbol entityType)
                     entityTypes.Add(entityType);
             }
         }

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeQueryAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeQueryAnalysis.cs
@@ -1,0 +1,214 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using System.Threading;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC045_MissingInclude;
+
+public sealed partial class MissingIncludeAnalyzer
+{
+    /// <summary>
+    /// Operators that keep the query shaped as "a stream of the root entity". Anything else
+    /// (Select, Join, GroupBy, custom extensions, …) reshapes the result or may add its own
+    /// loading behaviour, so the whole query is conservatively out of scope.
+    /// </summary>
+    private static readonly ImmutableHashSet<string> ShapePreservingOperators = ImmutableHashSet.Create(
+        System.StringComparer.Ordinal,
+        "Where",
+        "OrderBy",
+        "OrderByDescending",
+        "ThenBy",
+        "ThenByDescending",
+        "Skip",
+        "Take",
+        "Distinct",
+        "AsNoTracking",
+        "AsNoTrackingWithIdentityResolution",
+        "AsTracking",
+        "AsSplitQuery",
+        "AsSingleQuery",
+        "TagWith",
+        "TagWithCallSite",
+        "IgnoreQueryFilters",
+        "Include",
+        "ThenInclude");
+
+    private sealed class QueryChainInfo
+    {
+        public QueryChainInfo(INamedTypeSymbol entityType, INamedTypeSymbol contextType, HashSet<string> includedPrefixes)
+        {
+            EntityType = entityType;
+            ContextType = contextType;
+            IncludedPrefixes = includedPrefixes;
+        }
+
+        public INamedTypeSymbol EntityType { get; }
+        public INamedTypeSymbol ContextType { get; }
+        public HashSet<string> IncludedPrefixes { get; }
+    }
+
+    private static bool IsEntityMaterializer(IMethodSymbol method, out bool returnsCollection)
+    {
+        returnsCollection = false;
+
+        switch (method.Name)
+        {
+            case "ToList":
+            case "ToListAsync":
+            case "ToArray":
+            case "ToArrayAsync":
+                returnsCollection = true;
+                break;
+
+            case "First":
+            case "FirstAsync":
+            case "FirstOrDefault":
+            case "FirstOrDefaultAsync":
+            case "Single":
+            case "SingleAsync":
+            case "SingleOrDefault":
+            case "SingleOrDefaultAsync":
+            case "Last":
+            case "LastAsync":
+            case "LastOrDefault":
+            case "LastOrDefaultAsync":
+                break;
+
+            default:
+                return false;
+        }
+
+        return method.IsFrameworkMethod();
+    }
+
+    private static bool TryAnalyzeQueryChain(
+        IInvocationOperation materializer,
+        CancellationToken cancellationToken,
+        out QueryChainInfo queryInfo)
+    {
+        queryInfo = null!;
+
+        var chain = new List<IInvocationOperation>();
+        var current = materializer.GetInvocationReceiver();
+
+        while (current != null)
+        {
+            current = current.UnwrapConversions();
+
+            if (current is IInvocationOperation invocation)
+            {
+                if (!ShapePreservingOperators.Contains(invocation.TargetMethod.Name) ||
+                    !invocation.TargetMethod.IsFrameworkMethod())
+                {
+                    return false;
+                }
+
+                chain.Add(invocation);
+                current = invocation.GetInvocationReceiver();
+                continue;
+            }
+
+            // The query may be hoisted across a single-assignment local:
+            // `var q = db.Orders.Where(...); var list = q.ToList();`
+            if (current is ILocalReferenceOperation localReference)
+            {
+                var executableRoot = localReference.FindOwningExecutableRoot();
+                if (executableRoot != null &&
+                    LocalAssignmentCache.TryGetSingleAssignedValueBefore(
+                        executableRoot,
+                        localReference.Local,
+                        localReference.Syntax.SpanStart,
+                        out var assignedValue,
+                        cancellationToken))
+                {
+                    current = assignedValue;
+                    continue;
+                }
+
+                return false;
+            }
+
+            break;
+        }
+
+        if (!TryGetDbSetRoot(current, out var entityType, out var contextType))
+            return false;
+
+        var includedPrefixes = new HashSet<string>(System.StringComparer.Ordinal);
+        var semanticModel = materializer.SemanticModel;
+        IncludePath? currentIncludePath = null;
+
+        // Root-first order so each ThenInclude sees the Include path it extends.
+        chain.Reverse();
+        foreach (var invocation in chain)
+        {
+            var methodName = invocation.TargetMethod.Name;
+            if (methodName != "Include" && methodName != "ThenInclude")
+                continue;
+
+            // An Include we cannot parse (dynamic string, unresolved symbol) could cover any
+            // navigation, so the whole query must stay quiet.
+            if (semanticModel == null ||
+                !IncludePathParser.TryGetIncludePath(invocation, semanticModel, currentIncludePath, out var includePath))
+            {
+                return false;
+            }
+
+            currentIncludePath = includePath;
+            AddPathPrefixes(includePath, includedPrefixes);
+        }
+
+        queryInfo = new QueryChainInfo(entityType, contextType, includedPrefixes);
+        return true;
+    }
+
+    private static bool TryGetDbSetRoot(
+        IOperation? operation,
+        out INamedTypeSymbol entityType,
+        out INamedTypeSymbol contextType)
+    {
+        entityType = null!;
+        contextType = null!;
+
+        if (operation is not IMemberReferenceOperation memberReference)
+            return false;
+        if (operation is not (IPropertyReferenceOperation or IFieldReferenceOperation))
+            return false;
+
+        var rootType = memberReference.Type;
+        if (rootType == null || !rootType.IsDbSet())
+            return false;
+
+        var contextCandidate = memberReference.Instance?.Type as INamedTypeSymbol ??
+                               memberReference.Member.ContainingType;
+        if (contextCandidate == null || !contextCandidate.IsDbContext())
+            return false;
+
+        if (rootType is not INamedTypeSymbol namedRoot ||
+            namedRoot.TypeArguments.Length != 1 ||
+            namedRoot.TypeArguments[0] is not INamedTypeSymbol element)
+        {
+            return false;
+        }
+
+        entityType = element;
+        contextType = contextCandidate;
+        return true;
+    }
+
+    private static void AddPathPrefixes(IncludePath path, HashSet<string> prefixes)
+    {
+        // Include(o => o.A.B) loads every entity along the path, so each prefix counts as loaded.
+        var builder = new StringBuilder();
+        foreach (var segment in path.Segments)
+        {
+            if (builder.Length > 0)
+                builder.Append('.');
+            builder.Append(segment.Name);
+            prefixes.Add(builder.ToString());
+        }
+    }
+}

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeQueryAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeQueryAnalysis.cs
@@ -91,7 +91,9 @@ public sealed partial class MissingIncludeAnalyzer
     {
         queryInfo = null!;
 
-        var chain = new List<IInvocationOperation>();
+        // Allocated lazily: most materializer-named invocations are plain LINQ-to-objects
+        // that fail the DbSet root proof.
+        List<IInvocationOperation>? chain = null;
         var current = materializer.GetInvocationReceiver();
 
         while (current != null)
@@ -106,7 +108,7 @@ public sealed partial class MissingIncludeAnalyzer
                     return false;
                 }
 
-                chain.Add(invocation);
+                (chain ??= new List<IInvocationOperation>()).Add(invocation);
                 current = invocation.GetInvocationReceiver();
                 continue;
             }
@@ -142,23 +144,26 @@ public sealed partial class MissingIncludeAnalyzer
         IncludePath? currentIncludePath = null;
 
         // Root-first order so each ThenInclude sees the Include path it extends.
-        chain.Reverse();
-        foreach (var invocation in chain)
+        if (chain != null)
         {
-            var methodName = invocation.TargetMethod.Name;
-            if (methodName != "Include" && methodName != "ThenInclude")
-                continue;
-
-            // An Include we cannot parse (dynamic string, unresolved symbol) could cover any
-            // navigation, so the whole query must stay quiet.
-            if (semanticModel == null ||
-                !IncludePathParser.TryGetIncludePath(invocation, semanticModel, currentIncludePath, out var includePath))
+            chain.Reverse();
+            foreach (var invocation in chain)
             {
-                return false;
-            }
+                var methodName = invocation.TargetMethod.Name;
+                if (methodName != "Include" && methodName != "ThenInclude")
+                    continue;
 
-            currentIncludePath = includePath;
-            AddPathPrefixes(includePath, includedPrefixes);
+                // An Include we cannot parse (dynamic string, unresolved symbol) could cover any
+                // navigation, so the whole query must stay quiet.
+                if (semanticModel == null ||
+                    !IncludePathParser.TryGetIncludePath(invocation, semanticModel, currentIncludePath, out var includePath))
+                {
+                    return false;
+                }
+
+                currentIncludePath = includePath;
+                AddPathPrefixes(includePath, includedPrefixes);
+            }
         }
 
         queryInfo = new QueryChainInfo(entityType, contextType, includedPrefixes);

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeUsageAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeUsageAnalysis.cs
@@ -49,7 +49,17 @@ public sealed partial class MissingIncludeAnalyzer
             // single-entity materializers.
             return returnsCollection
                 ? null
-                : CollectInlineAccesses(materializer, entityType, entityTypes);
+                : CollectInlineAccesses(WalkUpThroughWrappers(materializer.Parent), entityType, entityTypes);
+        }
+
+        // db.Orders.FirstOrDefault()?.Customer.Name — the materializer is the guarded
+        // receiver of a conditional access; the nav chain lives in WhenNotNull.
+        if (upwardParent is IConditionalAccessOperation conditionalParent &&
+            conditionalParent.Operation.UnwrapConversions() == materializer)
+        {
+            return returnsCollection
+                ? null
+                : CollectInlineAccesses(FindConditionalAccessEntryProperty(conditionalParent), entityType, entityTypes);
         }
 
         var resultLocal = FindVariableAssignment(materializer);
@@ -129,15 +139,17 @@ public sealed partial class MissingIncludeAnalyzer
             {
                 case IReturnOperation returnOperation when
                     returnOperation.ReturnedValue != null &&
-                    IsTrackedLocal(returnOperation.ReturnedValue):
+                    IsEntitySource(returnOperation.ReturnedValue):
                     return null;
 
                 case IInvocationOperation call when call != materializer:
-                    if (IsTrackedLocal(call.Instance))
+                    if (IsEntitySource(call.Instance))
                         return null;
                     foreach (var argument in call.Arguments)
                     {
-                        if (IsTrackedLocal(argument.Value))
+                        // Hydrate(orders) and Hydrate(orders[0]) both hand the entity to a
+                        // helper that could explicitly load the navigation.
+                        if (IsEntitySource(argument.Value))
                             return null;
                     }
 
@@ -148,7 +160,7 @@ public sealed partial class MissingIncludeAnalyzer
                     return null;
 
                 case ISimpleAssignmentOperation assignmentOperation when
-                    IsTrackedLocal(assignmentOperation.Value) &&
+                    IsEntitySource(assignmentOperation.Value) &&
                     assignmentOperation.Target.UnwrapConversions() is not ILocalReferenceOperation:
                     return null;
 
@@ -170,8 +182,13 @@ public sealed partial class MissingIncludeAnalyzer
                     }
 
                     // o.Items.Add(x): mutating a tracked entity's collection does not read it.
-                    if (IsCollectionMutatorReceiver(propertyReference))
+                    // Only collection navigations qualify — order.Customer.Clear() still reads
+                    // the Customer navigation.
+                    if (IsCollectionNavigation(propertyReference, entityTypes) &&
+                        IsCollectionMutatorReceiver(propertyReference))
+                    {
                         break;
+                    }
 
                     accesses.Add(new NavigationAccess(path, propertyReference.Syntax));
                     break;
@@ -209,12 +226,12 @@ public sealed partial class MissingIncludeAnalyzer
     }
 
     private static List<NavigationAccess> CollectInlineAccesses(
-        IInvocationOperation materializer,
+        IOperation? start,
         INamedTypeSymbol entityType,
         HashSet<INamedTypeSymbol> entityTypes)
     {
         var accesses = new List<NavigationAccess>();
-        var current = WalkUpThroughWrappers(materializer.Parent);
+        var current = start;
         var currentEntity = entityType;
         string? path = null;
 
@@ -222,8 +239,11 @@ public sealed partial class MissingIncludeAnalyzer
                IsPropertyOfEntity(propertyReference.Property, currentEntity) &&
                TryGetNavigationTarget(propertyReference.Property, entityTypes, out var target, out var isCollection))
         {
-            if (IsWriteTarget(propertyReference) || IsCollectionMutatorReceiver(propertyReference))
+            if (IsWriteTarget(propertyReference) ||
+                (isCollection && IsCollectionMutatorReceiver(propertyReference)))
+            {
                 break;
+            }
 
             path = path == null ? propertyReference.Property.Name : path + "." + propertyReference.Property.Name;
             accesses.Add(new NavigationAccess(path, propertyReference.Syntax));
@@ -284,6 +304,34 @@ public sealed partial class MissingIncludeAnalyzer
         }
 
         return false;
+    }
+
+    private static bool IsCollectionNavigation(
+        IPropertyReferenceOperation propertyReference,
+        HashSet<INamedTypeSymbol> entityTypes)
+    {
+        return TryGetNavigationTarget(propertyReference.Property, entityTypes, out _, out var isCollection) &&
+               isCollection;
+    }
+
+    /// <summary>
+    /// For db.Orders.First()?.Customer.Name the navigation chain hangs off WhenNotNull;
+    /// descend it to the property whose instance is the conditional-access placeholder.
+    /// </summary>
+    private static IOperation? FindConditionalAccessEntryProperty(IConditionalAccessOperation conditionalAccess)
+    {
+        IOperation? current = conditionalAccess.WhenNotNull.UnwrapConversions();
+
+        while (current is IPropertyReferenceOperation propertyReference)
+        {
+            var instance = propertyReference.Instance?.UnwrapConversions();
+            if (instance is IConditionalAccessInstanceOperation)
+                return propertyReference;
+
+            current = instance;
+        }
+
+        return null;
     }
 
     private static IOperation? ResolveConditionalAccessReceiver(IOperation operation)

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeUsageAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeUsageAnalysis.cs
@@ -83,15 +83,19 @@ public sealed partial class MissingIncludeAnalyzer
                             entityLocals.Add(loopLocal);
                         break;
 
+                    // A local fed from the result by index only counts while it can't be
+                    // repointed at some unrelated object: require a single assignment.
                     case IVariableDeclaratorOperation declarator when
                         declarator.Initializer != null &&
-                        IsIndexedAccessOf(declarator.Initializer.Value, resultLocal):
+                        IsIndexedAccessOf(declarator.Initializer.Value, resultLocal) &&
+                        LocalAssignmentCache.GetAssignments(executableRoot, declarator.Symbol, cancellationToken).Count == 1:
                         entityLocals.Add(declarator.Symbol);
                         break;
 
                     case ISimpleAssignmentOperation assignmentOperation when
                         assignmentOperation.Target is ILocalReferenceOperation targetLocal &&
-                        IsIndexedAccessOf(assignmentOperation.Value, resultLocal):
+                        IsIndexedAccessOf(assignmentOperation.Value, resultLocal) &&
+                        LocalAssignmentCache.GetAssignments(executableRoot, targetLocal.Local, cancellationToken).Count == 1:
                         entityLocals.Add(targetLocal.Local);
                         break;
                 }
@@ -105,7 +109,17 @@ public sealed partial class MissingIncludeAnalyzer
                     entityLocals.Contains(localReference.Local));
         }
 
+        bool IsEntitySource(IOperation? operation)
+        {
+            if (IsTrackedLocal(operation))
+                return true;
+
+            // Direct indexed access: orders[0].Customer without an intermediate local.
+            return returnsCollection && operation != null && IsIndexedAccessOf(operation, resultLocal);
+        }
+
         var accesses = new List<NavigationAccess>();
+        var satisfiedPaths = new HashSet<string>(System.StringComparer.Ordinal);
 
         foreach (var descendant in executableRoot.Descendants())
         {
@@ -139,15 +153,50 @@ public sealed partial class MissingIncludeAnalyzer
                     return null;
 
                 case IPropertyReferenceOperation propertyReference:
-                    if (IsWriteUsage(propertyReference))
+                    if (IsInsideNameOf(propertyReference))
                         break;
-                    if (TryGetAccessPath(propertyReference, entityType, entityTypes, IsTrackedLocal, out var path))
-                        accesses.Add(new NavigationAccess(path, propertyReference.Syntax));
+                    if (!TryGetAccessPath(propertyReference, entityType, entityTypes, IsEntitySource, out var path))
+                        break;
+
+                    if (IsWriteTarget(propertyReference))
+                    {
+                        // o.Customer = c assigns an in-memory object, so later reads of that
+                        // path (and below it) are backed regardless of Include.
+                        satisfiedPaths.Add(path);
+                        break;
+                    }
+
+                    // o.Items.Add(x): mutating a tracked entity's collection does not read it.
+                    if (IsCollectionMutatorReceiver(propertyReference))
+                        break;
+
+                    accesses.Add(new NavigationAccess(path, propertyReference.Syntax));
                     break;
             }
         }
 
+        if (satisfiedPaths.Count > 0)
+            accesses.RemoveAll(access => IsSatisfied(access.Path, satisfiedPaths));
+
         return accesses;
+    }
+
+    private static bool IsSatisfied(string path, HashSet<string> satisfiedPaths)
+    {
+        foreach (var satisfied in satisfiedPaths)
+        {
+            if (path.Length == satisfied.Length && path == satisfied)
+                return true;
+
+            if (path.Length > satisfied.Length &&
+                path[satisfied.Length] == '.' &&
+                path.StartsWith(satisfied, System.StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static List<NavigationAccess> CollectInlineAccesses(
@@ -164,7 +213,7 @@ public sealed partial class MissingIncludeAnalyzer
                IsPropertyOfEntity(propertyReference.Property, currentEntity) &&
                TryGetNavigationTarget(propertyReference.Property, entityTypes, out var target, out var isCollection))
         {
-            if (IsWriteUsage(propertyReference))
+            if (IsWriteTarget(propertyReference) || IsCollectionMutatorReceiver(propertyReference))
                 break;
 
             path = path == null ? propertyReference.Property.Name : path + "." + propertyReference.Property.Name;
@@ -184,7 +233,7 @@ public sealed partial class MissingIncludeAnalyzer
         IPropertyReferenceOperation propertyReference,
         INamedTypeSymbol entityType,
         HashSet<INamedTypeSymbol> entityTypes,
-        System.Func<IOperation?, bool> isTrackedLocal,
+        System.Func<IOperation?, bool> isEntitySource,
         out string path)
     {
         path = null!;
@@ -194,7 +243,12 @@ public sealed partial class MissingIncludeAnalyzer
 
         var instance = propertyReference.Instance?.UnwrapConversions();
 
-        if (instance is ILocalReferenceOperation && isTrackedLocal(instance))
+        // order?.Customer: the instance is the conditional-access placeholder; resolve it to
+        // the guarded receiver so idiomatic null-guarded reads are still recognized.
+        if (instance is IConditionalAccessInstanceOperation)
+            instance = ResolveConditionalAccessReceiver(propertyReference)?.UnwrapConversions();
+
+        if (isEntitySource(instance))
         {
             if (!IsPropertyOfEntity(propertyReference.Property, entityType))
                 return false;
@@ -205,7 +259,7 @@ public sealed partial class MissingIncludeAnalyzer
 
         // Nested access through a reference navigation: o.Customer.Address => "Customer.Address".
         if (instance is IPropertyReferenceOperation parentReference &&
-            TryGetAccessPath(parentReference, entityType, entityTypes, isTrackedLocal, out var parentPath))
+            TryGetAccessPath(parentReference, entityType, entityTypes, isEntitySource, out var parentPath))
         {
             if (!TryGetNavigationTarget(parentReference.Property, entityTypes, out var parentTarget, out var parentIsCollection) ||
                 parentIsCollection)
@@ -223,16 +277,54 @@ public sealed partial class MissingIncludeAnalyzer
         return false;
     }
 
-    private static bool IsWriteUsage(IPropertyReferenceOperation propertyReference)
+    private static IOperation? ResolveConditionalAccessReceiver(IOperation operation)
     {
-        // o.Customer = c: relationship fix-up, not a read of unloaded data.
+        for (var current = operation.Parent; current != null; current = current.Parent)
+        {
+            if (current is IConditionalAccessOperation conditionalAccess)
+                return conditionalAccess.Operation;
+        }
+
+        return null;
+    }
+
+    private static bool IsInsideNameOf(IOperation operation)
+    {
+        for (var current = operation.Parent; current != null; current = current.Parent)
+        {
+            if (current is INameOfOperation)
+                return true;
+            if (current is IBlockOperation or IExpressionStatementOperation)
+                return false;
+        }
+
+        return false;
+    }
+
+    private static bool IsWriteTarget(IPropertyReferenceOperation propertyReference)
+    {
+        // o.Customer = c (also += / ??=): relationship fix-up, not a read of unloaded data.
         if (propertyReference.Parent is IAssignmentOperation assignment &&
             assignment.Target == propertyReference)
         {
             return true;
         }
 
-        // o.Items.Add(x): mutating a tracked entity's collection does not require loading it.
+        // (o.Customer, o.Status) = (...): the property sits in a tuple on the target side.
+        IOperation child = propertyReference;
+        var parent = propertyReference.Parent;
+        while (parent is ITupleOperation or IConversionOperation or IParenthesizedOperation)
+        {
+            child = parent;
+            parent = parent.Parent;
+        }
+
+        return parent is IDeconstructionAssignmentOperation deconstruction &&
+               deconstruction.Target == child;
+    }
+
+    private static bool IsCollectionMutatorReceiver(IPropertyReferenceOperation propertyReference)
+    {
         return propertyReference.Parent is IInvocationOperation parentCall &&
                parentCall.Instance == propertyReference &&
                CollectionMutatorMethods.Contains(parentCall.TargetMethod.Name);

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeUsageAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeUsageAnalysis.cs
@@ -1,0 +1,316 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using LinqContraband.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace LinqContraband.Analyzers.LC045_MissingInclude;
+
+public sealed partial class MissingIncludeAnalyzer
+{
+    private static readonly ImmutableHashSet<string> CollectionMutatorMethods = ImmutableHashSet.Create(
+        System.StringComparer.Ordinal,
+        "Add",
+        "AddRange",
+        "Remove",
+        "RemoveRange",
+        "Clear");
+
+    private readonly struct NavigationAccess
+    {
+        public NavigationAccess(string path, SyntaxNode syntax)
+        {
+            Path = path;
+            Syntax = syntax;
+        }
+
+        public string Path { get; }
+        public SyntaxNode Syntax { get; }
+    }
+
+    /// <summary>
+    /// Collects every navigation path read from the materialized result inside the owning
+    /// method. Returns null when the result (or an entity drawn from it) escapes — returned,
+    /// passed as an argument, captured by a lambda, or stored outside a local — because a
+    /// helper might explicitly load the navigation.
+    /// </summary>
+    private static List<NavigationAccess>? CollectNavigationAccesses(
+        IInvocationOperation materializer,
+        bool returnsCollection,
+        INamedTypeSymbol entityType,
+        HashSet<INamedTypeSymbol> entityTypes,
+        CancellationToken cancellationToken)
+    {
+        var upwardParent = WalkUpThroughWrappers(materializer.Parent);
+        if (upwardParent is IPropertyReferenceOperation)
+        {
+            // Inline access like db.Orders.First().Customer.Name — only provable for
+            // single-entity materializers.
+            return returnsCollection
+                ? null
+                : CollectInlineAccesses(materializer, entityType, entityTypes);
+        }
+
+        var resultLocal = FindVariableAssignment(materializer);
+        if (resultLocal == null)
+            return null;
+
+        var executableRoot = materializer.FindOwningExecutableRoot();
+        if (executableRoot == null)
+            return null;
+
+        // A reassigned result local could point at anything by the time it is read.
+        if (LocalAssignmentCache.GetAssignments(executableRoot, resultLocal, cancellationToken).Count != 1)
+            return null;
+
+        var entityLocals = new HashSet<ILocalSymbol>(SymbolEqualityComparer.Default);
+        if (!returnsCollection)
+            entityLocals.Add(resultLocal);
+
+        if (returnsCollection)
+        {
+            foreach (var descendant in executableRoot.Descendants())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                switch (descendant)
+                {
+                    case IForEachLoopOperation forEach when
+                        forEach.Collection.UnwrapConversions() is ILocalReferenceOperation collectionRef &&
+                        SymbolEqualityComparer.Default.Equals(collectionRef.Local, resultLocal):
+                        foreach (var loopLocal in forEach.Locals)
+                            entityLocals.Add(loopLocal);
+                        break;
+
+                    case IVariableDeclaratorOperation declarator when
+                        declarator.Initializer != null &&
+                        IsIndexedAccessOf(declarator.Initializer.Value, resultLocal):
+                        entityLocals.Add(declarator.Symbol);
+                        break;
+
+                    case ISimpleAssignmentOperation assignmentOperation when
+                        assignmentOperation.Target is ILocalReferenceOperation targetLocal &&
+                        IsIndexedAccessOf(assignmentOperation.Value, resultLocal):
+                        entityLocals.Add(targetLocal.Local);
+                        break;
+                }
+            }
+        }
+
+        bool IsTrackedLocal(IOperation? operation)
+        {
+            return operation?.UnwrapConversions() is ILocalReferenceOperation localReference &&
+                   (SymbolEqualityComparer.Default.Equals(localReference.Local, resultLocal) ||
+                    entityLocals.Contains(localReference.Local));
+        }
+
+        var accesses = new List<NavigationAccess>();
+
+        foreach (var descendant in executableRoot.Descendants())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            switch (descendant)
+            {
+                case IReturnOperation returnOperation when
+                    returnOperation.ReturnedValue != null &&
+                    IsTrackedLocal(returnOperation.ReturnedValue):
+                    return null;
+
+                case IInvocationOperation call when call != materializer:
+                    if (IsTrackedLocal(call.Instance))
+                        return null;
+                    foreach (var argument in call.Arguments)
+                    {
+                        if (IsTrackedLocal(argument.Value))
+                            return null;
+                    }
+
+                    break;
+
+                case IAnonymousFunctionOperation lambda when
+                    LambdaReferencesTrackedLocal(lambda, resultLocal, entityLocals, cancellationToken):
+                    return null;
+
+                case ISimpleAssignmentOperation assignmentOperation when
+                    IsTrackedLocal(assignmentOperation.Value) &&
+                    assignmentOperation.Target.UnwrapConversions() is not ILocalReferenceOperation:
+                    return null;
+
+                case IPropertyReferenceOperation propertyReference:
+                    if (IsWriteUsage(propertyReference))
+                        break;
+                    if (TryGetAccessPath(propertyReference, entityType, entityTypes, IsTrackedLocal, out var path))
+                        accesses.Add(new NavigationAccess(path, propertyReference.Syntax));
+                    break;
+            }
+        }
+
+        return accesses;
+    }
+
+    private static List<NavigationAccess> CollectInlineAccesses(
+        IInvocationOperation materializer,
+        INamedTypeSymbol entityType,
+        HashSet<INamedTypeSymbol> entityTypes)
+    {
+        var accesses = new List<NavigationAccess>();
+        var current = WalkUpThroughWrappers(materializer.Parent);
+        var currentEntity = entityType;
+        string? path = null;
+
+        while (current is IPropertyReferenceOperation propertyReference &&
+               IsPropertyOfEntity(propertyReference.Property, currentEntity) &&
+               TryGetNavigationTarget(propertyReference.Property, entityTypes, out var target, out var isCollection))
+        {
+            if (IsWriteUsage(propertyReference))
+                break;
+
+            path = path == null ? propertyReference.Property.Name : path + "." + propertyReference.Property.Name;
+            accesses.Add(new NavigationAccess(path, propertyReference.Syntax));
+
+            if (isCollection)
+                break;
+
+            currentEntity = target;
+            current = WalkUpThroughWrappers(propertyReference.Parent);
+        }
+
+        return accesses;
+    }
+
+    private static bool TryGetAccessPath(
+        IPropertyReferenceOperation propertyReference,
+        INamedTypeSymbol entityType,
+        HashSet<INamedTypeSymbol> entityTypes,
+        System.Func<IOperation?, bool> isTrackedLocal,
+        out string path)
+    {
+        path = null!;
+
+        if (!TryGetNavigationTarget(propertyReference.Property, entityTypes, out _, out _))
+            return false;
+
+        var instance = propertyReference.Instance?.UnwrapConversions();
+
+        if (instance is ILocalReferenceOperation && isTrackedLocal(instance))
+        {
+            if (!IsPropertyOfEntity(propertyReference.Property, entityType))
+                return false;
+
+            path = propertyReference.Property.Name;
+            return true;
+        }
+
+        // Nested access through a reference navigation: o.Customer.Address => "Customer.Address".
+        if (instance is IPropertyReferenceOperation parentReference &&
+            TryGetAccessPath(parentReference, entityType, entityTypes, isTrackedLocal, out var parentPath))
+        {
+            if (!TryGetNavigationTarget(parentReference.Property, entityTypes, out var parentTarget, out var parentIsCollection) ||
+                parentIsCollection)
+            {
+                return false;
+            }
+
+            if (!IsPropertyOfEntity(propertyReference.Property, parentTarget))
+                return false;
+
+            path = parentPath + "." + propertyReference.Property.Name;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsWriteUsage(IPropertyReferenceOperation propertyReference)
+    {
+        // o.Customer = c: relationship fix-up, not a read of unloaded data.
+        if (propertyReference.Parent is IAssignmentOperation assignment &&
+            assignment.Target == propertyReference)
+        {
+            return true;
+        }
+
+        // o.Items.Add(x): mutating a tracked entity's collection does not require loading it.
+        return propertyReference.Parent is IInvocationOperation parentCall &&
+               parentCall.Instance == propertyReference &&
+               CollectionMutatorMethods.Contains(parentCall.TargetMethod.Name);
+    }
+
+    private static bool LambdaReferencesTrackedLocal(
+        IAnonymousFunctionOperation lambda,
+        ILocalSymbol resultLocal,
+        HashSet<ILocalSymbol> entityLocals,
+        CancellationToken cancellationToken)
+    {
+        foreach (var descendant in lambda.Descendants())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (descendant is ILocalReferenceOperation localReference &&
+                (SymbolEqualityComparer.Default.Equals(localReference.Local, resultLocal) ||
+                 entityLocals.Contains(localReference.Local)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IOperation? WalkUpThroughWrappers(IOperation? operation)
+    {
+        while (operation is IConversionOperation or IParenthesizedOperation or IAwaitOperation)
+            operation = operation.Parent;
+
+        return operation;
+    }
+
+    private static bool IsIndexedAccessOf(IOperation operation, ILocalSymbol collectionLocal)
+    {
+        var unwrapped = operation.UnwrapConversions();
+        if (unwrapped is IPropertyReferenceOperation propertyReference && propertyReference.Arguments.Length > 0)
+        {
+            var instance = propertyReference.Instance?.UnwrapConversions();
+            if (instance is ILocalReferenceOperation localReference &&
+                SymbolEqualityComparer.Default.Equals(localReference.Local, collectionLocal))
+            {
+                return true;
+            }
+        }
+
+        if (unwrapped is IArrayElementReferenceOperation arrayElement &&
+            arrayElement.ArrayReference.UnwrapConversions() is ILocalReferenceOperation arrayLocal &&
+            SymbolEqualityComparer.Default.Equals(arrayLocal.Local, collectionLocal))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static ILocalSymbol? FindVariableAssignment(IInvocationOperation invocation)
+    {
+        var parent = invocation.Parent;
+
+        while (parent != null)
+        {
+            if (parent is IVariableDeclaratorOperation declarator)
+                return declarator.Symbol;
+
+            if (parent is ISimpleAssignmentOperation assignment &&
+                assignment.Target is ILocalReferenceOperation localReference)
+            {
+                return localReference.Local;
+            }
+
+            if (parent is IExpressionStatementOperation or IReturnOperation)
+                break;
+
+            parent = parent.Parent;
+        }
+
+        return null;
+    }
+}

--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeUsageAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeUsageAnalysis.cs
@@ -119,7 +119,7 @@ public sealed partial class MissingIncludeAnalyzer
         }
 
         var accesses = new List<NavigationAccess>();
-        var satisfiedPaths = new HashSet<string>(System.StringComparer.Ordinal);
+        var satisfiedPaths = new Dictionary<string, int>(System.StringComparer.Ordinal);
 
         foreach (var descendant in executableRoot.Descendants())
         {
@@ -160,9 +160,12 @@ public sealed partial class MissingIncludeAnalyzer
 
                     if (IsWriteTarget(propertyReference))
                     {
-                        // o.Customer = c assigns an in-memory object, so later reads of that
-                        // path (and below it) are backed regardless of Include.
-                        satisfiedPaths.Add(path);
+                        // o.Customer = c assigns an in-memory object, so reads of that path
+                        // (and below it) AFTER the assignment are backed regardless of
+                        // Include. Reads before it still flag.
+                        var spanStart = propertyReference.Syntax.SpanStart;
+                        if (!satisfiedPaths.TryGetValue(path, out var existingSpan) || spanStart < existingSpan)
+                            satisfiedPaths[path] = spanStart;
                         break;
                     }
 
@@ -176,21 +179,27 @@ public sealed partial class MissingIncludeAnalyzer
         }
 
         if (satisfiedPaths.Count > 0)
-            accesses.RemoveAll(access => IsSatisfied(access.Path, satisfiedPaths));
+            accesses.RemoveAll(access => IsSatisfied(access, satisfiedPaths));
 
         return accesses;
     }
 
-    private static bool IsSatisfied(string path, HashSet<string> satisfiedPaths)
+    private static bool IsSatisfied(NavigationAccess access, Dictionary<string, int> satisfiedPaths)
     {
-        foreach (var satisfied in satisfiedPaths)
+        foreach (var pair in satisfiedPaths)
         {
-            if (path.Length == satisfied.Length && path == satisfied)
+            // Lexical ordering is the v1 heuristic: only reads after the assignment count
+            // as backed (a conditional assignment before a read is conservatively quiet).
+            if (access.Syntax.SpanStart < pair.Value)
+                continue;
+
+            var satisfied = pair.Key;
+            if (access.Path.Length == satisfied.Length && access.Path == satisfied)
                 return true;
 
-            if (path.Length > satisfied.Length &&
-                path[satisfied.Length] == '.' &&
-                path.StartsWith(satisfied, System.StringComparison.Ordinal))
+            if (access.Path.Length > satisfied.Length &&
+                access.Path[satisfied.Length] == '.' &&
+                access.Path.StartsWith(satisfied, System.StringComparison.Ordinal))
             {
                 return true;
             }

--- a/src/LinqContraband/Catalog/RuleCatalog.cs
+++ b/src/LinqContraband/Catalog/RuleCatalog.cs
@@ -623,7 +623,21 @@ public static class RuleCatalog
             samplePath: "samples/LinqContraband.Sample/Samples/LC044_AsNoTrackingThenModify/AsNoTrackingThenModifySample.cs",
             analyzerSourcePath: "src/LinqContraband/Analyzers/ChangeTrackingAndContextLifetime/LC044_AsNoTrackingThenModify",
             hasCodeFix: false,
-            noCodeFixRationale: "No automatic fix: the right resolution depends on intent — either remove AsNoTracking() so the entity is tracked from origin, or call Update/Attach (or set Entry.State = Modified) before SaveChanges. Both are semantically valid depending on context.")
+            noCodeFixRationale: "No automatic fix: the right resolution depends on intent — either remove AsNoTracking() so the entity is tracked from origin, or call Update/Attach (or set Entry.State = Modified) before SaveChanges. Both are semantically valid depending on context."),
+        new RuleCatalogEntry(
+            id: "LC045",
+            slug: "LC045_MissingInclude",
+            title: "Missing Include: navigation accessed on materialized entity",
+            category: "Reliability",
+            domain: "Loading & Includes",
+            severity: DiagnosticSeverity.Warning,
+            analyzerTypeName: "MissingIncludeAnalyzer",
+            fixerTypeName: "MissingIncludeFixer",
+            documentationPath: "docs/LC045_MissingInclude.md",
+            samplePath: "samples/LinqContraband.Sample/Samples/LC045_MissingInclude/MissingIncludeSample.cs",
+            analyzerSourcePath: "src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude",
+            hasCodeFix: true,
+            noCodeFixRationale: null)
     );
 
     public static RuleCatalogEntry GetById(string id)

--- a/src/LinqContraband/Extensions/IncludePathParser.cs
+++ b/src/LinqContraband/Extensions/IncludePathParser.cs
@@ -1,13 +1,55 @@
 using System.Collections.Immutable;
-using LinqContraband.Extensions;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 
-namespace LinqContraband.Analyzers.LC006_CartesianExplosion;
+namespace LinqContraband.Extensions;
 
-public sealed partial class CartesianExplosionAnalyzer
+/// <summary>
+/// A single navigation step inside an Include/ThenInclude path, e.g. the "Items" in
+/// <c>Include(o => o.Items)</c>.
+/// </summary>
+internal readonly struct NavigationSegment
+{
+    public NavigationSegment(string name, bool isCollection)
+    {
+        Name = name;
+        IsCollection = isCollection;
+    }
+
+    public string Name { get; }
+    public bool IsCollection { get; }
+}
+
+/// <summary>
+/// A full eager-loading path built from one Include plus any chained ThenIncludes,
+/// e.g. "Orders.Items" for <c>Include(c => c.Orders).ThenInclude(o => o.Items)</c>.
+/// </summary>
+internal sealed class IncludePath
+{
+    public IncludePath(ImmutableArray<NavigationSegment> segments)
+    {
+        Segments = segments;
+    }
+
+    public ImmutableArray<NavigationSegment> Segments { get; }
+
+    public string Key => string.Join(".", Segments.Select(segment => segment.Name));
+
+    public IncludePath Append(IncludePath childPath)
+    {
+        return new IncludePath(Segments.AddRange(childPath.Segments));
+    }
+}
+
+/// <summary>
+/// Parses EF Core Include/ThenInclude invocations (lambda, filtered-lambda, and constant-string
+/// overloads) into <see cref="IncludePath"/> values. Shared by LC006 (cartesian explosion) and
+/// LC045 (missing include).
+/// </summary>
+internal static class IncludePathParser
 {
     private static readonly ImmutableHashSet<string> FilteredIncludeMethods = ImmutableHashSet.Create(
         System.StringComparer.Ordinal,
@@ -19,7 +61,7 @@ public sealed partial class CartesianExplosionAnalyzer
         "Skip",
         "Take");
 
-    private static bool TryGetIncludePath(
+    public static bool TryGetIncludePath(
         IInvocationOperation invocation,
         SemanticModel semanticModel,
         IncludePath? previousIncludePath,
@@ -201,7 +243,7 @@ public sealed partial class CartesianExplosionAnalyzer
         return null;
     }
 
-    private static bool IsCollection(ITypeSymbol type)
+    public static bool IsCollection(ITypeSymbol type)
     {
         if (type.SpecialType == SpecialType.System_String)
             return false;
@@ -229,7 +271,7 @@ public sealed partial class CartesianExplosionAnalyzer
         return false;
     }
 
-    private static bool TryGetCollectionElementType(ITypeSymbol type, out ITypeSymbol elementType)
+    public static bool TryGetCollectionElementType(ITypeSymbol type, out ITypeSymbol elementType)
     {
         elementType = null!;
         if (type.SpecialType == SpecialType.System_String)

--- a/src/LinqContraband/Extensions/IncludePathParser.cs
+++ b/src/LinqContraband/Extensions/IncludePathParser.cs
@@ -194,9 +194,22 @@ internal static class IncludePathParser
         if (expression is not MemberAccessExpressionSyntax memberAccess)
             return false;
 
-        if (memberAccess.Expression is MemberAccessExpressionSyntax parentMemberAccess)
+        // Unwrap mid-path casts/parens/null-forgiving (`o.Customer!.Address`,
+        // `((Derived)o.Nav).Child`) so the parent segments are still collected. Any other
+        // parent shape fails the parse — truncating would turn an unknown into a wrong path.
+        switch (UnwrapExpression(memberAccess.Expression))
         {
-            if (!TryAddNavigationSegments(parentMemberAccess, semanticModel, builder))
+            case MemberAccessExpressionSyntax parentMemberAccess:
+                if (!TryAddNavigationSegments(parentMemberAccess, semanticModel, builder))
+                    return false;
+                break;
+            case InvocationExpressionSyntax parentInvocation:
+                if (!TryAddNavigationSegments(parentInvocation, semanticModel, builder))
+                    return false;
+                break;
+            case IdentifierNameSyntax:
+                break;
+            default:
                 return false;
         }
 

--- a/src/LinqContraband/Extensions/OperationTraversalExtensions.cs
+++ b/src/LinqContraband/Extensions/OperationTraversalExtensions.cs
@@ -63,7 +63,9 @@ public static partial class AnalysisExtensions
         var current = operation;
         while (current != null)
         {
-            if (current is IMethodBodyOperation or ILocalFunctionOperation or IAnonymousFunctionOperation)
+            // IMethodBodyBaseOperation covers both ordinary method bodies and constructor
+            // bodies — analyzers must not go blind inside constructors.
+            if (current is IMethodBodyBaseOperation or ILocalFunctionOperation or IAnonymousFunctionOperation)
                 return current;
 
             current = current.Parent;

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeEdgeCasesTests.cs
@@ -514,6 +514,137 @@ class Program
     }
 
     [Fact]
+    public async Task TestInnocent_NullForgivingMidPathInclude_NoDiagnostic()
+    {
+        // o.Customer!.Address is the idiomatic NRT spelling of a multi-level include; the
+        // parser must see "Customer.Address", not a truncated "Address".
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => o.Customer!.Address).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Address.City);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_CastMidPathInclude_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => ((Customer)o.Customer).Address).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Address.City);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_NavAssignedThenRead_NoDiagnostic()
+    {
+        // The navigation now points at an in-memory object, so the later read is backed
+        // regardless of Include.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var order = db.Orders.FirstOrDefault();
+        order.Customer = new Customer();
+        Console.WriteLine(order.Customer.Name);
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_EntityLocalReusedAcrossObjects_NoDiagnostic()
+    {
+        // The local is repointed between a fresh in-memory object and a query entity; with
+        // more than one assignment we cannot prove which object any given read sees.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        Order t = new Order();
+        Console.WriteLine(t.Customer.Name);
+        t = orders[0];
+        Console.WriteLine(t.Id);
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_NameofNavigation_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(nameof(o.Customer));
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_DeconstructionAssignmentToNav_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            (o.Customer, o.Status) = (new Customer(), ""done"");
+        }
+        db.SaveChanges();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task TestInnocent_AggregateTerminal_NoDiagnostic()
     {
         var test = Usings + @"

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeEdgeCasesTests.cs
@@ -645,6 +645,28 @@ class Program
     }
 
     [Fact]
+    public async Task TestInnocent_IndexedEntityPassedAsArgument_NoDiagnostic()
+    {
+        // orders[0] escapes to a helper that could explicitly load the navigation.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        Hydrate(orders[0]);
+        Console.WriteLine(orders[0].Customer.Name);
+    }
+
+    void Hydrate(Order order) { }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task TestInnocent_AggregateTerminal_NoDiagnostic()
     {
         var test = Usings + @"

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeEdgeCasesTests.cs
@@ -1,0 +1,533 @@
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    LinqContraband.Analyzers.LC045_MissingInclude.MissingIncludeAnalyzer>;
+
+namespace LinqContraband.Tests.Analyzers.LC045_MissingInclude;
+
+public class MissingIncludeEdgeCasesTests
+{
+    private const string Usings = @"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using TestNamespace;
+";
+
+    private const string MockNamespace = @"
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public interface IIncludableQueryable<out TEntity, out TProperty> : IQueryable<TEntity> { }
+}
+
+namespace Microsoft.EntityFrameworkCore
+{
+    using Microsoft.EntityFrameworkCore.Query;
+
+    public class DbContext : IDisposable
+    {
+        public void Dispose() { }
+        public int SaveChanges() => 0;
+        public EntityEntry<T> Entry<T>(T entity) where T : class => null;
+    }
+
+    public class EntityEntry<T> where T : class { }
+
+    public class DbSet<T> : IQueryable<T> where T : class
+    {
+        public Type ElementType => typeof(T);
+        public System.Linq.Expressions.Expression Expression => System.Linq.Expressions.Expression.Constant(this);
+        public IQueryProvider Provider => null;
+        public IEnumerator<T> GetEnumerator() => null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null;
+    }
+
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static IQueryable<TEntity> Include<TEntity>(
+            this IQueryable<TEntity> source,
+            string navigationPropertyPath)
+            => source;
+
+        public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TProperty>(
+            this IQueryable<TEntity> source,
+            System.Linq.Expressions.Expression<Func<TEntity, TProperty>> navigationPropertyPath)
+            => null;
+
+        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this IIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>> source,
+            System.Linq.Expressions.Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+            => null;
+
+        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this IIncludableQueryable<TEntity, TPreviousProperty> source,
+            System.Linq.Expressions.Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+            => null;
+
+        public static IQueryable<T> AsNoTracking<T>(this IQueryable<T> source) => source;
+        public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source) => null;
+    }
+}
+
+namespace TestNamespace
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public string Status { get; set; }
+        public Customer Customer { get; set; }
+        public List<OrderItem> Items { get; set; }
+        public OrderSummary Summary { get; set; }
+    }
+
+    public class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Address Address { get; set; }
+    }
+
+    public class Address
+    {
+        public int Id { get; set; }
+        public string City { get; set; }
+    }
+
+    public class OrderItem
+    {
+        public int Id { get; set; }
+        public string Sku { get; set; }
+    }
+
+    public class OrderSummary
+    {
+        public decimal Total { get; set; }
+    }
+
+    public class MyDbContext : DbContext
+    {
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<Customer> Customers { get; set; }
+        public DbSet<Address> Addresses { get; set; }
+        public DbSet<OrderItem> OrderItems { get; set; }
+    }
+
+    public static class MyExtensions
+    {
+        public static IQueryable<T> Shuffle<T>(this IQueryable<T> source) => source;
+    }
+}";
+
+    [Fact]
+    public async Task TestInnocent_LambdaIncludeCoversAccess_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => o.Customer).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_StringIncludeCoversAccess_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(""Customer"").ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ThenIncludeCoversNestedAccess_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => o.Customer).ThenInclude(c => c.Address).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Address.City);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_FilteredIncludeCoversAccess_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => o.Items.Where(i => i.Id > 0)).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Items.Count);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_SelectProjectionInChain_NoDiagnostic()
+    {
+        // A Select reshapes the query: the materialized objects are no longer raw entities, so
+        // any navigation data was either projected deliberately or the access happens on a
+        // different type. The whole query is out of scope.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var customers = db.Orders.Select(o => o.Customer).ToList();
+        foreach (var c in customers)
+        {
+            Console.WriteLine(c.Address.City);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_OnlyScalarPropertiesAccessed_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Id + o.Status);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_PropertyTypeWithoutDbSet_NoDiagnostic()
+    {
+        // OrderSummary has no DbSet on the context: it is an owned/unmapped type, which EF
+        // loads with the entity (or never), so Include does not apply.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Summary.Total);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ResultLocalReassigned_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        orders = new List<Order>();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ResultPassedAsArgument_NoDiagnostic()
+    {
+        // The helper may explicitly load the navigations; once the list escapes we cannot
+        // prove the access is unbacked.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        Hydrate(orders);
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+
+    void Hydrate(List<Order> orders) { }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ResultReturned_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    List<Order> Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        Console.WriteLine(orders.Count);
+        return orders;
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ResultUsedThroughLambda_NoDiagnostic()
+    {
+        // Accesses inside lambdas over the result are out of scope for v1; the local escaping
+        // into the Select call keeps the rule quiet.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        var names = orders.Select(o => o.Customer.Name).ToList();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ForEachMethodOnResult_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        orders.ForEach(o => Console.WriteLine(o.Customer.Name));
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_NavAssignedNotRead_NoDiagnostic()
+    {
+        // Setting a navigation is how relationships are created on tracked entities; it does
+        // not read unloaded data.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            o.Customer = new Customer();
+        }
+        db.SaveChanges();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_CollectionNavMutated_NoDiagnostic()
+    {
+        // Adding to a tracked entity's collection is a legitimate write pattern that does not
+        // require the existing rows to be loaded.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            o.Items.Add(new OrderItem());
+        }
+        db.SaveChanges();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_EntityPassedToEntry_NoDiagnostic()
+    {
+        // db.Entry(order) may be used to explicitly load the navigation; the entity escaping
+        // as an argument keeps the rule quiet.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var order = db.Orders.FirstOrDefault();
+        db.Entry(order);
+        Console.WriteLine(order.Customer.Name);
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_NonEfSource_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var source = new List<Order>();
+        var orders = source.Where(o => o.Id > 0).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_NonConstantStringInclude_BailsOnWholeQuery_NoDiagnostic()
+    {
+        // We cannot prove what the dynamic Include loads, so the entire query is out of scope
+        // — even for navigations the dynamic string could not plausibly cover.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var navigation = ""Customer"";
+        var orders = db.Orders.Include(navigation).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+            Console.WriteLine(o.Items.Count);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_UnknownQueryOperatorInChain_NoDiagnostic()
+    {
+        // A custom operator may reshape the query or add its own includes; bail conservatively.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Shuffle().ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_AggregateTerminal_NoDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var count = db.Orders.Count();
+        Console.WriteLine(count);
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeFixerTests.cs
@@ -356,6 +356,48 @@ class Program
     }
 
     [Fact]
+    public async Task FixCrime_StaticCallSyntax_WrapsTheArgumentNotTheTypeName()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = System.Linq.Enumerable.ToList(db.Orders);
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|LC045:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = System.Linq.Enumerable.ToList(db.Orders.Include(x => x.Customer));
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
     public async Task FixAll_AddsIncludeToEveryFlaggedQuery()
     {
         var test = Usings + @"

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeFixerTests.cs
@@ -97,6 +97,7 @@ namespace TestNamespace
         public int Id { get; set; }
         public string Status { get; set; }
         public Customer Customer { get; set; }
+        public Customer @event { get; set; }
         public List<OrderItem> Items { get; set; }
     }
 
@@ -383,6 +384,48 @@ class Program
         foreach (var o in orders)
         {
             Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixCrime_KeywordNamedNavigation_EscapesTheIdentifier()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|LC045:o.@event|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(x => x.@event).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.@event.Name);
         }
     }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeFixerTests.cs
@@ -1,0 +1,376 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using CodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
+    LinqContraband.Analyzers.LC045_MissingInclude.MissingIncludeAnalyzer,
+    LinqContraband.Analyzers.LC045_MissingInclude.MissingIncludeFixer,
+    Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+
+namespace LinqContraband.Tests.Analyzers.LC045_MissingInclude;
+
+public class MissingIncludeFixerTests
+{
+    private const string Usings = @"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using TestNamespace;
+";
+
+    private const string UsingsWithoutEfCore = @"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TestNamespace;
+";
+
+    private const string UsingsWithEfCoreAppended = @"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TestNamespace;
+using Microsoft.EntityFrameworkCore;
+";
+
+    private const string MockNamespace = @"
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public interface IIncludableQueryable<out TEntity, out TProperty> : IQueryable<TEntity> { }
+}
+
+namespace Microsoft.EntityFrameworkCore
+{
+    using Microsoft.EntityFrameworkCore.Query;
+
+    public class DbContext : IDisposable
+    {
+        public void Dispose() { }
+        public int SaveChanges() => 0;
+    }
+
+    public class DbSet<T> : IQueryable<T> where T : class
+    {
+        public Type ElementType => typeof(T);
+        public System.Linq.Expressions.Expression Expression => System.Linq.Expressions.Expression.Constant(this);
+        public IQueryProvider Provider => null;
+        public IEnumerator<T> GetEnumerator() => null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null;
+    }
+
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static IQueryable<TEntity> Include<TEntity>(
+            this IQueryable<TEntity> source,
+            string navigationPropertyPath)
+            => source;
+
+        public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TProperty>(
+            this IQueryable<TEntity> source,
+            System.Linq.Expressions.Expression<Func<TEntity, TProperty>> navigationPropertyPath)
+            => null;
+
+        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this IIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>> source,
+            System.Linq.Expressions.Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+            => null;
+
+        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this IIncludableQueryable<TEntity, TPreviousProperty> source,
+            System.Linq.Expressions.Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+            => null;
+
+        public static IQueryable<T> AsNoTracking<T>(this IQueryable<T> source) => source;
+        public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source) => null;
+    }
+}
+
+namespace TestNamespace
+{
+    using Microsoft.EntityFrameworkCore;
+
+    public class Order
+    {
+        public int Id { get; set; }
+        public string Status { get; set; }
+        public Customer Customer { get; set; }
+        public List<OrderItem> Items { get; set; }
+    }
+
+    public class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Address Address { get; set; }
+    }
+
+    public class Address
+    {
+        public int Id { get; set; }
+        public string City { get; set; }
+    }
+
+    public class OrderItem
+    {
+        public int Id { get; set; }
+        public string Sku { get; set; }
+    }
+
+    public class MyDbContext : DbContext
+    {
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<Customer> Customers { get; set; }
+        public DbSet<Address> Addresses { get; set; }
+        public DbSet<OrderItem> OrderItems { get; set; }
+    }
+}";
+
+    [Fact]
+    public async Task FixCrime_AddsIncludeBeforeMaterializer()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|LC045:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(x => x.Customer).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixCrime_AppendsAfterExistingInclude()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => o.Items).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Items.Count);
+            Console.WriteLine({|LC045:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => o.Items).Include(x => x.Customer).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Items.Count);
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixCrime_NestedPath_AddsIncludeThenInclude()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => o.Customer).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|LC045:o.Customer.Address|}.City);
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => o.Customer).Include(x => x.Customer).ThenInclude(x => x.Address).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Address.City);
+        }
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixCrime_AddsMissingEfCoreUsing()
+    {
+        var test = UsingsWithoutEfCore + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|LC045:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = UsingsWithEfCoreAppended + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(x => x.Customer).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode
+        };
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
+    public async Task FixAll_AddsIncludeToEveryFlaggedQuery()
+    {
+        var test = Usings + @"
+class Program
+{
+    void First()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer|}.Name);
+        }
+    }
+
+    void Second()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Where(o => o.Id > 0).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#1:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void First()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(x => x.Customer).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+
+    void Second()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Where(o => o.Id > 0).Include(x => x.Customer).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            BatchFixedCode = fixedCode,
+            NumberOfIncrementalIterations = 2,
+            CodeFixEquivalenceKey = "LC045_AddInclude:Customer"
+        };
+
+        testObj.ExpectedDiagnostics.Add(
+            new DiagnosticResult("LC045", DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("Customer", "Order")
+                .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations));
+        testObj.ExpectedDiagnostics.Add(
+            new DiagnosticResult("LC045", DiagnosticSeverity.Warning)
+                .WithLocation(1)
+                .WithArguments("Customer", "Order")
+                .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations));
+
+        await testObj.RunAsync();
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeFixerTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeFixerTests.cs
@@ -299,6 +299,63 @@ class Program
     }
 
     [Fact]
+    public async Task FixCrime_TwoMissingNavsOnOneQuery_FixesBoth()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer|}.Name);
+            Console.WriteLine({|#1:o.Items|}.Count);
+        }
+    }
+}
+" + MockNamespace;
+
+        var fixedCode = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(x => x.Customer).Include(x => x.Items).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Customer.Name);
+            Console.WriteLine(o.Items.Count);
+        }
+    }
+}
+" + MockNamespace;
+
+        var testObj = new CodeFixTest
+        {
+            TestCode = test,
+            FixedCode = fixedCode,
+            NumberOfIncrementalIterations = 2,
+            NumberOfFixAllIterations = 2
+        };
+
+        testObj.ExpectedDiagnostics.Add(
+            new DiagnosticResult("LC045", DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("Customer", "Order")
+                .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations));
+        testObj.ExpectedDiagnostics.Add(
+            new DiagnosticResult("LC045", DiagnosticSeverity.Warning)
+                .WithLocation(1)
+                .WithArguments("Items", "Order")
+                .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations));
+
+        await testObj.RunAsync();
+    }
+
+    [Fact]
     public async Task FixAll_AddsIncludeToEveryFlaggedQuery()
     {
         var test = Usings + @"

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeTests.cs
@@ -98,6 +98,7 @@ namespace TestNamespace
         public int Id { get; set; }
         public string Name { get; set; }
         public Address Address { get; set; }
+        public void Clear() { }
     }
 
     public class Address
@@ -494,6 +495,50 @@ class Program
         foreach (var o in orders)
         {
             Console.WriteLine({|#0:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_InlineConditionalAccessOnMaterializer_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var name = db.Orders.FirstOrDefault()?{|#0:.Customer|}.Name;
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_MutatorNamedMethodOnReferenceNav_StillTriggersDiagnostic()
+    {
+        // Clear() here is an instance method on the Customer entity, not a collection
+        // mutation: evaluating o.Customer is still a read of unloaded data.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            {|#0:o.Customer|}.Clear();
         }
     }
 }

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeTests.cs
@@ -1,0 +1,415 @@
+using Microsoft.CodeAnalysis.Testing;
+using VerifyCS = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    LinqContraband.Analyzers.LC045_MissingInclude.MissingIncludeAnalyzer>;
+
+namespace LinqContraband.Tests.Analyzers.LC045_MissingInclude;
+
+public class MissingIncludeTests
+{
+    // LC045 carries the materializer invocation as an additional location for the fixer; the
+    // fixer tests verify it lands correctly, so analyzer tests ignore it instead of spelling
+    // out a second brittle span per case.
+    private static DiagnosticResult Diagnostic(int markupKey, string navigationPath, string entityName)
+    {
+        return VerifyCS.Diagnostic("LC045")
+            .WithLocation(markupKey)
+            .WithArguments(navigationPath, entityName)
+            .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations);
+    }
+
+    private const string Usings = @"
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using TestNamespace;
+";
+
+    private const string MockNamespace = @"
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public interface IIncludableQueryable<out TEntity, out TProperty> : IQueryable<TEntity> { }
+}
+
+namespace Microsoft.EntityFrameworkCore
+{
+    using Microsoft.EntityFrameworkCore.Query;
+
+    public class DbContext : IDisposable
+    {
+        public void Dispose() { }
+        public int SaveChanges() => 0;
+        public EntityEntry<T> Entry<T>(T entity) where T : class => null;
+    }
+
+    public class EntityEntry<T> where T : class { }
+
+    public class DbSet<T> : IQueryable<T> where T : class
+    {
+        public Type ElementType => typeof(T);
+        public System.Linq.Expressions.Expression Expression => System.Linq.Expressions.Expression.Constant(this);
+        public IQueryProvider Provider => null;
+        public IEnumerator<T> GetEnumerator() => null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null;
+    }
+
+    public static class EntityFrameworkQueryableExtensions
+    {
+        public static IQueryable<TEntity> Include<TEntity>(
+            this IQueryable<TEntity> source,
+            string navigationPropertyPath)
+            => source;
+
+        public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TProperty>(
+            this IQueryable<TEntity> source,
+            System.Linq.Expressions.Expression<Func<TEntity, TProperty>> navigationPropertyPath)
+            => null;
+
+        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this IIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>> source,
+            System.Linq.Expressions.Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+            => null;
+
+        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+            this IIncludableQueryable<TEntity, TPreviousProperty> source,
+            System.Linq.Expressions.Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+            => null;
+
+        public static IQueryable<T> AsNoTracking<T>(this IQueryable<T> source) => source;
+        public static Task<List<T>> ToListAsync<T>(this IQueryable<T> source) => null;
+    }
+}
+
+namespace TestNamespace
+{
+    public class Order
+    {
+        public int Id { get; set; }
+        public string Status { get; set; }
+        public Customer Customer { get; set; }
+        public List<OrderItem> Items { get; set; }
+        public OrderSummary Summary { get; set; }
+    }
+
+    public class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Address Address { get; set; }
+    }
+
+    public class Address
+    {
+        public int Id { get; set; }
+        public string City { get; set; }
+    }
+
+    public class OrderItem
+    {
+        public int Id { get; set; }
+        public string Sku { get; set; }
+    }
+
+    public class OrderSummary
+    {
+        public decimal Total { get; set; }
+    }
+
+    public class MyDbContext : DbContext
+    {
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<Customer> Customers { get; set; }
+        public DbSet<Address> Addresses { get; set; }
+        public DbSet<OrderItem> OrderItems { get; set; }
+    }
+}";
+
+    [Fact]
+    public async Task TestCrime_ForeachOverList_ReferenceNavAccessed_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_CollectionNavAccessed_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Items|}.Count);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Items", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_SingleEntityMaterializer_NavAccessedOnLocal_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var order = db.Orders.FirstOrDefault();
+        if (order != null)
+        {
+            Console.WriteLine({|#0:order.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_PartialInclude_FlagsOnlyTheMissingNav()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => o.Items).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine(o.Items.Count);
+            Console.WriteLine({|#0:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_NestedNavAccess_FlagsTheFullPath()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(o => o.Customer).ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer.Address|}.City);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer.Address", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_TwoMissingNavs_TwoDiagnostics()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer|}.Name);
+            Console.WriteLine({|#1:o.Items|}.Count);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = new[]
+        {
+            Diagnostic(0, "Customer", "Order"),
+            Diagnostic(1, "Items", "Order")
+        };
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_StringIncludeForOtherNav_DoesNotBlindTheRule()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.Include(""Items"").ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_AwaitToListAsync_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    async Task Main()
+    {
+        var db = new MyDbContext();
+        var orders = await db.Orders.ToListAsync();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_QueryHoistedToLocal_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var q = db.Orders.Where(o => o.Id > 0);
+        var orders = q.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_InlineAccessOnSingleEntityMaterializer_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var name = {|#0:db.Orders.First().Customer|}.Name;
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_NullGuardedAccess_StillTriggersDiagnostic()
+    {
+        // Deliberate: with lazy-loading proxies the null check itself fires the N+1 query;
+        // without proxies the navigation is always null and the guard is dead code hiding
+        // the missing Include. Either way the query is wrong.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            if ({|#0:o.Customer|} != null)
+            {
+                Console.WriteLine(o.Customer.Name);
+            }
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_AsNoTrackingQuery_StillTriggersDiagnostic()
+    {
+        // AsNoTracking + missing Include is the worst case: even with lazy-loading proxies
+        // configured, many setups cannot lazy-load untracked entities — the nav is just null.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.AsNoTracking().ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+}

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeTests.cs
@@ -124,6 +124,12 @@ namespace TestNamespace
         public DbSet<Address> Addresses { get; set; }
         public DbSet<OrderItem> OrderItems { get; set; }
     }
+
+    public class FieldDbContext : DbContext
+    {
+        public DbSet<Order> Orders = null;
+        public DbSet<Customer> Customers = null;
+    }
 }";
 
     [Fact]
@@ -443,6 +449,52 @@ class Program
         var db = new MyDbContext();
         var orders = db.Orders.ToList();
         Console.WriteLine({|#0:orders[0].Customer|}.Name);
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_ReadBeforeNavAssignment_StillTriggersDiagnostic()
+    {
+        // The assignment only backs reads AFTER it; this read happens first and still hits
+        // unloaded data.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var order = db.Orders.FirstOrDefault();
+        Console.WriteLine({|#0:order.Customer|}.Name);
+        order.Customer = new Customer();
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_DbSetFieldRoot_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new FieldDbContext();
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer|}.Name);
+        }
     }
 }
 " + MockNamespace;

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeTests.cs
@@ -389,6 +389,70 @@ class Program
     }
 
     [Fact]
+    public async Task TestCrime_InConstructorBody_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    public Program(MyDbContext db)
+    {
+        var orders = db.Orders.ToList();
+        foreach (var o in orders)
+        {
+            Console.WriteLine({|#0:o.Customer|}.Name);
+        }
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_ConditionalAccessNav_TriggersDiagnostic()
+    {
+        // order?.Customer is the idiomatic null guard — same deliberate decision as the
+        // explicit `!= null` check: the guard does not make the missing Include safe.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var order = db.Orders.FirstOrDefault();
+        Console.WriteLine(order?{|#0:.Customer|}.Name);
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_DirectIndexedAccess_TriggersDiagnostic()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var orders = db.Orders.ToList();
+        Console.WriteLine({|#0:orders[0].Customer|}.Name);
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task TestCrime_AsNoTrackingQuery_StillTriggersDiagnostic()
     {
         // AsNoTracking + missing Include is the worst case: even with lazy-loading proxies

--- a/tests/LinqContraband.Tests/Architecture/RuleCatalogIntegrityTests.cs
+++ b/tests/LinqContraband.Tests/Architecture/RuleCatalogIntegrityTests.cs
@@ -16,7 +16,7 @@ public sealed class RuleCatalogIntegrityTests
     {
         var rules = RuleCatalog.All;
 
-        Assert.Equal(44, rules.Length);
+        Assert.Equal(45, rules.Length);
         Assert.Equal(rules.Length, rules.Select(rule => rule.Id).Distinct(StringComparer.Ordinal).Count());
         Assert.Equal(rules.OrderBy(rule => rule.Id, StringComparer.Ordinal).Select(rule => rule.Id), rules.Select(rule => rule.Id));
     }


### PR DESCRIPTION
## What

Adds **LC045 `MissingInclude`** — the 45th rule — covering the single most famous EF Core bug that no existing rule caught: a DbSet-rooted query is materialized (`ToList`, `FirstOrDefault`, …) and a navigation property is then read that the query never `Include`d.

- With lazy-loading proxies: a read-side **N+1** (one query per access).
- Without proxies: a **silent null / empty collection** — a correctness bug.

```csharp
var orders = db.Orders.ToList();
foreach (var o in orders)
    Console.WriteLine(o.Customer.Name);   // LC045 on o.Customer

// fixer output
var orders = db.Orders.Include(x => x.Customer).ToList();
```

## How it stays FP-free (Warning severity)

- DbSet root proof + whitelist of shape-preserving operators; `Select`/`Join`/custom extensions bail the whole query.
- Include parsing (lambda, filtered, constant-string, `!`/cast mid-path) shared with LC006 via a new `IncludePathParser`; any unparseable Include bails.
- Escape analysis: result or entity returned / passed as argument / lambda-captured / stored non-locally → quiet.
- Navigation = property whose type has a DbSet on the same context → owned/unmapped types never flag.
- Nav writes (`o.Customer = c`, deconstruction, `o.Items.Add`) are not reads; in-memory assignment satisfies later reads (lexically ordered).
- Deliberate: null-guarded reads (`!= null`, `?.`) still flag — documented with suppression guidance.

## Fixer

Wraps the materializer receiver with `.Include(x => x.Nav)` (+ `.ThenInclude` per nested segment), handles static call syntax, keyword-named navigations (`@event`), adds the EF using, supports FixAll (BatchFixer) with per-path equivalence keys.

## Hardening

Adversarial passes by `analyzer-fp-fn-hunter`, `roslyn-analyzer-reviewer`, and four rounds of `codex review` — all findings fixed with regression tests (mid-path `!`/cast includes, repointed locals, `nameof`, constructors, `?.` access, indexed access, DbSet fields, static-syntax fixer, keyword escaping) or explicitly documented as v1 scope cuts in the rule doc.

## Verification

- 1001 tests pass (`dotnet test --framework net10.0`), 53 of them LC045-specific (crimes / innocents / fixer / FixAll batch).
- SampleDiagnosticsVerifier green; rule-catalog doc regenerated; five-surface contract + descriptor/convention architecture tests pass.
- `codex review --base master`: no actionable findings.