### PR TITLE
chore: prepare 5.6.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.6] - 2026-06-10
+
+### Fixed
+- `LC009` no longer suggests `AsNoTracking()` for methods that **mutate the materialized entity and commit through a helper**, closing the deferred cross-method residual from the 2026-06-04 rerun. The write detection only saw same-body `SaveChanges`/`Add`/`Update`/`Remove` calls, so the common repository shape — materialize, set a property, call `_repository.Commit()` — was flagged read-only, and applying the suggested `AsNoTracking()` would have silently dropped the save. A property mutation of the materialized result now marks the body as a write path: on the result local (only when the materializer's value is stored directly into a single-assignment local), on `foreach` iteration variables over the result or the inline materializer, and inline on the materializer itself (`db.Users.First(...).Name = x`); compound assignment and `++`/`--` count. Guards keep the rule honest: a DTO populated from entity values, a repointed local mutated while it held a different object, and indexer element replacement (`users[0] = new User()`) all still report. The caller-mutates-the-returned-entity case remains documented as unprovable locally.
+
 ## [5.6.5] - 2026-06-10
 
 ### Fixed

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.5</Version>
+        <Version>5.6.6</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC025 (Avoid AsNoTracking with Update/Remove) is now path-aware for conditionally reassigned locals. When the latest assignment before the write sits in a branch that may not execute and the latest unconditional fallback disagrees on tracking-ness, the entity's state depends on the path taken and the rule stays quiet instead of judging by the lexically-last write. Unconditional latest assignments, agreeing fallbacks (every path untracked), superseded history, and same-branch reassign-plus-write shapes all keep firing.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC009 (Missing AsNoTracking in read-only path) no longer flags methods that mutate the materialized entity and commit through a helper. A property mutation of the result — on the result local (stored directly into a single-assignment local), a foreach variable over it, or inline on the materializer, compound assignment and increment included — now marks the body as a write path, where the suggested AsNoTracking() would have silently dropped the cross-method save. DTO mutation, repointed locals, and collection-element replacement do not suppress.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
Release prep for **5.6.6** — ships the LC009 mutation-as-write-path heuristic (PR #176).

## Impact
- `<Version>` 5.6.5 → 5.6.6; `<PackageReleaseNotes>` and `CHANGELOG.md` both reference LC009 (consistency test green).

## Validation
- `dotnet test` net10.0: 1045/1045 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
