### PR TITLE
chore: prepare 5.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.1] - 2026-06-10
+
+### Fixed
+- **Critical:** `LC045` crashed the C# compiler itself — an uncatchable `StackOverflowException`, not a containable AD0001 — whenever a materialized entity's navigation was read through a **chained null-conditional** (`order?.Customer?.Name`). The conditional-access placeholder of the middle link belongs to the *outer* `?.`, but the receiver resolution matched the first conditional access found walking up, which for nested accesses returned the property reference being resolved itself, so `TryGetAccessPath` recursed on its own input until the stack overflowed and the whole `csc` process died (reported against 5.6.0 from a production codebase; the mixed shape `order?.Customer.Address?.City` triggered the same crash via mutual recursion). Placeholders now resolve to the conditional access reached from its `WhenNotNull` side, bounding the walk by expression size. Un-crashing these shapes also unmasked one false positive, fixed here too: `order?.Items?.Add(x)` — the null-guarded spelling of the collection-mutation pattern the rule deliberately ignores — is now recognised by the mutator-receiver check instead of being flagged as an unloaded read. Anyone who disabled the rule with `dotnet_diagnostic.LC045.severity = none` to unblock builds can re-enable it on this version.
+
 ## [5.6.0] - 2026-06-09
 
 ### Added

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.0</Version>
+        <Version>5.6.1</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>New rule LC045 (Missing Include): flags navigation properties read from materialized query results that the query never eagerly loaded — the classic read-side N+1 under lazy-loading proxies, or a silent null/empty collection without them. Ships with a code fix that inserts .Include()/.ThenInclude() before the materializer (FixAll supported) and conservative escape analysis to keep false positives at zero. Also fixes the Include-path parsing shared with LC006: mid-path casts and null-forgiving operators (o.Customer!.Address) now parse as the full navigation path instead of a silently truncated segment.</PackageReleaseNotes>
+        <PackageReleaseNotes>Critical fix for LC045 (Missing Include): reading a navigation through a chained null-conditional — order?.Customer?.Name — sent the analyzer into infinite recursion, and the resulting StackOverflowException is uncatchable, so it crashed the csc process itself and failed the whole build (reported from a production codebase on 5.6.0). Conditional-access placeholders now resolve to their owning access, the mixed shape order?.Customer.Address?.City is fixed too, and the null-guarded collection mutation order?.Items?.Add(x) no longer produces a false positive now that the shape analyzes instead of crashing. If you disabled the rule with dotnet_diagnostic.LC045.severity = none, it is safe to re-enable on 5.6.1.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
Release-prep PR for **5.6.1** — ships the LC045 compiler-crash fix from #164.

- `<Version>` 5.6.0 → 5.6.1
- `<PackageReleaseNotes>` and new `CHANGELOG.md` `## [5.6.1]` entry (both reference only LC045, satisfying the release-notes/changelog rule-id contract test)

After merge: publish GitHub release `v5.6.1` to trigger the NuGet publish workflow.

Full suite 1006/1006 on net10.0 on this branch; Codex review clean.