### PR TITLE
chore: prepare 5.6.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.13] - 2026-06-23
+
+### Changed
+- `LC038` excessive eager-loading validation now locks threshold fallback/lowering, transparent EF query options, and non-EF `Include` lookalikes. The docs now explain intentional large-load cases, projection and split-query alternatives, and the LC006 cartesian-explosion boundary.
+
 ## [5.6.12] - 2026-06-23
 
 ### Changed

--- a/docs/LC038_ExcessiveEagerLoading.md
+++ b/docs/LC038_ExcessiveEagerLoading.md
@@ -1,12 +1,25 @@
-# Spec: LC038 - Excessive Eager Loading
+# LC038: Excessive Eager Loading
 
-## Goal
-Detect query chains with too many `Include(...)` / `ThenInclude(...)` calls.
+## What it flags
 
-## The Problem
-Very deep eager-loading chains often over-fetch related graphs, create large result shapes, and make query behavior harder to reason about.
+Flags EF Core query chains that use too many `Include(...)` / `ThenInclude(...)` calls on the same provable query root.
 
-### Example Violation
+By default the threshold is 4 include steps. Teams can raise or lower it with:
+
+```ini
+dotnet_code_quality.LC038.include_threshold = 4
+```
+
+Invalid, missing, or non-positive values fall back to the default threshold.
+
+## Why it matters
+
+Large eager-loading graphs often over-fetch related data, create wide joined result shapes, duplicate rows before materialization, and make query behaviour harder to reason about. Even when `AsSplitQuery()` avoids cartesian blow-ups, the query can still load more data than the caller needs.
+
+LC038 is intentionally advisory. Sometimes a large Include graph is exactly the right shape for a screen or export. The diagnostic is a review prompt, not proof of a bug.
+
+## The crime
+
 ```csharp
 var customers = db.Customers
     .Include(c => c.Address)
@@ -16,18 +29,57 @@ var customers = db.Customers
     .ToList();
 ```
 
-## Analyzer Logic
+## Better shapes
 
-### ID: `LC038`
-### Category: `Performance`
-### Severity: `Info`
+Project the exact result when the caller only needs a DTO or scalar values:
 
