### PR TITLE
chore: prepare 5.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.2] - 2026-06-10
+
+### Fixed
+- `LC045` was silent on the **null-conditional spellings** of shapes it already flags in plain form, contradicting the rule doc's "null-guarded access still fires" contract. Five false negatives are closed: chained inline access on the materializer (`db.Orders.FirstOrDefault()?.Customer?.Name` — the entry-property descent stopped at a nested conditional access), the mixed chain (`FirstOrDefault()?.Customer.Address?.City`), a method call on the navigation (`FirstOrDefault()?.Customer.Clear()` — the `WhenNotNull` arm is an invocation), conditional element access on the result (`orders?[0].Customer.Name`), and a local initialized from a conditional indexer (`var o = orders?[0];`). The fixes descend only strictly-shrinking sides of the operation tree (a conditional access's `Operation` side, an invocation's receiver), so the 5.6.0 recursion-crash class cannot recur — and the same adversarial pass that found these confirmed no surviving crash shapes across deep `?.` chains, `!`/cast mixes, interpolation, and nested conditional access in arguments, all locked in by regression tests. Residual documented polish: a parenthesized regrouping (`(order?.Customer)?.Address?.City`) truncates the reported path to `Customer`.
+
 ## [5.6.1] - 2026-06-10
 
 ### Fixed

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.1</Version>
+        <Version>5.6.2</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>Critical fix for LC045 (Missing Include): reading a navigation through a chained null-conditional — order?.Customer?.Name — sent the analyzer into infinite recursion, and the resulting StackOverflowException is uncatchable, so it crashed the csc process itself and failed the whole build (reported from a production codebase on 5.6.0). Conditional-access placeholders now resolve to their owning access, the mixed shape order?.Customer.Address?.City is fixed too, and the null-guarded collection mutation order?.Items?.Add(x) no longer produces a false positive now that the shape analyzes instead of crashing. If you disabled the rule with dotnet_diagnostic.LC045.severity = none, it is safe to re-enable on 5.6.1.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC045 (Missing Include) now flags the null-conditional spellings of inline and indexed navigation reads that were silently missed: db.Orders.FirstOrDefault()?.Customer?.Name, FirstOrDefault()?.Customer.Address?.City, FirstOrDefault()?.Customer.Clear(), orders?[0].Customer.Name, and var o = orders?[0]. A dedicated adversarial pass over the conditional-access surface (the code behind the 5.6.0 csc crash) confirmed no remaining crash shapes — deep ?. chains, !/cast mixes, interpolation, and nested conditional access in arguments all terminate cleanly and are locked in by regression tests.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
Release prep for **5.6.2** — ships the LC045 conditional-access false-negative fixes (PR #167).

## Impact
- `<Version>` 5.6.1 → 5.6.2; `<PackageReleaseNotes>` and `CHANGELOG.md` both reference LC045 (consistency test green).

## Validation
- `dotnet test` net10.0: 1013/1013 passed (includes the release-notes/changelog consistency test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)