### PR TITLE
fix(LC045): chained ?. navigation access crashed the compiler (uncatchable StackOverflowException)

### DIFF
--- a/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeUsageAnalysis.cs
+++ b/src/LinqContraband/Analyzers/LoadingAndIncludes/LC045_MissingInclude/MissingIncludeUsageAnalysis.cs
@@ -336,10 +336,22 @@ public sealed partial class MissingIncludeAnalyzer
 
     private static IOperation? ResolveConditionalAccessReceiver(IOperation operation)
     {
+        // o?.Customer?.Name nests two conditional accesses, and Customer's placeholder belongs
+        // to the OUTER one: its owner is the nearest ancestor reached from the WhenNotNull
+        // side. Matching the first IConditionalAccessOperation ancestor regardless of side
+        // returns the inner access — whose Operation is the very property reference being
+        // resolved — and TryGetAccessPath then recurses on its own input until the stack
+        // overflows, killing the whole compilation.
+        var child = operation;
         for (var current = operation.Parent; current != null; current = current.Parent)
         {
-            if (current is IConditionalAccessOperation conditionalAccess)
+            if (current is IConditionalAccessOperation conditionalAccess &&
+                conditionalAccess.WhenNotNull == child)
+            {
                 return conditionalAccess.Operation;
+            }
+
+            child = current;
         }
 
         return null;
@@ -382,9 +394,20 @@ public sealed partial class MissingIncludeAnalyzer
 
     private static bool IsCollectionMutatorReceiver(IPropertyReferenceOperation propertyReference)
     {
-        return propertyReference.Parent is IInvocationOperation parentCall &&
-               parentCall.Instance == propertyReference &&
-               CollectionMutatorMethods.Contains(parentCall.TargetMethod.Name);
+        if (propertyReference.Parent is IInvocationOperation parentCall &&
+            parentCall.Instance == propertyReference &&
+            CollectionMutatorMethods.Contains(parentCall.TargetMethod.Name))
+        {
+            return true;
+        }
+
+        // o?.Items?.Add(x): the mutator call hangs off a conditional access guarding the
+        // navigation, so its instance is the placeholder rather than the property reference.
+        return propertyReference.Parent is IConditionalAccessOperation conditionalAccess &&
+               conditionalAccess.Operation == propertyReference &&
+               conditionalAccess.WhenNotNull.UnwrapConversions() is IInvocationOperation conditionalCall &&
+               conditionalCall.Instance is IConditionalAccessInstanceOperation &&
+               CollectionMutatorMethods.Contains(conditionalCall.TargetMethod.Name);
     }
 
     private static bool LambdaReferencesTrackedLocal(

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeEdgeCasesTests.cs
@@ -667,6 +667,49 @@ class Program
     }
 
     [Fact]
+    public async Task TestInnocent_ConditionalCollectionMutatorCall_NoDiagnostic()
+    {
+        // order?.Items?.Add(x) is the null-guarded spelling of the mutation pattern that the
+        // rule deliberately ignores: the Add call hangs off a conditional access, so the
+        // mutator-receiver check must look through the placeholder.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var order = db.Orders.FirstOrDefault();
+        order?.Items?.Add(new OrderItem());
+        db.SaveChanges();
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TestInnocent_ChainedConditionalAccessCoveredByInclude_NoDiagnostic()
+    {
+        // order?.Customer?.Name nests two conditional accesses — the shape that previously
+        // sent TryGetAccessPath into infinite recursion. With the Include present the
+        // analyzer must both terminate and stay quiet.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var order = db.Orders.Include(o => o.Customer).FirstOrDefault();
+        Console.WriteLine(order?.Customer?.Name);
+    }
+}
+" + MockNamespace;
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task TestInnocent_AggregateTerminal_NoDiagnostic()
     {
         var test = Usings + @"

--- a/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC045_MissingInclude/MissingIncludeTests.cs
@@ -440,6 +440,73 @@ class Program
     }
 
     [Fact]
+    public async Task TestCrime_ChainedConditionalAccessNav_TriggersDiagnostic()
+    {
+        // order?.Customer?.Name nests two conditional accesses; Customer's placeholder belongs
+        // to the OUTER one. Resolving it to the inner one returns the Customer reference
+        // itself, and TryGetAccessPath recurses on its own input until the stack overflows —
+        // an uncatchable crash that kills the whole csc process (5.6.0 regression).
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var order = db.Orders.FirstOrDefault();
+        Console.WriteLine(order?{|#0:.Customer|}?.Name);
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_ChainedConditionalAccessNestedNav_FlagsTheFullPath()
+    {
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var order = db.Orders.FirstOrDefault();
+        Console.WriteLine(order?.Customer?{|#0:.Address|}?.City);
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer.Address", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
+    public async Task TestCrime_MixedPlainAndConditionalChain_FlagsTheFullPath()
+    {
+        // order?.Customer.Address?.City was a second, independent crash shape: Customer's
+        // placeholder walk used to resolve to its own PARENT (the Address reference),
+        // producing mutual recursion instead of self-recursion.
+        var test = Usings + @"
+class Program
+{
+    void Main()
+    {
+        var db = new MyDbContext();
+        var order = db.Orders.FirstOrDefault();
+        Console.WriteLine(order?{|#0:.Customer.Address|}?.City);
+    }
+}
+" + MockNamespace;
+
+        var expected = Diagnostic(0, "Customer.Address", "Order");
+
+        await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    }
+
+    [Fact]
     public async Task TestCrime_DirectIndexedAccess_TriggersDiagnostic()
     {
         var test = Usings + @"


### PR DESCRIPTION
## Problem

Building any project where a materialized entity's navigation is read through a **chained null-conditional** — `order?.Customer?.Name` — crashed the C# compiler itself with a `StackOverflowException` inside `MissingIncludeAnalyzer.TryGetAccessPath` (reported against 5.6.0 from a production codebase, ~21,500 recursive frames). Because a stack overflow is uncatchable, Roslyn's `ExecuteAndCatchIfThrows` sandbox cannot downgrade it to AD0001: the whole `csc` process dies and the build fails hard.

## Root cause

Not the visited-set/`SymbolEqualityComparer` theory from the report — the entity-type sets were already symbol-keyed correctly. `o?.A?.B` nests two `IConditionalAccessOperation`s, and `A`'s `IConditionalAccessInstanceOperation` placeholder belongs to the **outer** one. `ResolveConditionalAccessReceiver` matched the **first** conditional-access ancestor regardless of which side the walk arrived from:

- `order?.Customer?.Name` → the first ancestor of `Customer` is the *inner* access, whose `Operation` **is** the `Customer` reference itself → `TryGetAccessPath` recurses on its own input forever (self-recursion).
- `order?.Customer.Address?.City` → the placeholder resolves to `Customer`'s own parent (`.Address`) → `TryGetAccessPath(Customer) → (Address) → (Customer) → …` (mutual recursion).

## Fix

The walk-up now tracks the child it came from and only matches a conditional access reached from its **`WhenNotNull`** side, returning that access's guarded receiver — the documented placeholder-correspondence rule. Every resolved receiver now lives in a disjoint subtree strictly left of the access, so the recursion is bounded by expression size.

Un-crashing `o?.X?.Y(...)` also unmasked one false positive in the same family: `order?.Items?.Add(x)` — the null-guarded spelling of the collection-mutation pattern LC045 deliberately ignores. `IsCollectionMutatorReceiver` now recognizes the mutator call through the conditional-access placeholder.

## Tests (TDD — each red first, except the noted guard)

- `TestCrime_ChainedConditionalAccessNav_TriggersDiagnostic` — `order?.Customer?.Name` flags `Customer` (previously: compiler crash)
- `TestCrime_ChainedConditionalAccessNestedNav_FlagsTheFullPath` — `order?.Customer?.Address?.City` flags `Customer.Address`
- `TestCrime_MixedPlainAndConditionalChain_FlagsTheFullPath` — the mutual-recursion shape (green regression guard)
- `TestInnocent_ChainedConditionalAccessCoveredByInclude_NoDiagnostic`
- `TestInnocent_ConditionalCollectionMutatorCall_NoDiagnostic` — `order?.Items?.Add(x)` stays quiet

Full suite 1006/1006 on net10.0; sample-diagnostics verifier passes; Codex review clean; `roslyn-analyzer-reviewer` and `analyzer-fp-fn-hunter` both sign off on termination (no remaining non-termination risk found across `(o?.A)?.B`, `o?.A!.B`, `o?.GetX().B`, `o?.Items?[0]`, deep chains).

## Known follow-ups (pre-existing 5.6.0 behavior, out of scope here)

- FN: inline `db.Orders.FirstOrDefault()?.Customer?.Name` is silently skipped (`FindConditionalAccessEntryProperty` doesn't descend nested conditional accesses)
- FP: `entity?.SomeMethod()` is not recognized as an escape (`IsEntitySource` doesn't resolve placeholders), unlike `entity.SomeMethod()`
- FN: parenthesized receiver `(order?.Customer)?.Address.City` reports only `Customer`, not `Customer.Address`