### PR TITLE
chore: prepare 5.6.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.9] - 2026-06-23
+
+### Changed
+- `LC034` and `LC037` raw SQL docs now clarify direct raw-execution interpolation/concatenation versus hidden constructed-SQL flows. The docs include parameterized rewrite guidance and analyzer-backed examples for `string.Format`, `string.Concat`, chained `StringBuilder`, and `SqlQueryRaw<T>` so users can choose the right safe API without assuming unsupported coverage.
+
 ## [5.6.8] - 2026-06-13
 
 ### Fixed

--- a/docs/LC034_AvoidExecuteSqlRawWithInterpolation.md
+++ b/docs/LC034_AvoidExecuteSqlRawWithInterpolation.md
@@ -13,10 +13,18 @@ await db.Database.ExecuteSqlRawAsync($"DELETE FROM Users WHERE Name = '{name}'")
 ```
 
 ### The Fix
-Use the safe interpolated API so values are parameterized.
+Use the safe interpolated API so values are parameterized by EF Core.
 
 ```csharp
 await db.Database.ExecuteSqlAsync($"DELETE FROM Users WHERE Name = {name}");
+```
+
+If the SQL is not naturally an interpolated string at the call site, keep the SQL text constant and pass values through the raw API's parameter list.
+
+```csharp
+await db.Database.ExecuteSqlRawAsync(
+    "DELETE FROM Users WHERE Name = {0}",
+    name);
 ```
 
 ## Analyzer Logic
@@ -33,9 +41,34 @@ an interpolation hole appears inside SQL single quotes, such as `'{name}'`; remo
 
 No-hole interpolated strings and constant-only interpolations stay quiet because they do not embed runtime data into raw SQL.
 
+`string.Format(...)`, `string.Concat(...)`, `StringBuilder`, and aliases that hide SQL construction are not auto-fixed by this rule. Those shapes need a manual rewrite to constant SQL plus parameters, and `LC037` reports them when they reach a raw SQL sink.
+
 ## Rule Boundary
 - LC034 owns direct interpolated-string holes containing runtime data and direct non-constant `+` concatenation passed straight into `ExecuteSqlRaw(...)` or `ExecuteSqlRawAsync(...)`.
 - LC034 requires the matched method to come from the EF Core namespace boundary (`Microsoft.EntityFrameworkCore` or a child namespace), not a same-named lookalike namespace.
 - LC034 requires a `DatabaseFacade` receiver from the EF Core namespace, so same-named helpers on unrelated receiver types stay quiet.
 - LC034 fires regardless of how the receiver is reached: the instance call `db.Database.ExecuteSqlRaw(...)` and the static-extension form `RelationalDatabaseFacadeExtensions.ExecuteSqlRaw(db.Database, ...)` both participate for sync and async; the safe siblings `ExecuteSql`/`ExecuteSqlAsync` stay quiet on every variant.
-- LC037 covers broader constructed-SQL flows such as local aliases, `string.Format(...)`, `string.Concat(...)`, and `StringBuilder`.
+- LC018 owns direct interpolated and direct `+`-concatenated SQL passed to query APIs (`FromSqlRaw(...)` and `SqlQueryRaw<T>(...)`).
+- LC037 owns broader constructed-SQL flows such as local aliases, `string.Format(...)`, `string.Concat(...)`, and `StringBuilder` before they reach `FromSqlRaw(...)`, `ExecuteSqlRaw(...)`, `ExecuteSqlRawAsync(...)`, or `SqlQueryRaw<T>(...)`.
+
+### Boundary Examples
+
+Direct `ExecuteSqlRaw` interpolation is `LC034`:
+
+```csharp
+await db.Database.ExecuteSqlRawAsync($"DELETE FROM Users WHERE Name = {name}");
+```
+
+Direct query API interpolation is `LC018`, not `LC034`:
+
+```csharp
+var users = db.Users.FromSqlRaw($"SELECT * FROM Users WHERE Name = {name}");
+var names = db.Database.SqlQueryRaw<string>($"SELECT Name FROM Users WHERE Name = {name}");
+```
+
+Hidden construction is `LC037`:
+
+```csharp
+var sql = string.Format("DELETE FROM Users WHERE Name = '{0}'", name);
+await db.Database.ExecuteSqlRawAsync(sql);
+```

--- a/docs/LC037_RawSqlStringConstruction.md
+++ b/docs/LC037_RawSqlStringConstruction.md
@@ -12,11 +12,40 @@ var sql = "SELECT * FROM Users WHERE Name = '" + name + "'";
 var users = db.Users.FromSqlRaw(sql).ToList();
 ```
 
