### PR TITLE
chore: prepare 5.6.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.12] - 2026-06-23
+
+### Changed
+- `LC019` conditional `Include` validation now locks `ThenInclude` receiver conditionals, richer filtered Include negatives, and non-EF `ThenInclude` lookalikes. The docs now explain when to split the query, project the conditional shape, or eager-load both branches explicitly.
+
 ## [5.6.11] - 2026-06-23
 
 ### Changed

--- a/docs/LC019_ConditionalInclude.md
+++ b/docs/LC019_ConditionalInclude.md
@@ -6,15 +6,24 @@ Flags conditional logic embedded in EF Core Include paths because include graphs
 
 ## Why it matters
 
-EF Core expects Include and ThenInclude lambdas to describe a concrete navigation path. Choosing between alternate navigations inside the lambda can fail at runtime or make the eager-loading shape ambiguous. Split the query shape before the Include call so each branch has a normal navigation path.
+EF Core expects `Include` and `ThenInclude` lambdas to describe a concrete navigation path. Choosing between alternate navigations inside the lambda can fail at runtime or make the eager-loading shape ambiguous. Split the query shape before the `Include` call so each branch has a normal navigation path.
+
+The problem is not the `?:` operator by itself. A conditional inside a filtered Include predicate, ordering selector, or `Take` argument does not choose between navigation paths, so LC019 leaves those shapes alone.
 
 ## What it does not flag
 
-LC019 is limited to EF Core `Include` and `ThenInclude` calls. It does not report unrelated application extension methods named `Include`, and it does not treat conditionals inside filtered Include predicates as conditional navigation paths.
+LC019 is limited to EF Core `Include` and `ThenInclude` calls. It does not report unrelated application extension methods named `Include` or `ThenInclude`, and it does not treat conditionals inside filtered Include operators as conditional navigation paths.
 
 ## Typical fix
 
 Project a conditional shape outside the Include chain, split the query, or load alternate branches explicitly. This rule is manual-only because the correct replacement usually depends on whether both branches should run, whether the branches need different filters, and how the query is composed afterward.
+
+Use this decision path:
+
+1. If exactly one navigation should be eager-loaded, split the query before `Include`.
+2. If both navigations are useful to the caller, eager-load both explicit paths.
+3. If the caller only needs scalar values or a small DTO, project the conditional shape with `Select` instead of using `Include`.
+4. If each branch needs a different filtered Include, keep the filters inside two separate branch-specific Include chains.
 
 ## Samples
 
@@ -32,6 +41,12 @@ var query = db.Orders
     .Include(o => (includePrimary ? o.PrimaryCustomer : o.FallbackCustomer).Address);
 ```
 
+```csharp
+var query = db.Orders
+    .Include(o => o.Customer)
+    .ThenInclude(c => (preferBilling ? c.BillingAddress : c.ShippingAddress).Country);
+```
+
 ## A better shape
 
 ```csharp
