### PR TITLE
chore: prepare 5.6.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.10] - 2026-06-23
+
+### Changed
+- `LC039` repeated `SaveChanges` docs now explain the intended batching shape, explicit EF Core transaction boundaries, branch/try/catch suppression rules, separate-context behaviour, executable-root scoping, and why the advisory remains manual-only.
+
 ## [5.6.9] - 2026-06-23
 
 ### Changed

--- a/docs/LC039_NestedSaveChanges.md
+++ b/docs/LC039_NestedSaveChanges.md
@@ -12,6 +12,30 @@ db.SaveChanges();
 db.SaveChanges();
 ```
 
+### Safer Shape
+Prefer one unit of work: make all tracked changes first, then save once.
+
+```csharp
+user.Name = name;
+order.Status = OrderStatus.Paid;
+
+db.SaveChanges();
+```
+
+If two saves are deliberately separated because the first write must be flushed before the second step, make that boundary visible with an EF Core transaction or split the work into separate executable roots.
+
+```csharp
+using var transaction = db.Database.BeginTransaction();
+
+db.SaveChanges();
+AuditAfterFirstCommit();
+db.SaveChanges();
+
+transaction.Commit();
+```
+
+The transaction is not a performance trick; it documents that the two saves are part of a deliberate transactional sequence rather than an accidental batching miss.
+
 ## Analyzer Logic
 
 ### ID: `LC039`
@@ -22,3 +46,67 @@ db.SaveChanges();
 The rule suppresses obvious EF Core transaction-boundary cases, repeated saves inside the same explicit transaction `using` block, repeated saves inside a C# 8+ `using`/`await using` local declaration of an EF Core transaction, mutually exclusive `if`/`else` branches, mutually exclusive `switch` sections, and a `try` block versus a `catch` clause (a `catch` save is a compensating/retry save, not a batchable repeat — but a `finally` save still counts because it always runs), then reports on a per-context basis within the same executable root.
 
 Only EF Core transaction APIs on `DatabaseFacade` or `IDbContextTransaction`-style receivers count as boundaries. Unrelated helper methods named `Commit`, `Rollback`, or similar do not suppress the diagnostic. A `using` declaration of an unrelated disposable (for example a `MemoryStream`) does not suppress the diagnostic, and a transaction `using` declaration introduced after the first save does not retroactively cover saves that preceded it.
+
+## Rule Boundary
+- LC039 is scoped to repeated `SaveChanges()` / `SaveChangesAsync()` calls on the same provable `DbContext` receiver inside one executable root.
+- Separate context instances do not report; saving `db1` and `db2` is treated as two different units of work.
+- Nested local functions, lambdas, and other executable roots are analysed independently. A save in the outer method and a save in an inner local function are not treated as one repeated-save sequence.
+- Independent `if` statements can still report because both branches may execute in one call. Mutually exclusive `if`/`else`, `else if`, and `switch` sections stay quiet.
+- `try` versus `catch` saves stay quiet because the catch save is a retry/compensation path after the try save failed. `finally` saves still report because the finally block runs after the try path.
+- Transaction boundaries are recognised only when the invocation is on EF Core's `DatabaseFacade` or an EF Core transaction type. Lookalike methods on application services are intentionally ignored.
+- This rule has no code fix. Whether to batch, split the method, introduce an explicit transaction, or keep the repeated save depends on the business invariant protected by the earlier commit.
+
+### Boundary Examples
+
+Independent branches can both run, so the second save reports:
+
+```csharp
+if (saveUser)
+{
+    db.SaveChanges();
+}
+
+if (saveAudit)
+{
+    db.SaveChanges();
+}
+```
+
+Mutually exclusive branches stay quiet:
+
+```csharp
+if (saveUser)
+{
+    db.SaveChanges();
+}
+else
+{
+    db.SaveChanges();
+}
+```
+
+A retry/compensation save is allowed:
+
+```csharp
+try
+{
+    db.SaveChanges();
+}
+catch
+{
+    db.SaveChanges();
+}
+```
+
+A finally save always runs, so it still reports:
+
+```csharp
+try
+{
+    db.SaveChanges();
+}
+finally
+{
+    db.SaveChanges();
+}
+```

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -72,7 +72,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC036 | DbContext captured by thread work item | Execution & Async | Warning | 4 | 4 | 4 | 4 | 5 | 5 | Low | High-value thread-safety rule covering lambda, anonymous-method, callback, async-lambda, member capture, factory/scope-safe, materialized-value, and local-function shapes (17 tests). The method-group FN claim was rejected — arbitrary method-group inspection is a documented non-goal. Compact 41-line doc remains a DS=5 anchor (violation, safer shape, intent, explicit non-goals). |
 | LC037 | Constructed raw SQL strings | Raw SQL & Security | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong manual security rule (3-file analyzer: concatenation, `string.Format`/`Concat`, `StringBuilder`, aliased-local resolution; 26 tests); 5.5.5 added `SqlQueryRaw<T>` as a construction sink with no LC018 double-report. Docs now include concrete `string.Format`, `string.Concat`, `StringBuilder`, parameterized rewrite, and LC018/LC034 boundary examples. |
 | LC038 | Excessive eager loading | Loading & Includes | Info | 3 | 4 | 4 | 3 | 3 | 2 | Low | Coarse depth-threshold heuristic (configurable, default 4) with only 6 test methods; modern EF Core split-query support reduces the underlying risk and the 33-line doc has no intentional-load rationale. |
-| LC039 | Repeated SaveChanges on same context | Change Tracking & Context Lifetime | Info | 4 | 4 | 4 | 4 | 3 | 4 | Low | Useful reliability smell guarded for transaction boundaries (`using`/`await using` declarations included), mutually exclusive if/else, switch, ternary arms, and try-vs-catch saves (5.5.7); 21 tests. **DS re-scored 4→3**: the doc is 24 lines — below the calibration bar for a `4` (no intentional-use patterns, no non-goals). Remaining analyzer gaps: exception-handler and nested-loop control flow. |
+| LC039 | Repeated SaveChanges on same context | Change Tracking & Context Lifetime | Info | 4 | 4 | 4 | 4 | 4 | 4 | Low | Useful reliability smell guarded for transaction boundaries (`using`/`await using` declarations included), mutually exclusive if/else, switch, ternary arms, and try-vs-catch saves (5.5.7); 21 tests. Docs now cover batching guidance, explicit transaction boundaries, branch/try/finally behavior, separate contexts, executable-root scoping, EF-only boundary recognition, and the manual-only rationale. Remaining analyzer gaps: exception-handler and nested-loop control flow. |
 | LC040 | Mixed tracking and no-tracking modes | Change Tracking & Context Lifetime | Info | 3 | 4 | 4 | 3 | 3 | 3 | Low | Branch resolution now covers ternary arms (5.5.7); exception handlers and nested scopes remain unhandled — the try/catch deferral is deliberate (a tracked entity materialised before a mid-`try` throw can still be tracked). 16 tests, no provider/transaction interaction coverage; doc silent on legitimate split-workflow rationale. |
 | LC041 | Single entity over-fetches one consumed property | Materialization & Projection | Info | 4 | 4 | 3 | 2 | 2 | 2 | Low | Narrow heuristic; 5.5.12 exempted key-predicates on an upstream `Where` (same single-row-by-key fetch the terminal form exempts). Fixer intentionally excludes `FirstOrDefault`/`SingleOrDefault` to preserve no-row semantics. Deferred: hoisted `Expression<Func<>>` predicates not resolved; null-conditional single-property reads unhandled. 14 tests, 37-line doc. |
 | LC042 | Complex query should be tagged | Loading & Includes | Info | 2 | 2 | 4 | 2 | 2 | 2 | Low | Crude operator-count threshold with 4 test methods; no semantic complexity distinction (`Where`+`OrderBy`+`Take` ranks the same as nested `SelectMany`+aggregates). Pure team-policy observability rule — appropriately harsh-scored, no investment warranted. |
@@ -134,6 +134,14 @@ Focused security-docs pass on the raw SQL rule boundary.
 | LC034 | **DS 3→4** | Expanded the rule doc with parameterized `ExecuteSqlRaw` alternatives, quoted-interpolation limits, and concrete examples showing direct `ExecuteSqlRaw` interpolation/concatenation as LC034, direct `FromSqlRaw`/`SqlQueryRaw<T>` interpolation as LC018, and hidden constructed-SQL aliases as LC037. |
 | LC037 | **DS 3→4** | Added concrete `string.Format`, `string.Concat`, `StringBuilder`, `SqlQueryRaw<T>`, and parameterized rewrite examples, plus an explicit LC018/LC034/LC037 ownership split so constructed SQL flows are easier to remediate without double-report confusion. |
 
+## 2026-06-23 LC039 docs hardening pass
+
+Focused reliability-docs pass on the repeated-save advisory.
+
+| Rule | Change | Why |
+| --- | --- | --- |
+| LC039 | **DS 3→4** | Expanded the rule doc with batching guidance, explicit EF Core transaction examples, branch and try/catch/finally boundaries, separate-context and executable-root scoping, EF-only transaction-boundary recognition, and the manual-only rationale for keeping or rewriting repeated saves. |
+
 ## Planning Shortlist
 
 Work flows to rules that are high in the Importance Ranking **and** carry health gaps.
@@ -142,7 +150,7 @@ Work flows to rules that are high in the Importance Ranking **and** carry health
 | --- | --- | --- |
 | High | None | No crash, unsafe-fix-in-the-wild, or security FN is currently open. Promote on fresh concrete FP/FN/unsafe-fix/crash evidence only. |
 | Medium — next batch, in order | None | The entire 2026-06-10 Medium tier has shipped: LC045's adversarial pass (no crash shapes survived, five null-conditional FNs fixed), LC023's `HasQueryFilter` gate (the catalog's last live shipped-fix hazard), LC012's same-instance + branch-exclusivity precision for the `SaveChanges` suppression, LC025's path-ambiguity guard for conditionally-reassigned locals, LC009's mutation-as-write-path heuristic for helper-committed saves, and LC008's static-local-function sync boundary. Promote new items only on fresh concrete FP/FN/unsafe-fix/crash evidence. |
-| Low — opportunistic, Tier-1-importance hygiene first | LC039, LC019, LC028 | LC037/LC034 boundary-doc backfill addressed in this pass; next cheap backfill is LC039 doc expansion past 24 lines, then LC019/LC028 test depth. Everything else is currently acceptable or appropriately harsh-scored. |
+| Low — opportunistic, Tier-1-importance hygiene first | LC019, LC028 | LC039 doc expansion addressed in this pass; next cheap backfill is LC019/LC028 test depth. Everything else is currently acceptable or appropriately harsh-scored. |
 
 Rejected/deferred-by-design items (LC004 nested-local-function, LC036 method-group, LC040 try/catch + `Select`, LC044 untaken-branch re-attach, LC020 Ordinal flagging, LC015 `TakeLast`/`SkipLast`, LC031 `TakeLast`, LC021 selective filter keys) stay closed — do not re-chase without new evidence. See the 2026-06-04 Rerun tables below for full rationale.
 
@@ -209,13 +217,13 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.6.9**
+Package version: **5.6.10**
 
 Base audited commit: master at `ae15734` (5.6.1 release merge). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), and the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
-Current local verification (2026-06-23, release-bound LC034/LC037 docs pass):
+Current local verification (2026-06-23, release-bound LC039 docs pass):
 
 - `dotnet restore`, `RuleCatalogDocGenerator --check`, `dotnet build --no-restore`, and `SampleDiagnosticsVerifier --frameworks net8.0 net9.0 net10.0` passed.
 - `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1061 tests**.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.9</Version>