+`LC037` also catches construction that is hidden behind common helper APIs:
+
+```csharp
+var sql = string.Format("SELECT * FROM Users WHERE Name = '{0}'", name);
+var users = db.Users.FromSqlRaw(sql).ToList();
+```
+
+```csharp
+var sql = string.Concat("DELETE FROM Users WHERE Name = '", name, "'");
+db.Database.ExecuteSqlRaw(sql);
+```
+
+```csharp
+var sql = new StringBuilder()
+    .Append("SELECT * FROM Users WHERE Name = '")
+    .Append(name)
+    .Append("'")
+    .ToString();
+
+var names = db.Database.SqlQueryRaw<string>(sql);
+```
+
 ### Safer Shape
 Keep dynamic values out of the SQL string and pass them as parameters.
 
 ```csharp
 var users = db.Users.FromSqlRaw("SELECT * FROM Users WHERE Name = {0}", name).ToList();
+```
+
+The same pattern applies to raw execution and scalar/keyless raw SQL:
+
+```csharp
+db.Database.ExecuteSqlRaw("DELETE FROM Users WHERE Name = {0}", name);
+var names = db.Database.SqlQueryRaw<string>("SELECT Name FROM Users WHERE Name = {0}", name);
 ```
 
 ## Analyzer Logic
@@ -28,8 +57,13 @@ var users = db.Users.FromSqlRaw("SELECT * FROM Users WHERE Name = {0}", name).To
 ### Notes
 This v1 surface is analyzer-only. It intentionally avoids speculative rewrites for complex SQL-building code.
 
+The rule reports where the constructed string reaches the raw SQL API. The fix depends on the SQL shape: remove embedded quotes around values, keep the command/query text constant, and pass values through EF Core parameters instead of assembling them into the SQL string.
+
 ## Rule Boundary
-- LC037 intentionally yields when the raw SQL argument is passed directly as an interpolated string or direct non-constant `+` concatenation. Those direct call-site patterns are owned by LC018 (`FromSqlRaw` and `SqlQueryRaw`) and LC034 (`ExecuteSqlRaw` / `ExecuteSqlRawAsync`).
-- LC037 still reports broader constructed-SQL shapes such as `string.Format(...)`, `string.Concat(...)`, `StringBuilder`, and local alias / variable flow into all three raw SQL sinks — including `SqlQueryRaw<T>` (`db.Database.SqlQueryRaw<T>(string.Format(...))`), whose interpolation/concatenation LC018 owns while its other construction shapes are LC037's.
+- LC018 owns direct interpolated strings and direct non-constant `+` concatenation passed to query APIs (`FromSqlRaw(...)` and `SqlQueryRaw<T>(...)`).
+- LC034 owns direct interpolated strings and direct non-constant `+` concatenation passed to raw execution APIs (`ExecuteSqlRaw(...)` and `ExecuteSqlRawAsync(...)`).
+- LC037 intentionally yields for those direct call-site patterns so a single raw SQL expression is not double-reported.
+- LC037 still reports broader constructed-SQL shapes such as `string.Format(...)`, `string.Concat(...)`, `StringBuilder`, and local alias / variable flow into all three raw SQL sink families: `FromSqlRaw(...)`, `ExecuteSqlRaw(...)` / `ExecuteSqlRawAsync(...)`, and `SqlQueryRaw<T>(...)`.
+- `SqlQueryRaw<T>` is split deliberately: direct interpolation and direct `+` concatenation are LC018's territory, while `string.Format(...)`, `string.Concat(...)`, `StringBuilder`, and aliased local construction are LC037's.
 - For simple local variables, LC037 resolves the latest guaranteed declaration or assignment before the raw SQL call, so an earlier constructed value overwritten unconditionally by a constant is ignored while later constructed overwrites are still reported.
 - Conditional overwrites are treated conservatively: a branch-only constant assignment does not suppress an earlier constructed SQL value, and a branch-only constructed assignment remains suspicious unless a later guaranteed assignment overwrites it.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -209,13 +209,13 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.6.8**
+Package version: **5.6.9**
 
 Base audited commit: master at `ae15734` (5.6.1 release merge). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), and the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