-### Configuration
-```ini
-dotnet_code_quality.LC038.include_threshold = 4
+```csharp
+var customers = db.Customers.Select(c => new CustomerSummary
+{
+    Id = c.Id,
+    Country = c.Address.Country.Name,
+    OpenOrderCount = c.Orders.Count(o => o.IsOpen)
+});
 ```
 
-### Notes
-The rule reports only when the include chain is provably EF-backed and the counted include steps meet or exceed the configured threshold.
+Split unrelated work into separate queries when different parts of the graph are used independently:
 
-LC038 follows common transparent query-shaping calls before the include chain, including `Where`, ordering, `Skip`, `Take`, `AsNoTracking`, `AsSplitQuery`, `AsSingleQuery`, and `TagWith`. This keeps filtered or tagged EF queries covered without guessing through arbitrary helper methods or projected shapes.
+```csharp
+var customer = await db.Customers
+    .Include(c => c.Address)
+    .SingleAsync(c => c.Id == id);
+
+var recentOrders = await db.Orders
+    .Where(o => o.CustomerId == id)
+    .OrderByDescending(o => o.CreatedAt)
+    .Take(20)
+    .ToListAsync();
+```
+
+Keep the Include graph when the caller genuinely needs the full aggregate and the cost is acceptable. In that case, consider `AsSplitQuery()`, query tags, pagination, and explicit suppressions so future readers know the large load was intentional.
+
+## What it counts
+
+LC038 counts EF Core `Include` and `ThenInclude` calls in one chain once the chain is rooted in a provable EF query:
+
+- `DbSet<T>` properties and fields.
+- `DbContext.Set<T>()`.
+- Transparent query shapers before the Include chain, such as `Where`, ordering, `Skip`, `Take`, `AsNoTracking`, `AsNoTrackingWithIdentityResolution`, `AsTracking`, `AsSplitQuery`, `AsSingleQuery`, and `TagWith`.
+
+It does not guess through arbitrary helper methods or projected shapes.
+
+## What it does not flag
+
+LC038 does not flag non-EF Include lookalikes, dynamic helper APIs, or query shapes where the EF root cannot be proven. It also does not decide whether the Include graph is wrong; the correct action depends on the caller, cardinality, and provider behaviour.
+
+## Relationship to LC006
+
+LC006 looks for sibling collection Includes that can cause cartesian explosion. LC038 is broader and lower severity: it flags a high Include count even when the risk is simply over-fetching or review complexity.
+
+## Manual review checklist
+
+1. Does the caller use every included navigation?
+2. Would a projection be clearer and cheaper?
+3. Are unrelated branches better loaded as separate queries?
+4. Does `AsSplitQuery()` help, or does it only hide the fact that too much data is loaded?
+5. Is a suppression warranted because the full aggregate is intentionally loaded?

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -71,7 +71,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC035 | Missing Where before bulk execute | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 4 | 3 | 4 | 4 | Low | High-impact safety smell; 5.5.9 closed the "base filter + optional narrowing" FP (unconditional base plus every conditional reassignment must be filtered). 18 tests still below peers on filtered-local/reassignment depth. Imp stays `4` — transactions and audit logging diminish bare data-loss risk in modern stacks. Demoted from Medium: the named FP shipped. |
 | LC036 | DbContext captured by thread work item | Execution & Async | Warning | 4 | 4 | 4 | 4 | 5 | 5 | Low | High-value thread-safety rule covering lambda, anonymous-method, callback, async-lambda, member capture, factory/scope-safe, materialized-value, and local-function shapes (17 tests). The method-group FN claim was rejected — arbitrary method-group inspection is a documented non-goal. Compact 41-line doc remains a DS=5 anchor (violation, safer shape, intent, explicit non-goals). |
 | LC037 | Constructed raw SQL strings | Raw SQL & Security | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong manual security rule (3-file analyzer: concatenation, `string.Format`/`Concat`, `StringBuilder`, aliased-local resolution; 26 tests); 5.5.5 added `SqlQueryRaw<T>` as a construction sink with no LC018 double-report. Docs now include concrete `string.Format`, `string.Concat`, `StringBuilder`, parameterized rewrite, and LC018/LC034 boundary examples. |
-| LC038 | Excessive eager loading | Loading & Includes | Info | 3 | 4 | 4 | 3 | 3 | 2 | Low | Coarse depth-threshold heuristic (configurable, default 4) with only 6 test methods; modern EF Core split-query support reduces the underlying risk and the 33-line doc has no intentional-load rationale. |
+| LC038 | Excessive eager loading | Loading & Includes | Info | 3 | 4 | 4 | 4 | 4 | 2 | Low | Coarse but documented depth-threshold heuristic (configurable, default 4) with 10 test methods covering default/suppressing/lowering/invalid thresholds, `DbContext.Set`, transparent LINQ/EF query options, and non-EF Include lookalikes. Docs now frame the warning as a manual review prompt, explain intentional full-aggregate loads, projection/separate-query alternatives, split-query limits, and the LC006 cartesian-explosion boundary. |
 | LC039 | Repeated SaveChanges on same context | Change Tracking & Context Lifetime | Info | 4 | 4 | 4 | 4 | 4 | 4 | Low | Useful reliability smell guarded for transaction boundaries (`using`/`await using` declarations included), mutually exclusive if/else, switch, ternary arms, and try-vs-catch saves (5.5.7); 21 tests. Docs now cover batching guidance, explicit transaction boundaries, branch/try/finally behavior, separate contexts, executable-root scoping, EF-only boundary recognition, and the manual-only rationale. Remaining analyzer gaps: exception-handler and nested-loop control flow. |
 | LC040 | Mixed tracking and no-tracking modes | Change Tracking & Context Lifetime | Info | 3 | 4 | 4 | 3 | 3 | 3 | Low | Branch resolution now covers ternary arms (5.5.7); exception handlers and nested scopes remain unhandled — the try/catch deferral is deliberate (a tracked entity materialised before a mid-`try` throw can still be tracked). 16 tests, no provider/transaction interaction coverage; doc silent on legitimate split-workflow rationale. |
 | LC041 | Single entity over-fetches one consumed property | Materialization & Projection | Info | 4 | 4 | 3 | 2 | 2 | 2 | Low | Narrow heuristic; 5.5.12 exempted key-predicates on an upstream `Where` (same single-row-by-key fetch the terminal form exempts). Fixer intentionally excludes `FirstOrDefault`/`SingleOrDefault` to preserve no-row semantics. Deferred: hoisted `Expression<Func<>>` predicates not resolved; null-conditional single-property reads unhandled. 14 tests, 37-line doc. |
@@ -158,6 +158,14 @@ Focused coverage and documentation pass on the conditional Include correctness r
 | --- | --- | --- |
 | LC019 | **T 3→4, DS 3→4** | Added coverage for `ThenInclude` coalesced receiver paths, filtered Include ordering/window conditionals that must stay quiet, and non-EF `ThenInclude` lookalikes. Expanded the doc with the split-query vs. projection vs. eager-load-both decision path, branch-specific filtered Include guidance, and the filtered-Include boundary. |
 
+## 2026-06-23 LC038 docs/test-depth pass
+
+Focused low-importance polish pass on the excessive eager-loading review rule.
+
+| Rule | Change | Why |
+| --- | --- | --- |
+| LC038 | **T 3→4, DS 3→4** | Added threshold fallback/lowering coverage, remaining transparent EF query-option coverage (`AsTracking`, `AsNoTrackingWithIdentityResolution`, `AsSingleQuery`), and non-EF Include lookalike negatives. Expanded the doc with intentional large-load rationale, projection/separate-query alternatives, split-query limits, and the LC006 boundary. Importance stays 2 because modern EF split queries and explicit projections often make this a review-smell rather than a correctness problem. |
+
 ## Planning Shortlist
 
 Work flows to rules that are high in the Importance Ranking **and** carry health gaps.
@@ -166,7 +174,7 @@ Work flows to rules that are high in the Importance Ranking **and** carry health
 | --- | --- | --- |
 | High | None | No crash, unsafe-fix-in-the-wild, or security FN is currently open. Promote on fresh concrete FP/FN/unsafe-fix/crash evidence only. |
 | Medium — next batch, in order | None | The entire 2026-06-10 Medium tier has shipped: LC045's adversarial pass (no crash shapes survived, five null-conditional FNs fixed), LC023's `HasQueryFilter` gate (the catalog's last live shipped-fix hazard), LC012's same-instance + branch-exclusivity precision for the `SaveChanges` suppression, LC025's path-ambiguity guard for conditionally-reassigned locals, LC009's mutation-as-write-path heuristic for helper-committed saves, and LC008's static-local-function sync boundary. Promote new items only on fresh concrete FP/FN/unsafe-fix/crash evidence. |
-| Low — opportunistic, Tier-1-importance hygiene first | None | LC039 doc expansion, LC028 test depth, and LC019 docs/test depth are addressed. Everything else is currently acceptable, explicitly deferred, or appropriately harsh-scored. |
+| Low — opportunistic, Tier-1-importance hygiene first | None | LC039 doc expansion, LC028 test depth, LC019 docs/test depth, and LC038 docs/test depth are addressed. Everything else is currently acceptable, explicitly deferred, or appropriately harsh-scored. |
 
 Rejected/deferred-by-design items (LC004 nested-local-function, LC036 method-group, LC040 try/catch + `Select`, LC044 untaken-branch re-attach, LC020 Ordinal flagging, LC015 `TakeLast`/`SkipLast`, LC031 `TakeLast`, LC021 selective filter keys) stay closed — do not re-chase without new evidence. See the 2026-06-04 Rerun tables below for full rationale.
 
@@ -233,16 +241,16 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.6.12**
+Package version: **5.6.13**
 
 Base audited commit: master at `ae15734` (5.6.1 release merge). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), and the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
-Current local verification (2026-06-23, release-bound LC019 docs/test-depth pass):
+Current local verification (2026-06-23, release-bound LC038 docs/test-depth pass):
 
 - `dotnet restore`, `RuleCatalogDocGenerator --check`, `dotnet build --no-restore`, and `SampleDiagnosticsVerifier --frameworks net8.0 net9.0 net10.0` passed.
-- `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1067 tests**.
+- `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1071 tests**.
 - `dotnet test --no-build --verbosity normal` starts the net10.0 leg successfully but cannot complete the local net8.0/net9.0 test legs on this Mac because only arm64 `Microsoft.NETCore.App 10.0.9` is installed; those target-framework test legs remain delegated to GitHub CI.
 
 Historical baselines: 2026-06-04 rerun verified 919 tests at 5.5.13; 2026-05-29 deep rescan verified 828 tests at 5.4.12 (840d00b); the 2026-05-14 fine-comb re-audit (six parallel slices, scores moved on 30 of 44 rules) established the harsh calibration and the DS=5 anchors (LC011 FP/T/DS, LC030 DS, LC036 DS/Imp) that remain the reference for what a `5` requires.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.12</Version>
+        <Version>5.6.13</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC019 conditional Include documentation and validation now cover ThenInclude receiver conditionals, filtered Include boundaries, non-EF ThenInclude lookalikes, and the split-query versus projection versus eager-load-both decision path.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC038 excessive eager loading documentation and validation now cover threshold fallback/lowering, transparent EF query options, non-EF Include lookalikes, intentional-load rationale, projection/split-query review guidance, and the LC006 cartesian-explosion boundary.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC038_ExcessiveEagerLoading/ExcessiveEagerLoadingTests.cs
@@ -44,7 +44,10 @@ namespace Microsoft.EntityFrameworkCore
         public static IncludableQueryable<TEntity, TProperty> Include<TEntity, TProperty>(this IQueryable<TEntity> source, Expression<Func<TEntity, TProperty>> navigationPropertyPath) where TEntity : class => new IncludableQueryable<TEntity, TProperty>();
         public static IncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(this IncludableQueryable<TEntity, TPreviousProperty> source, Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath) where TEntity : class => new IncludableQueryable<TEntity, TProperty>();
         public static IQueryable<TEntity> AsNoTracking<TEntity>(this IQueryable<TEntity> source) where TEntity : class => source;
+        public static IQueryable<TEntity> AsNoTrackingWithIdentityResolution<TEntity>(this IQueryable<TEntity> source) where TEntity : class => source;
+        public static IQueryable<TEntity> AsTracking<TEntity>(this IQueryable<TEntity> source) where TEntity : class => source;
         public static IQueryable<TEntity> AsSplitQuery<TEntity>(this IQueryable<TEntity> source) where TEntity : class => source;
+        public static IQueryable<TEntity> AsSingleQuery<TEntity>(this IQueryable<TEntity> source) where TEntity : class => source;
         public static IQueryable<TEntity> TagWith<TEntity>(this IQueryable<TEntity> source, string tag) where TEntity : class => source;
         public static List<TEntity> ToList<TEntity>(this IQueryable<TEntity> source) => new List<TEntity>();
     }
@@ -150,6 +153,71 @@ dotnet_code_quality.LC038.include_threshold = 5
     }
 
     [Fact]
+    public async Task InvalidThresholdFromAnalyzerConfig_FallsBackToDefaultAndReportsFourStepChain()
+    {
+        var test = new Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<
+            LinqContraband.Analyzers.LC038_ExcessiveEagerLoading.ExcessiveEagerLoadingAnalyzer,
+            Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>
+        {
+            TestCode = EFCoreMock + Types + @"
+
+class Program
+{
+    void Run(TestApp.AppDbContext db)
+    {
+        var parents = {|LC038:db.Parents
+            .Include(p => p.Child1)
+            .Include(p => p.Child2)
+            .Include(p => p.Child3)
+            .Include(p => p.Child4)|}
+            .ToList();
+    }
+}"
+        };
+
+        test.TestState.AnalyzerConfigFiles.Add(("/0/.editorconfig", """
+root = true
+
+[*.cs]
+dotnet_code_quality.LC038.include_threshold = not-a-number
+"""));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task LowerThresholdFromAnalyzerConfig_ReportsThreeStepChain()
+    {
+        var test = new Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<
+            LinqContraband.Analyzers.LC038_ExcessiveEagerLoading.ExcessiveEagerLoadingAnalyzer,
+            Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>
+        {
+            TestCode = EFCoreMock + Types + @"
+
+class Program
+{
+    void Run(TestApp.AppDbContext db)
+    {
+        var parents = {|LC038:db.Parents
+            .Include(p => p.Child1)
+            .Include(p => p.Child2)
+            .Include(p => p.Child3)|}
+            .ToList();
+    }
+}"
+        };
+
+        test.TestState.AnalyzerConfigFiles.Add(("/0/.editorconfig", """
+root = true
+
+[*.cs]
+dotnet_code_quality.LC038.include_threshold = 3
+"""));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
     public async Task DirectDbSetSetInvocation_WithFiveSteps_Triggers()
     {
         var test = EFCoreMock + Types + @"
@@ -189,6 +257,78 @@ class Program
             .Include(p => p.Child3)
             .Include(p => p.Child4)|}
             .ToList();
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task TrackingOptionsBeforeIncludeChain_Triggers()
+    {
+        var test = EFCoreMock + Types + @"
+
+class Program
+{
+    void Run(TestApp.AppDbContext db)
+    {
+        var parents = {|LC038:db.Parents
+            .AsTracking()
+            .AsNoTrackingWithIdentityResolution()
+            .AsSingleQuery()
+            .Include(p => p.Child1)
+            .Include(p => p.Child2)
+            .Include(p => p.Child3)
+            .Include(p => p.Child4)|}
+            .ToList();
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task NonEfIncludeLookalike_DoesNotTrigger()
+    {
+        var test = EFCoreMock + Types + @"
+
+namespace CustomIncludes
+{
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
+
+    public sealed class CustomQueryable<T> : IQueryable<T>
+    {
+        public Type ElementType => typeof(T);
+        public Expression Expression => Expression.Constant(this);
+        public IQueryProvider Provider => null;
+        public System.Collections.IEnumerator GetEnumerator() => null;
+        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() => null;
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public static class IncludeExtensions
+    {
+        public static CustomQueryable<T> Include<T, TProperty>(this CustomQueryable<T> source, Func<T, TProperty> selector) => source;
+    }
+}
+
+namespace NonEfScenario
+{
+    using CustomIncludes;
+
+    class Program
+    {
+        void Run(CustomQueryable<TestApp.Parent> parents)
+        {
+            var results = parents
+                .Include(p => p.Child1)
+                .Include(p => p.Child2)
+                .Include(p => p.Child3)
+                .Include(p => p.Child4)
+                .ToList();
+        }
     }
 }";
 


### PR DESCRIPTION
## Summary
- add LC038 coverage for invalid/lowered thresholds, transparent EF tracking/single-query options, and non-EF Include lookalikes
- expand LC038 docs with intentional-load rationale, projection/separate-query alternatives, split-query limits, and the LC006 boundary
- bump package metadata, changelog, and analyzer-health to 5.6.13

## Impact
This improves the LC038 review signal by locking the configurable threshold and EF-boundary behaviour while keeping the advisory rule scoped to provable EF query chains.

## Validation
- dotnet restore
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --write
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check
- dotnet build --no-restore
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net8.0 net9.0 net10.0
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter "FullyQualifiedName~LC038_ExcessiveEagerLoading" --verbosity minimal (10 passed)
- dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal (1071 passed)
- git diff --check
- changed-file hygiene scan for debug prints, TODO/FIXME, and hardcoded secret patterns
- codex review --uncommitted (clean after fixing the non-EF Include binding test)

Local caveat: this Mac only has arm64 Microsoft.NETCore.App 10.0.9 installed, so full local net8.0/net9.0 test execution is delegated to GitHub CI.