@@ -45,3 +60,48 @@ var query = includePrimary
     ? db.Orders.Include(o => o.PrimaryCustomer.Address)
     : db.Orders.Include(o => o.FallbackCustomer.Address);
 ```
+
+```csharp
+var query = preferBilling
+    ? db.Orders.Include(o => o.Customer).ThenInclude(c => c.BillingAddress.Country)
+    : db.Orders.Include(o => o.Customer).ThenInclude(c => c.ShippingAddress.Country);
+```
+
+## When projection is better
+
+If the conditional is there because the result model needs "the active address" or "the preferred contact", a projection is often clearer than an Include:
+
+```csharp
+var query = db.Orders.Select(o => new OrderSummary
+{
+    Id = o.Id,
+    Address = preferBilling ? o.Customer.BillingAddress : o.Customer.ShippingAddress
+});
+```
+
+Projection keeps the conditional in the result shape, where EF can translate ordinary scalar/entity selection, instead of trying to make the eager-loading graph dynamic.
+
+## When eager-loading both branches is better
+
+If the caller will inspect both possible navigations after materialization, include both paths explicitly:
+
+```csharp
+var query = db.Orders
+    .Include(o => o.PrimaryCustomer.Address)
+    .Include(o => o.FallbackCustomer.Address);
+```
+
+This may load more data, so prefer it only when both branches are genuinely needed. If only one branch is used per request, split before Include instead.
+
+## Filtered Include boundary
+
+Conditionals inside filtered Include operators are allowed because they do not change the navigation path:
+
+```csharp
+var query = db.Orders.Include(o => o.Lines
+    .Where(l => priorityOnly ? l.IsPriority : l.IsBackordered)
+    .OrderBy(l => newestFirst ? l.CreatedAt : l.Id)
+    .Take(shortList ? 5 : 10));
+```
+
+The navigation path remains `Orders -> Lines`; only the filter/order/window changes.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -52,7 +52,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC016 | Avoid DateTime.Now/UtcNow in queries | Query Shape & Translation | Warning | 4 | 4 | 3 | 4 | 2 | 2 | Low | Clock detection, per-lambda dedup, and unique-naming fixer are fine (5.5.1 CRLF fix in place); 31-line doc never covers testability/mocking or modern EF constant-folding, and the impact (cacheability/testability, not correctness) caps Importance at 2. |
 | LC017 | Whole entity projection | Materialization & Projection | Info | 4 | 4 | 3 | 4 | 5 | 3 | Low | Strong 38-test heuristic with a 171-line doc; FS stays `3` because the fixer rewrites to anonymous types, forcing caller refactoring rather than a safety-preserving change (a DTO-helper alternative is the obvious upgrade). |
 | LC018 | FromSqlRaw with interpolated strings | Raw SQL & Security | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | Security-critical with broad call-shape coverage, an exhaustive constant-only safe-shape suite (35 tests), and `SqlQueryRaw<T>` detection on the `DatabaseFacade`. Auto-fix stays `FromSqlRaw`→`FromSqlInterpolated`; `SqlQueryRaw` is report-only. Residual follow-ups: the `SqlQueryRaw`→`SqlQuery` auto-fix is not offered, and the LC018/LC037 boundary deserves clearer doc text. Demoted from Medium: the security FN shipped (LC037 owns construction sinks since 5.5.5). |
-| LC019 | Conditional Include expression | Loading & Includes | Warning | 4 | 4 | 3 | 3 | 3 | 4 | Low | Manual-only rule with sound rationale (a conditional inside an Include lambda always throws at runtime); only 10 test methods and no filtered-Include or non-EF Include negatives; doc is light on the "split query vs. project earlier vs. eager-load both branches" decision tree. |
+| LC019 | Conditional Include expression | Loading & Includes | Warning | 4 | 4 | 3 | 4 | 4 | 4 | Low | Manual-only rule with sound rationale (conditional Include/ThenInclude navigation choices fail at runtime). Coverage now includes 13 tests: root and receiver conditionals, coalesce, collection ThenInclude, filtered-Include predicate/order/take negatives, and non-EF Include/ThenInclude lookalikes. Docs now cover split-query, projection, eager-load-both, branch-specific filtered Include, and the filtered-Include boundary. |
 | LC020 | Untranslatable string comparison overloads | Query Shape & Translation | Warning | 3 | 3 | 4 | 4 | 4 | 3 | Low | 5.5.2 closed the argument-flow FN (`"admin".Contains(u.Name, cmp)`); the Ordinal/OrdinalIgnoreCase FP claim was rejected on verification (default providers throw, so flagging is correct). Still not provider-aware (Npgsql `ILIKE`, opt-in Pomelo) and EF 9 `Collate()` is not addressed — both Analyzer and FP stay at `3`. |
 | LC021 | IgnoreQueryFilters usage | Raw SQL & Security | Warning | 4 | 4 | 3 | 3 | 4 | 4 | Low | Narrow EF-extension detection is conservative; Round-2 rejected the EF9 selective `IgnoreQueryFilters(filterKeys)` FP claim (selective bypass still bypasses soft-delete/tenant filters). 14 tests but no `[SuppressMessage]` negatives documenting the intended suppression path. |
 | LC022 | Nested collection materialization inside projection | Materialization & Projection | Info | 3 | 3 | 3 | 4 | 3 | 2 | Low | EF 9 correlated-collection translation has largely closed the gap this rule targeted; the analyzer can flag patterns EF now translates correctly, and the 43-line doc carries no EF-version caveat. Both A/FP and Importance stay pulled down. |
@@ -150,6 +150,14 @@ Focused coverage pass on the deep eager-loading review rule.
 | --- | --- | --- |
 | LC028 | **T 2→3** | Added regression coverage for invalid `dotnet_code_quality.LC028.max_depth` fallback, sibling include-chain depth reset, and per-chain diagnostics when multiple sibling chains exceed the configured threshold. The rule remains a heuristic/manual-review warning, so deeper behavior investment is low priority. |
 
+## 2026-06-23 LC019 docs/test-depth pass
+
+Focused coverage and documentation pass on the conditional Include correctness rule.
+
+| Rule | Change | Why |
+| --- | --- | --- |
+| LC019 | **T 3→4, DS 3→4** | Added coverage for `ThenInclude` coalesced receiver paths, filtered Include ordering/window conditionals that must stay quiet, and non-EF `ThenInclude` lookalikes. Expanded the doc with the split-query vs. projection vs. eager-load-both decision path, branch-specific filtered Include guidance, and the filtered-Include boundary. |
+
 ## Planning Shortlist
 
 Work flows to rules that are high in the Importance Ranking **and** carry health gaps.
@@ -158,7 +166,7 @@ Work flows to rules that are high in the Importance Ranking **and** carry health
 | --- | --- | --- |
 | High | None | No crash, unsafe-fix-in-the-wild, or security FN is currently open. Promote on fresh concrete FP/FN/unsafe-fix/crash evidence only. |
 | Medium — next batch, in order | None | The entire 2026-06-10 Medium tier has shipped: LC045's adversarial pass (no crash shapes survived, five null-conditional FNs fixed), LC023's `HasQueryFilter` gate (the catalog's last live shipped-fix hazard), LC012's same-instance + branch-exclusivity precision for the `SaveChanges` suppression, LC025's path-ambiguity guard for conditionally-reassigned locals, LC009's mutation-as-write-path heuristic for helper-committed saves, and LC008's static-local-function sync boundary. Promote new items only on fresh concrete FP/FN/unsafe-fix/crash evidence. |
-| Low — opportunistic, Tier-1-importance hygiene first | LC019 | LC039 doc expansion and LC028 test depth addressed in this pass; next cheap backfill is LC019 test depth if no higher-severity evidence appears. Everything else is currently acceptable or appropriately harsh-scored. |
+| Low — opportunistic, Tier-1-importance hygiene first | None | LC039 doc expansion, LC028 test depth, and LC019 docs/test depth are addressed. Everything else is currently acceptable, explicitly deferred, or appropriately harsh-scored. |
 
 Rejected/deferred-by-design items (LC004 nested-local-function, LC036 method-group, LC040 try/catch + `Select`, LC044 untaken-branch re-attach, LC020 Ordinal flagging, LC015 `TakeLast`/`SkipLast`, LC031 `TakeLast`, LC021 selective filter keys) stay closed — do not re-chase without new evidence. See the 2026-06-04 Rerun tables below for full rationale.
 
@@ -225,16 +233,16 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.6.11**
+Package version: **5.6.12**
 
 Base audited commit: master at `ae15734` (5.6.1 release merge). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), and the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
-Current local verification (2026-06-23, release-bound LC028 test-depth pass):
+Current local verification (2026-06-23, release-bound LC019 docs/test-depth pass):
 
 - `dotnet restore`, `RuleCatalogDocGenerator --check`, `dotnet build --no-restore`, and `SampleDiagnosticsVerifier --frameworks net8.0 net9.0 net10.0` passed.
-- `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1064 tests**.
+- `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1067 tests**.
 - `dotnet test --no-build --verbosity normal` starts the net10.0 leg successfully but cannot complete the local net8.0/net9.0 test legs on this Mac because only arm64 `Microsoft.NETCore.App 10.0.9` is installed; those target-framework test legs remain delegated to GitHub CI.
 
 Historical baselines: 2026-06-04 rerun verified 919 tests at 5.5.13; 2026-05-29 deep rescan verified 828 tests at 5.4.12 (840d00b); the 2026-05-14 fine-comb re-audit (six parallel slices, scores moved on 30 of 44 rules) established the harsh calibration and the DS=5 anchors (LC011 FP/T/DS, LC030 DS, LC036 DS/Imp) that remain the reference for what a `5` requires.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.11</Version>
+        <Version>5.6.12</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC028 deep ThenInclude validation now locks sibling include-chain depth resets, per-chain reporting when multiple sibling chains exceed the threshold, and invalid dotnet_code_quality.LC028.max_depth fallback to the default threshold.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC019 conditional Include documentation and validation now cover ThenInclude receiver conditionals, filtered Include boundaries, non-EF ThenInclude lookalikes, and the split-query versus projection versus eager-load-both decision path.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC019_ConditionalInclude/ConditionalIncludeTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC019_ConditionalInclude/ConditionalIncludeTests.cs
@@ -200,6 +200,29 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task ThenInclude_WithCoalescedReceiverInPath_ShouldTriggerLC019()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    public class Order { public int Id { get; set; } public Customer Customer { get; set; } }
+    public class Customer { public int Id { get; set; } public Address BillingAddress { get; set; } public Address ShippingAddress { get; set; } }
+    public class Address { public int Id { get; set; } public Country Country { get; set; } }
+    public class Country { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(DbSet<Order> orders)
+        {
+            var result = {|LC019:orders.Include(o => o.Customer).ThenInclude(c => (c.BillingAddress ?? c.ShippingAddress).Country)|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task ThenInclude_Normal_ShouldNotTrigger()
     {
         var test = EFCoreMock + @"
@@ -243,6 +266,30 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task FilteredInclude_WithConditionalOrderingAndTake_ShouldNotTrigger()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    public class Order { public int Id { get; set; } public ICollection<OrderLine> Lines { get; set; } }
+    public class OrderLine { public int Id { get; set; } public int Priority { get; set; } public bool IsOpen { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(DbSet<Order> orders, bool priorityFirst, bool shortList)
+        {
+            var result = orders.Include(o => o.Lines
+                .Where(l => l.IsOpen)
+                .OrderBy(l => priorityFirst ? l.Priority : l.Id)
+                .Take(shortList ? 5 : 10));
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task NonEfInclude_WithTernary_ShouldNotTrigger()
     {
         var test = EFCoreMock + @"
@@ -264,6 +311,41 @@ namespace TestApp
         public void TestMethod(IEnumerable<Order> orders, bool usePrimary)
         {
             var result = orders.Include(o => usePrimary ? o.Customer : o.FallbackCustomer);
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NonEfThenInclude_WithTernary_ShouldNotTrigger()
+    {
+        var test = EFCoreMock + @"
+namespace TestApp
+{
+    using System;
+    using System.Collections.Generic;
+
+    public sealed class FakeIncludable<TEntity, TPrevious> : List<TEntity> { }
+
+    public static class IncludeExtensions
+    {
+        public static FakeIncludable<T, TProperty> Include<T, TProperty>(this IEnumerable<T> source, Func<T, TProperty> selector) => new();
+        public static FakeIncludable<T, TProperty> ThenInclude<T, TPrevious, TProperty>(this FakeIncludable<T, TPrevious> source, Func<TPrevious, TProperty> selector) => new();
+    }
+
+    public class Order { public int Id { get; set; } public Customer Customer { get; set; } }
+    public class Customer { public int Id { get; set; } public Address BillingAddress { get; set; } public Address ShippingAddress { get; set; } }
+    public class Address { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public void TestMethod(IEnumerable<Order> orders, bool useBilling)
+        {
+            var result = orders
+                .Include(o => o.Customer)
+                .ThenInclude(c => useBilling ? c.BillingAddress : c.ShippingAddress);
         }
     }
 }";


### PR DESCRIPTION
## Summary
- add LC019 coverage for `ThenInclude` coalesced receiver paths, filtered Include ordering/window conditionals that must stay quiet, and non-EF `ThenInclude` lookalikes
- expand the LC019 docs with the split-query vs projection vs eager-load-both decision path and the filtered Include boundary
- bump package metadata to 5.6.12 with matching changelog and analyzer-health updates

## Validation
- `dotnet restore`
- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --write`
- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check`
- `dotnet build --no-restore`
- `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net8.0 net9.0 net10.0`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter "FullyQualifiedName~LC019_ConditionalInclude" --verbosity minimal` (13 passed)
- `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` (1067 passed)
- `git diff --check`
- pre-commit hygiene scan for debug logging, TODO/FIXME markers, and secret-like literals
- `codex review --uncommitted` (clean)

Note: this Mac only has the arm64 .NET 10 runtime available locally, so the full net8.0/net9.0 solution test legs remain delegated to GitHub CI.