-Current local verification (2026-06-23, docs-only LC034/LC037 pass):
+Current local verification (2026-06-23, release-bound LC034/LC037 docs pass):
 
 - `dotnet restore`, `RuleCatalogDocGenerator --check`, `dotnet build --no-restore`, and `SampleDiagnosticsVerifier --frameworks net8.0 net9.0 net10.0` passed.
 - `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1061 tests**.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -67,10 +67,10 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC031 | Unbounded query materialization | Materialization & Projection | Info | 4 | 4 | 3 | 3 | 3 | 3 | Low | Sound chain walker, correct about `Chunk` (not a bounding operator) and `TakeLast`/`SkipLast` (untranslatable, so flagging stands). Advisory-only without a fixer-rationale doc; 17 tests light on query-syntax shapes; intentional full-scan guidance thin. |
 | LC032 | ExecuteUpdate for bulk scalar updates | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 4 | 4 | 4 | 3 | Low | **Re-scored — the prior row was stale.** The rule now ships a full async-aware fixer (loop+`SaveChanges` → `ExecuteUpdate`, warning comment, token preservation, duplicate-write collapse, declines on observed results / value-rereads / local-source inlining) with 38 tests (24 fixer) and a 108-line doc covering the safety contract; FS/T/DS all move 3→4. Conservative declines are documented and reasonable. |
 | LC033 | Use FrozenSet for static membership caches | Materialization & Projection | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Healthy niche optimization across 7 files and 18 tests (multi-phase compilation-end analysis with strict Contains-only usage gates); low real-world impact keeps it a poor near-term investment. |
-| LC034 | ExecuteSqlRaw with interpolated strings | Raw SQL & Security | Warning | 4 | 4 | 4 | 4 | 3 | 5 | Low | Strong sync/async raw-SQL detection (29 tests) with named/direct unsafe SQL, lookalike negatives, and quote-sensitive fixer suppression; doc remains light on the LC018/LC037 three-way overlap and parameterized-construction guidance. |
+| LC034 | ExecuteSqlRaw with interpolated strings | Raw SQL & Security | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong sync/async raw-SQL detection (29 tests) with named/direct unsafe SQL, lookalike negatives, and quote-sensitive fixer suppression. Docs now spell out LC018/LC034/LC037 ownership, direct-vs-hidden construction, quoted-interpolation limits, and parameterized `ExecuteSqlRaw` alternatives. |
 | LC035 | Missing Where before bulk execute | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 4 | 3 | 4 | 4 | Low | High-impact safety smell; 5.5.9 closed the "base filter + optional narrowing" FP (unconditional base plus every conditional reassignment must be filtered). 18 tests still below peers on filtered-local/reassignment depth. Imp stays `4` — transactions and audit logging diminish bare data-loss risk in modern stacks. Demoted from Medium: the named FP shipped. |
 | LC036 | DbContext captured by thread work item | Execution & Async | Warning | 4 | 4 | 4 | 4 | 5 | 5 | Low | High-value thread-safety rule covering lambda, anonymous-method, callback, async-lambda, member capture, factory/scope-safe, materialized-value, and local-function shapes (17 tests). The method-group FN claim was rejected — arbitrary method-group inspection is a documented non-goal. Compact 41-line doc remains a DS=5 anchor (violation, safer shape, intent, explicit non-goals). |
-| LC037 | Constructed raw SQL strings | Raw SQL & Security | Warning | 4 | 4 | 4 | 4 | 3 | 5 | Low | Strong manual security rule (3-file analyzer: concatenation, `string.Format`/`Concat`, `StringBuilder`, aliased-local resolution; 26 tests); 5.5.5 added `SqlQueryRaw<T>` as a construction sink with no LC018 double-report. Docs still need concrete `StringBuilder`/`string.Format` flow examples and clearer LC018/LC034 boundary text. |
+| LC037 | Constructed raw SQL strings | Raw SQL & Security | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong manual security rule (3-file analyzer: concatenation, `string.Format`/`Concat`, `StringBuilder`, aliased-local resolution; 26 tests); 5.5.5 added `SqlQueryRaw<T>` as a construction sink with no LC018 double-report. Docs now include concrete `string.Format`, `string.Concat`, `StringBuilder`, parameterized rewrite, and LC018/LC034 boundary examples. |
 | LC038 | Excessive eager loading | Loading & Includes | Info | 3 | 4 | 4 | 3 | 3 | 2 | Low | Coarse depth-threshold heuristic (configurable, default 4) with only 6 test methods; modern EF Core split-query support reduces the underlying risk and the 33-line doc has no intentional-load rationale. |
 | LC039 | Repeated SaveChanges on same context | Change Tracking & Context Lifetime | Info | 4 | 4 | 4 | 4 | 3 | 4 | Low | Useful reliability smell guarded for transaction boundaries (`using`/`await using` declarations included), mutually exclusive if/else, switch, ternary arms, and try-vs-catch saves (5.5.7); 21 tests. **DS re-scored 4→3**: the doc is 24 lines — below the calibration bar for a `4` (no intentional-use patterns, no non-goals). Remaining analyzer gaps: exception-handler and nested-loop control flow. |
 | LC040 | Mixed tracking and no-tracking modes | Change Tracking & Context Lifetime | Info | 3 | 4 | 4 | 3 | 3 | 3 | Low | Branch resolution now covers ternary arms (5.5.7); exception handlers and nested scopes remain unhandled — the try/catch deferral is deliberate (a tracked entity materialised before a mid-`try` throw can still be tracked). 16 tests, no provider/transaction interaction coverage; doc silent on legitimate split-workflow rationale. |
@@ -125,6 +125,15 @@ Single-rule precision pass on the Tier-1 silent-data-loss rule.
 | --- | --- | --- |
 | LC044 | **T 3→4** | Added nested-scope reachability coverage (`if`/`else`/`using`/`while` bodies whose control flow falls through to `SaveChanges`) plus additional foreach-mutation guardrails (queryable `AsNoTracking()` source, nested `if` inside the loop body). The analyzer's block-reachability check now handles ancestor/descendant block relationships and explicit `return`/`throw` terminators instead of requiring the mutation and save to share the same immediate block. Total LC044 tests: 30. |
 
+## 2026-06-23 LC034/LC037 docs hardening pass
+
+Focused security-docs pass on the raw SQL rule boundary.
+
+| Rule | Change | Why |
+| --- | --- | --- |
+| LC034 | **DS 3→4** | Expanded the rule doc with parameterized `ExecuteSqlRaw` alternatives, quoted-interpolation limits, and concrete examples showing direct `ExecuteSqlRaw` interpolation/concatenation as LC034, direct `FromSqlRaw`/`SqlQueryRaw<T>` interpolation as LC018, and hidden constructed-SQL aliases as LC037. |
+| LC037 | **DS 3→4** | Added concrete `string.Format`, `string.Concat`, `StringBuilder`, `SqlQueryRaw<T>`, and parameterized rewrite examples, plus an explicit LC018/LC034/LC037 ownership split so constructed SQL flows are easier to remediate without double-report confusion. |
+
 ## Planning Shortlist
 
 Work flows to rules that are high in the Importance Ranking **and** carry health gaps.
@@ -133,7 +142,7 @@ Work flows to rules that are high in the Importance Ranking **and** carry health
 | --- | --- | --- |
 | High | None | No crash, unsafe-fix-in-the-wild, or security FN is currently open. Promote on fresh concrete FP/FN/unsafe-fix/crash evidence only. |
 | Medium — next batch, in order | None | The entire 2026-06-10 Medium tier has shipped: LC045's adversarial pass (no crash shapes survived, five null-conditional FNs fixed), LC023's `HasQueryFilter` gate (the catalog's last live shipped-fix hazard), LC012's same-instance + branch-exclusivity precision for the `SaveChanges` suppression, LC025's path-ambiguity guard for conditionally-reassigned locals, LC009's mutation-as-write-path heuristic for helper-committed saves, and LC008's static-local-function sync boundary. Promote new items only on fresh concrete FP/FN/unsafe-fix/crash evidence. |
-| Low — opportunistic, Tier-1-importance hygiene first | LC037, LC034, LC039, LC019, LC028 | Cheap backfill on must-catch rules: LC037/LC034 boundary docs (`StringBuilder`/`string.Format` examples, LC018/LC034/LC037 three-way split); LC039 doc expansion past 24 lines. Then LC019/LC028 test depth. Everything else is currently acceptable or appropriately harsh-scored. |
+| Low — opportunistic, Tier-1-importance hygiene first | LC039, LC019, LC028 | LC037/LC034 boundary-doc backfill addressed in this pass; next cheap backfill is LC039 doc expansion past 24 lines, then LC019/LC028 test depth. Everything else is currently acceptable or appropriately harsh-scored. |
 
 Rejected/deferred-by-design items (LC004 nested-local-function, LC036 method-group, LC040 try/catch + `Select`, LC044 untaken-branch re-attach, LC020 Ordinal flagging, LC015 `TakeLast`/`SkipLast`, LC031 `TakeLast`, LC021 selective filter keys) stay closed — do not re-chase without new evidence. See the 2026-06-04 Rerun tables below for full rationale.
 
@@ -200,16 +209,16 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.6.1**
+Package version: **5.6.8**
 
 Base audited commit: master at `ae15734` (5.6.1 release merge). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), and the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
-Current local verification (2026-06-10, net10.0):
+Current local verification (2026-06-23, docs-only LC034/LC037 pass):
 
-- `dotnet test LinqContraband.sln --framework net10.0` passed with **1006 tests** (was 919 at the 2026-06-04 baseline; the bulk of the increase is the LC045 suite incl. post-crash regression tests).
-- The six-probe re-audit re-counted `[Fact]`/`[Theory]` methods per rule, re-measured doc line counts, and read each analyzer/fixer source; the LC032 fixer existence, LC023 fixer existence, and LC039 doc length were verified directly (they drove the score changes above).
-- `dotnet --list-runtimes` shows only .NET 10 runtimes locally; full multi-target verification (net8/net9) remains delegated to the GitHub `dotnet.yml` CI and the `publish.yml` workflow.
+- `dotnet restore`, `RuleCatalogDocGenerator --check`, `dotnet build --no-restore`, and `SampleDiagnosticsVerifier --frameworks net8.0 net9.0 net10.0` passed.
+- `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1061 tests**.
+- `dotnet test --no-build --verbosity normal` starts the net10.0 leg successfully but cannot complete the local net8.0/net9.0 test legs on this Mac because only arm64 `Microsoft.NETCore.App 10.0.9` is installed; those target-framework test legs remain delegated to GitHub CI.
 
 Historical baselines: 2026-06-04 rerun verified 919 tests at 5.5.13; 2026-05-29 deep rescan verified 828 tests at 5.4.12 (840d00b); the 2026-05-14 fine-comb re-audit (six parallel slices, scores moved on 30 of 44 rules) established the harsh calibration and the DS=5 anchors (LC011 FP/T/DS, LC030 DS, LC036 DS/Imp) that remain the reference for what a `5` requires.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.8</Version>
