### PR TITLE
chore: prepare 5.6.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.7] - 2026-06-10
+
+### Fixed
+- `LC008` no longer fires on a sync EF call inside a **`static` local function** declared in an `async` method, closing the deferred orphaned-warning item from the 2026-06-04 rerun. A `static` local function cannot capture the enclosing async context and `await` is illegal inside it, so the suggested "use the async counterpart and await it" was impossible to apply — the warning's only resolutions were suppression or removing `static`. Both async-context walks (operation tree and the semantic-model fallback) now treat a non-async `static` local function as a hard synchronous boundary. Capturing (non-static) local functions and lambdas inside async methods still flag — that refactoring debt is the rule's deliberate signal — and an `async static` local function still flags because it can await. This completes the 2026-06-10 Medium shortlist — every planned hardening item from the health-audit batch has now shipped (see the 5.6.2 through 5.6.6 entries above).
+
 ## [5.6.6] - 2026-06-10
 
 ### Fixed

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.6</Version>
+        <Version>5.6.7</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC009 (Missing AsNoTracking in read-only path) no longer flags methods that mutate the materialized entity and commit through a helper. A property mutation of the result — on the result local (stored directly into a single-assignment local), a foreach variable over it, or inline on the materializer, compound assignment and increment included — now marks the body as a write path, where the suggested AsNoTracking() would have silently dropped the cross-method save. DTO mutation, repointed locals, and collection-element replacement do not suppress.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC008 (Synchronous EF method in async context) no longer fires inside a static local function declared in an async method. A static local function cannot capture the enclosing async context and await is illegal inside it, so the previous warning was unfixable — its only resolutions were suppression or removing static. Capturing (non-static) local functions and lambdas inside async methods still flag, and an async static local function still flags because it can await the async counterpart.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
Release prep for **5.6.7** — ships the LC008 static-local-function sync boundary (PR #178). This completes the 2026-06-10 Medium shortlist.

## Impact
- `<Version>` 5.6.6 → 5.6.7; `<PackageReleaseNotes>` and `CHANGELOG.md` both reference LC008 (consistency test green).

## Validation
- `dotnet test` net10.0: 1048/1048 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
