### PR TITLE
chore: prepare 5.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.0] - 2026-06-09
+
+### Added
+- New rule `LC045` **Missing Include: navigation accessed on materialized entity** (Reliability, Warning, code fix). Detects the canonical EF Core read-side bug: a DbSet-rooted query is materialized (`ToList`, `FirstOrDefault`, …) and a navigation property of the result is then read without a matching `Include`/`ThenInclude` — an N+1 query per access under lazy-loading proxies, or a silent `null`/empty collection without them. The code fix inserts `.Include(x => x.Nav)` (with `.ThenInclude` for nested paths) immediately before the materializer and supports FixAll. Detection is deliberately conservative: only shape-preserving operator chains rooted in a `DbSet` property/field qualify; `Select`/`Join`/custom operators, unparseable (dynamic-string) Includes, reassigned locals, and any escape of the result (returned, passed as an argument, lambda-captured, stored non-locally) silence the query. Navigation writes (`o.Customer = c`, deconstruction, collection `Add`/`Remove`) are recognised as relationship fix-up, and an in-memory assignment satisfies later reads of that path. Null-guarded reads (`!= null`, `?.`) flag on purpose — the guard itself triggers the lazy load or hides the always-null bug. Hardened pre-release by adversarial FP/FN hunting and four cross-model review rounds (constructor bodies, `?.`-guarded and indexed access, `nameof`, keyword-named navigations, static LINQ call syntax, DbSet fields).
+
+### Fixed
+- `LC006` include-path parsing (now shared with `LC045` via `IncludePathParser`): a mid-path cast or null-forgiving operator in an Include lambda — `Include(o => o.Customer!.Address)`, `Include(o => ((Derived)o.Nav).Child)` — previously parsed as a silently truncated path (`Address`), which could mis-group sibling collections; the full path is now parsed, and an unrecognised lambda shape fails the parse instead of truncating.
+
 ## [5.5.13] - 2026-06-04
 
 ### Fixed

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.5.13</Version>
+        <Version>5.6.0</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC026 now recognises a CancellationToken stored in a field or surfaced through a readable property as an available token, so an EF async call that omits it is flagged (and the fixer passes it by name) — previously only locals and parameters counted, silently missing the common injected-token / IHostApplicationLifetime.ApplicationStopping patterns. (Found by a second adversarial false-negative rescan.)</PackageReleaseNotes>
+        <PackageReleaseNotes>New rule LC045 (Missing Include): flags navigation properties read from materialized query results that the query never eagerly loaded — the classic read-side N+1 under lazy-loading proxies, or a silent null/empty collection without them. Ships with a code fix that inserts .Include()/.ThenInclude() before the materializer (FixAll supported) and conservative escape analysis to keep false positives at zero. Also fixes the Include-path parsing shared with LC006: mid-path casts and null-forgiving operators (o.Customer!.Address) now parse as the full navigation path instead of a silently truncated segment.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
Release-prep PR for **v5.6.0** (two-PR cadence; fix PR was #162).

- Bumps `<Version>` 5.5.13 → 5.6.0
- `<PackageReleaseNotes>` and the new `CHANGELOG.md` 5.6.0 entry reference the same LC ids: **LC045** (new Missing Include rule + fixer) and **LC006** (shared include-path parsing fix)
- `docs/rule-catalog.md` regenerated (`--check` clean)

Local gate: build clean, 1001/1001 tests (incl. release-notes/changelog consistency + catalog integrity), SampleDiagnosticsVerifier passed.

After merge: publish the GitHub Release `v5.6.0` to trigger `publish.yml` → NuGet.