+        <Version>5.6.9</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC044 (AsNoTracking entity mutated then SaveChanges) now detects silent-data-loss patterns where the mutation happens inside a nested block that falls through to SaveChanges. The rule previously required the mutation and SaveChanges to be in the same immediate block, so mutations inside if/else/using/while bodies before a later SaveChanges were missed. The reachability check now accepts ancestor/descendant block relationships and blocks on explicit return/throw terminators, while still excluding sibling branches (e.g. mutation in one if branch and save only reachable through the other).</PackageReleaseNotes>
+        <PackageReleaseNotes>LC034 and LC037 raw SQL docs now clarify direct raw-execution interpolation/concatenation versus hidden constructed-SQL flows. The docs include parameterized rewrite guidance and analyzer-backed examples for string.Format, string.Concat, chained StringBuilder, and SqlQueryRaw&lt;T&gt; so users can choose the right safe API without assuming unsupported coverage.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- clarify LC034 ownership for direct ExecuteSqlRaw interpolation/concatenation and parameterized raw SQL alternatives
- expand LC037 docs with analyzer-backed string.Format, string.Concat, StringBuilder, SqlQueryRaw<T>, and parameterized rewrite examples
- prepare package version 5.6.9 with matching CHANGELOG.md and PackageReleaseNotes for the raw SQL docs hardening
- update analyzer-health scores, shortlist, package baseline, and verification notes for the release-bound pass

## Impact
This improves remediation clarity for the Tier-1 raw SQL security rules without changing analyzer behavior. It is release-bound so NuGet users get the corrected docs and package metadata in 5.6.9.

## Validation
- dotnet restore
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check
- dotnet build --no-restore
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net8.0 net9.0 net10.0
- dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity minimal: 1061 passed
- git diff --check
- pre-commit hygiene scan over changed files
- codex review --uncommitted: fixed one doc/example mismatch in the docs commit, rerun clean; release-metadata rerun clean

Local caveat: dotnet test --no-build --verbosity normal cannot complete net8.0/net9.0 test legs on this Mac because only arm64 Microsoft.NETCore.App 10.0.9 is installed; GitHub CI covers the full multi-target test matrix.
