### PR TITLE
chore: prepare 5.6.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.8] - 2026-06-13
+
 ### Fixed
 - `LC044` now detects silent-data-loss patterns where the mutation happens inside a **nested block that falls through to `SaveChanges`**. Previously the rule required the property mutation and `SaveChanges` to be in the same immediate block, so mutations inside `if`/`else`/`using`/`while` bodies before a later `SaveChanges` were missed. The reachability check now accepts ancestor/descendant block relationships and blocks on explicit `return`/`throw` terminators between the mutation and the save, while still excluding sibling branches (e.g., mutation in one `if` branch and save only reachable through the other). Added regression coverage for nested-scope mutations, foreach-mutation on an `AsNoTracking()` queryable source, and nested `if` inside a foreach body.
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.7</Version>
+        <Version>5.6.8</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC008 (Synchronous EF method in async context) no longer fires inside a static local function declared in an async method. A static local function cannot capture the enclosing async context and await is illegal inside it, so the previous warning was unfixable — its only resolutions were suppression or removing static. Capturing (non-static) local functions and lambdas inside async methods still flag, and an async static local function still flags because it can await the async counterpart.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC044 (AsNoTracking entity mutated then SaveChanges) now detects silent-data-loss patterns where the mutation happens inside a nested block that falls through to SaveChanges. The rule previously required the mutation and SaveChanges to be in the same immediate block, so mutations inside if/else/using/while bodies before a later SaveChanges were missed. The reachability check now accepts ancestor/descendant block relationships and blocks on explicit return/throw terminators, while still excluding sibling branches (e.g. mutation in one if branch and save only reachable through the other).</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
Bumps the package version to **5.6.8** and updates the release notes for the LC044 fix merged in #180.

## CHANGELOG ↔ PackageReleaseNotes consistency

Both surfaces reference **LC044** only:

- `CHANGELOG.md` `[5.6.8]` entry: LC044 nested-scope reachability fix.
- `<PackageReleaseNotes>`: LC044 summary.

## Verification

- `dotnet build` passes.
- `dotnet test -f net10.0` passes (1061 tests; net8.0/net9.0 hosts not installed locally).
- `RuleCatalogDocGenerator --check` clean.
- `SampleDiagnosticsVerifier --frameworks net10.0` passes.
- `RuleQualityContractTests` pass (release notes / changelog LC id consistency).

After this PR merges, publishing a GitHub Release for `v5.6.8` will trigger `publish.yml` to pack and push `LinqContraband.5.6.8.nupkg` to NuGet.