+        <Version>5.6.10</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC034 and LC037 raw SQL docs now clarify direct raw-execution interpolation/concatenation versus hidden constructed-SQL flows. The docs include parameterized rewrite guidance and analyzer-backed examples for string.Format, string.Concat, chained StringBuilder, and SqlQueryRaw&lt;T&gt; so users can choose the right safe API without assuming unsupported coverage.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC039 repeated SaveChanges docs now explain the intended batching shape, explicit EF Core transaction boundaries, branch/try/catch suppression rules, separate-context behavior, executable-root scoping, and why the advisory remains manual-only.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- expand LC039 repeated SaveChanges docs with batching guidance, explicit EF Core transaction boundaries, branch/try/catch/finally examples, separate-context behaviour, executable-root scoping, and manual-only rationale
- prepare package version 5.6.10 with matching CHANGELOG.md and PackageReleaseNotes for the LC039 docs hardening
- update analyzer-health scores, shortlist, package baseline, and verification notes for the release-bound pass

## Impact
This improves remediation clarity for the repeated-save reliability advisory without changing analyzer behaviour. It is release-bound so NuGet users get the corrected docs and package metadata in 5.6.10.

## Validation
- dotnet restore
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check
- dotnet build --no-restore
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net8.0 net9.0 net10.0
- dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity minimal: 1061 passed
- git diff --check
- pre-commit hygiene scan over changed files
- codex review --uncommitted: clean; reviewer also reran build, catalog check, sample diagnostics, and net10 tests

Local caveat: dotnet test --no-build --verbosity normal cannot complete net8.0/net9.0 test legs on this Mac because only arm64 Microsoft.NETCore.App 10.0.9 is installed; GitHub CI covers the full multi-target test matrix.
