### PR TITLE
chore: prepare 5.6.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.4] - 2026-06-10
+
+### Fixed
+- `LC012` no longer lets an unrelated `SaveChanges` hide the RemoveRange→`ExecuteDelete` suggestion. Two false negatives are closed: a save on a **provably different context instance** (`db1.Users.RemoveRange(q); db2.SaveChanges();` — proof requires both receivers to resolve, through single-assignment alias chains, to two *different freshly-created* locals) and a save in a **mutually exclusive `if`/`else` or `switch` branch**, which can never run after the `RemoveRange` in the same execution. Precision stays deliberately conservative: aliased contexts (`var db2 = db1;`) still suppress, context parameters/fields/factory results and reassigned locals can never be proven distinct and suppress, a `switch` containing `goto case`/`goto default` keeps suppressing because sections can flow into each other, and a try-block `RemoveRange` with a catch-side save stays quiet because the try may throw *after* the removals were registered. (Closes the LC012 open follow-up from the 2026-06-04 rerun.)
+
 ## [5.6.3] - 2026-06-10
 
 ### Fixed

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.3</Version>
+        <Version>5.6.4</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC023 (Prefer Find/FindAsync) no longer reports for entities with a visible global query filter. Find checks the change tracker before querying, and a tracker hit bypasses HasQueryFilter — so the FirstOrDefault(pk) to Find(pk) rewrite could silently resurrect soft-deleted or other-tenant rows. The gate keys on the DbSet's entity type (an Id inherited from a base class doesn't dodge it), walks base types (EF declares filters on the hierarchy root), and recognises OnModelCreating, EntityTypeBuilder configuration classes, and the non-generic Entity(typeof(X)).HasQueryFilter(...) form. Filters configured in another assembly remain invisible to the analyzer.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC012 (Use ExecuteDelete instead of RemoveRange) no longer lets an unrelated SaveChanges hide the report: a save on a provably different context instance (both receivers resolve through single-assignment alias chains to different freshly-created locals) and a save in a mutually exclusive if/else or switch branch can never commit the pending removals, so the suggestion now fires. Aliased contexts (var db2 = db1), context parameters/fields/factory results, switches containing goto case, and try/catch shapes stay conservatively quiet.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
Release prep for **5.6.4** — ships the LC012 SaveChanges-suppression precision fix (PR #171).

## Impact
- `<Version>` 5.6.3 → 5.6.4; `<PackageReleaseNotes>` and `CHANGELOG.md` both reference LC012 (consistency test green).

## Validation
- `dotnet test` net10.0: 1030/1030 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
