### PR TITLE
chore: prepare 5.6.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.5] - 2026-06-10
+
+### Fixed
+- `LC025` is now **path-aware** for conditionally reassigned locals, closing a false positive deferred since the 2026-06-04 rerun: `var user = db.Users.First(); if (flag) user = db.Users.AsNoTracking().First(); db.Users.Update(user);` no longer fires — on the `flag=false` path the entity is tracked, so the verdict depends on the path taken. The latest assignment before the write decides alone only when it is unconditional; a conditional latest is compared against the latest *unconditional fallback* (the state if the branch is skipped), with superseded history — e.g. an initial `= null` overwritten before the branch — excluded so it cannot manufacture false ambiguity. A disagreeing fallback or a conditional-only origin set stays quiet (the same ambiguity trade-off the silent-write rule makes for multiply-assigned locals); unconditional latest assignments, agreeing fallbacks, and same-branch reassign+write shapes all keep firing.
+
 ## [5.6.4] - 2026-06-10
 
 ### Fixed

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.4</Version>
+        <Version>5.6.5</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC012 (Use ExecuteDelete instead of RemoveRange) no longer lets an unrelated SaveChanges hide the report: a save on a provably different context instance (both receivers resolve through single-assignment alias chains to different freshly-created locals) and a save in a mutually exclusive if/else or switch branch can never commit the pending removals, so the suggestion now fires. Aliased contexts (var db2 = db1), context parameters/fields/factory results, switches containing goto case, and try/catch shapes stay conservatively quiet.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC025 (Avoid AsNoTracking with Update/Remove) is now path-aware for conditionally reassigned locals. When the latest assignment before the write sits in a branch that may not execute and the latest unconditional fallback disagrees on tracking-ness, the entity's state depends on the path taken and the rule stays quiet instead of judging by the lexically-last write. Unconditional latest assignments, agreeing fallbacks (every path untracked), superseded history, and same-branch reassign-plus-write shapes all keep firing.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
Release prep for **5.6.5** — ships the LC025 path-aware conditional-reassignment guard (PR #173). (Replaces #174, which accidentally included unreviewed LC009 working-tree changes.)

## Impact
- `<Version>` 5.6.4 → 5.6.5; `<PackageReleaseNotes>` and `CHANGELOG.md` both reference LC025 (consistency test green).

## Validation
- Release-notes/changelog consistency test: 6/6 passed; full suite green on the fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
