### PR TITLE
chore: prepare 5.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.3] - 2026-06-10
+
+### Fixed
+- `LC023` no longer suggests `Find`/`FindAsync` for entities with a visible **global query filter**. `Find` checks the change tracker before querying, and a tracker hit bypasses `HasQueryFilter` (verified against EF Core 9's `EntityFinder`: only the database fallback runs through the filtered query root) — so the `FirstOrDefault(x => x.Id == id)` → `Find(id)` rewrite could silently return an already-tracked soft-deleted or other-tenant row the filtered query excluded. The gate keys on the `DbSet`'s entity type rather than the key's declaring type (an `Id` inherited from a `BaseEntity` doesn't dodge it), walks base types because EF declares filters on the hierarchy root and propagates them to derived entities, and recognises `OnModelCreating`, `EntityTypeBuilder<T>` configuration classes, and the non-generic `modelBuilder.Entity(typeof(X)).HasQueryFilter(...)` form. Lookalike `HasQueryFilter` methods on non-EF builder types and filters on unrelated entities do not suppress. A filter configured in another assembly remains invisible — documented as a manual review point. (Closes the hazard deferred from the 2026-06-04 Round-2 rescan.)
+
 ## [5.6.2] - 2026-06-10
 
 ### Fixed

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.2</Version>
+        <Version>5.6.3</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC045 (Missing Include) now flags the null-conditional spellings of inline and indexed navigation reads that were silently missed: db.Orders.FirstOrDefault()?.Customer?.Name, FirstOrDefault()?.Customer.Address?.City, FirstOrDefault()?.Customer.Clear(), orders?[0].Customer.Name, and var o = orders?[0]. A dedicated adversarial pass over the conditional-access surface (the code behind the 5.6.0 csc crash) confirmed no remaining crash shapes — deep ?. chains, !/cast mixes, interpolation, and nested conditional access in arguments all terminate cleanly and are locked in by regression tests.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC023 (Prefer Find/FindAsync) no longer reports for entities with a visible global query filter. Find checks the change tracker before querying, and a tracker hit bypasses HasQueryFilter — so the FirstOrDefault(pk) to Find(pk) rewrite could silently resurrect soft-deleted or other-tenant rows. The gate keys on the DbSet's entity type (an Id inherited from a base class doesn't dodge it), walks base types (EF declares filters on the hierarchy root), and recognises OnModelCreating, EntityTypeBuilder configuration classes, and the non-generic Entity(typeof(X)).HasQueryFilter(...) form. Filters configured in another assembly remain invisible to the analyzer.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
Release prep for **5.6.3** — ships the LC023 `HasQueryFilter` gate (PR #169).

## Impact
- `<Version>` 5.6.2 → 5.6.3; `<PackageReleaseNotes>` and `CHANGELOG.md` both reference LC023 (consistency test green).

## Validation
- `dotnet test` net10.0: 1021/1021 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)