### PR TITLE
chore: prepare 5.6.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.14] - 2026-06-23
+
+### Changed
+- `LC035` bulk execute validation now locks deeper filtered-local and reassignment paths, including overwritten earlier assignments, filtered-local conditional reassignments, multiple optional filtered narrowings, and unfiltered catch-path reassignment. The docs now explain every-path filtering, project-local `Where` lookalikes, and why the rule has no automatic fixer.
+
 ## [5.6.13] - 2026-06-23
 
 ### Changed

--- a/docs/LC035_MissingWhereBeforeExecuteDeleteUpdate.md
+++ b/docs/LC035_MissingWhereBeforeExecuteDeleteUpdate.md
@@ -1,39 +1,104 @@
-# Spec: LC035 - Missing Where Before ExecuteDelete or ExecuteUpdate
+# LC035: Missing Where Before ExecuteDelete or ExecuteUpdate
 
-## Goal
-Detect bulk delete or update calls that target an unfiltered entity set.
+## What it flags
 
-## The Problem
-`ExecuteDelete()` and `ExecuteUpdate()` are set-based commands. Calling them on a bare `DbSet` can wipe or rewrite an entire table in one statement.
+Flags EF Core `ExecuteDelete`, `ExecuteDeleteAsync`, `ExecuteUpdate`, and `ExecuteUpdateAsync` calls when the target query has no proven `Where` filter.
 
-### Example Violation
+Bulk execute APIs are set-based. Calling them on a bare `DbSet` or unfiltered query can delete or rewrite every row in the table.
+
+## The crime
+
 ```csharp
 db.Users.ExecuteDelete();
 db.Users.ExecuteUpdate(setters => setters.SetProperty(u => u.Name, "Archived"));
 ```
 
-### Safer Shape
-Filter the target rows first.
+## Safer shapes
+
+Filter the target rows before the bulk operation:
 
 ```csharp
-db.Users.Where(u => u.Age < 18).ExecuteDelete();
+db.Users
+    .Where(u => u.Age < 18)
+    .ExecuteDelete();
 ```
 
-## Analyzer Logic
-
-### ID: `LC035`
-### Category: `Safety`
-### Severity: `Info`
-
-### Notes
-This rule is advisory only. There is no automatic fixer because adding a predicate speculatively would be unsafe. LC035 recognizes semantic LINQ filters in the direct fluent chain, query-syntax `where` clauses, simple local query initializers such as `var filtered = db.Users.Where(...); filtered.ExecuteDelete();`, and straight-line local reassignments such as `query = query.Where(...);`. A local with a **conditional** reassignment is treated as filtered only when the unconditional base assignment is filtered **and** every later conditional reassignment also adds a filter — so the common "base filter + optional extra narrowing" shape stays quiet:
+Use query syntax when that is clearer; LC035 still recognises the `where` clause:
 
 ```csharp
-var q = db.Users.Where(u => u.Id > 10);
-if (flag) q = q.Where(u => u.Id < 100);   // every path is filtered
-q.ExecuteDelete();                         // not reported
+var inactiveUsers =
+    from user in db.Users
+    where !user.IsActive
+    select user;
+
+inactiveUsers.ExecuteUpdate(setters => setters.SetProperty(u => u.Status, "Inactive"));
 ```
 
-while a conditional path that reassigns to an unfiltered query still reports. Project-local methods merely named `Where` do not count as a proven filter.
+Build a filtered local query and optionally narrow it further:
+
+```csharp
+var q = db.Users.Where(u => u.TenantId == tenantId);
+
+if (archivedOnly)
+{
+    q = q.Where(u => u.IsArchived);
+}
+
+q.ExecuteDelete();
+```
+
+## Local reassignment rules
+
+LC035 treats a local query as filtered only when every visible path to the bulk call is filtered.
+
+This stays quiet because the unconditional base assignment is filtered and the later conditional assignment only adds another filter:
+
+```csharp
+var q = db.Users.Where(u => u.TenantId == tenantId);
+if (flag) q = q.Where(u => u.Id < 100);
+q.ExecuteDelete();
+```
+
+This reports because the catch path can replace the filtered query with an unfiltered one:
+
+```csharp
+var q = db.Users.Where(u => u.TenantId == tenantId);
+
+try
+{
+    q = q.Where(u => u.Id < 100);
+}
+catch
+{
+    q = db.Users;
+}
+
+q.ExecuteUpdate();
+```
+
+Earlier conditional assignments do not matter once a later unconditional filtered assignment overwrites the local before the bulk call.
+
+## What counts as a filter
+
+LC035 recognises:
+
+- LINQ `Queryable.Where` and `Enumerable.Where` in the receiver chain.
+- Query-syntax `where` clauses.
+- Filtered local query initializers.
+- Straight-line filtered local reassignments.
+- Optional filtered narrowings after a filtered base local.
+
+Project-local methods merely named `Where` do not count as proven filters.
+
+## What it does not flag
 
 LC035 only binds EF Core bulk execute methods from the real `Microsoft.EntityFrameworkCore` namespace. Same-name helpers in project-local or lookalike namespaces stay quiet.
+
+There is no automatic fixer. Adding a predicate speculatively would be unsafe; the correct filter depends on tenant, lifecycle, audit, or business rules that the analyzer cannot infer.
+
+## Manual review checklist
+
+1. Is the target tenant, account, or lifecycle state filtered before the bulk operation?
+2. Can any conditional, catch, loop, or switch path replace the query with an unfiltered one?
+3. Is a project-local helper named `Where` hiding an unfiltered query?
+4. Should this operation be guarded by a transaction, audit record, or explicit suppression comment?

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -68,7 +68,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC032 | ExecuteUpdate for bulk scalar updates | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 4 | 4 | 4 | 3 | Low | **Re-scored — the prior row was stale.** The rule now ships a full async-aware fixer (loop+`SaveChanges` → `ExecuteUpdate`, warning comment, token preservation, duplicate-write collapse, declines on observed results / value-rereads / local-source inlining) with 38 tests (24 fixer) and a 108-line doc covering the safety contract; FS/T/DS all move 3→4. Conservative declines are documented and reasonable. |
 | LC033 | Use FrozenSet for static membership caches | Materialization & Projection | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Healthy niche optimization across 7 files and 18 tests (multi-phase compilation-end analysis with strict Contains-only usage gates); low real-world impact keeps it a poor near-term investment. |
 | LC034 | ExecuteSqlRaw with interpolated strings | Raw SQL & Security | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong sync/async raw-SQL detection (29 tests) with named/direct unsafe SQL, lookalike negatives, and quote-sensitive fixer suppression. Docs now spell out LC018/LC034/LC037 ownership, direct-vs-hidden construction, quoted-interpolation limits, and parameterized `ExecuteSqlRaw` alternatives. |
-| LC035 | Missing Where before bulk execute | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 4 | 3 | 4 | 4 | Low | High-impact safety smell; 5.5.9 closed the "base filter + optional narrowing" FP (unconditional base plus every conditional reassignment must be filtered). 18 tests still below peers on filtered-local/reassignment depth. Imp stays `4` — transactions and audit logging diminish bare data-loss risk in modern stacks. Demoted from Medium: the named FP shipped. |
+| LC035 | Missing Where before bulk execute | Bulk Operations & Set-Based Writes | Info | 4 | 4 | 4 | 4 | 4 | 4 | Low | High-impact safety smell; 5.5.9 closed the "base filter + optional narrowing" FP and 5.6.14 locks the surrounding reassignment depth: overwritten earlier unfiltered assignments, filtered-local conditional reassignments, multiple optional filtered narrowings, and unfiltered catch-path reassignments. 22 tests. Imp stays `4` because transactions and audit logging diminish bare data-loss risk in modern stacks. Demoted from Medium: the named FP shipped. |
 | LC036 | DbContext captured by thread work item | Execution & Async | Warning | 4 | 4 | 4 | 4 | 5 | 5 | Low | High-value thread-safety rule covering lambda, anonymous-method, callback, async-lambda, member capture, factory/scope-safe, materialized-value, and local-function shapes (17 tests). The method-group FN claim was rejected — arbitrary method-group inspection is a documented non-goal. Compact 41-line doc remains a DS=5 anchor (violation, safer shape, intent, explicit non-goals). |
 | LC037 | Constructed raw SQL strings | Raw SQL & Security | Warning | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong manual security rule (3-file analyzer: concatenation, `string.Format`/`Concat`, `StringBuilder`, aliased-local resolution; 26 tests); 5.5.5 added `SqlQueryRaw<T>` as a construction sink with no LC018 double-report. Docs now include concrete `string.Format`, `string.Concat`, `StringBuilder`, parameterized rewrite, and LC018/LC034 boundary examples. |
 | LC038 | Excessive eager loading | Loading & Includes | Info | 3 | 4 | 4 | 4 | 4 | 2 | Low | Coarse but documented depth-threshold heuristic (configurable, default 4) with 10 test methods covering default/suppressing/lowering/invalid thresholds, `DbContext.Set`, transparent LINQ/EF query options, and non-EF Include lookalikes. Docs now frame the warning as a manual review prompt, explain intentional full-aggregate loads, projection/separate-query alternatives, split-query limits, and the LC006 cartesian-explosion boundary. |
@@ -166,6 +166,14 @@ Focused low-importance polish pass on the excessive eager-loading review rule.
 | --- | --- | --- |
 | LC038 | **T 3→4, DS 3→4** | Added threshold fallback/lowering coverage, remaining transparent EF query-option coverage (`AsTracking`, `AsNoTrackingWithIdentityResolution`, `AsSingleQuery`), and non-EF Include lookalike negatives. Expanded the doc with intentional large-load rationale, projection/separate-query alternatives, split-query limits, and the LC006 boundary. Importance stays 2 because modern EF split queries and explicit projections often make this a review-smell rather than a correctness problem. |
 
+## 2026-06-23 LC035 docs/test-depth pass
+
+Focused coverage and documentation pass on the bulk execute safety rule.
+
+| Rule | Change | Why |
+| --- | --- | --- |
+| LC035 | **T 3→4** | Added coverage for overwritten earlier unfiltered assignments, conditional reassignment to another filtered local, multiple optional filtered narrowings, and unfiltered catch-path reassignment. Expanded the doc with every-path filtering guidance, project-local `Where` boundaries, and the no-fixer rationale. DS stays 4; the doc was already adequate, but now mirrors the analyzer's local-assignment contract more directly. |
+
 ## Planning Shortlist
 
 Work flows to rules that are high in the Importance Ranking **and** carry health gaps.
@@ -174,7 +182,7 @@ Work flows to rules that are high in the Importance Ranking **and** carry health
 | --- | --- | --- |
 | High | None | No crash, unsafe-fix-in-the-wild, or security FN is currently open. Promote on fresh concrete FP/FN/unsafe-fix/crash evidence only. |
 | Medium — next batch, in order | None | The entire 2026-06-10 Medium tier has shipped: LC045's adversarial pass (no crash shapes survived, five null-conditional FNs fixed), LC023's `HasQueryFilter` gate (the catalog's last live shipped-fix hazard), LC012's same-instance + branch-exclusivity precision for the `SaveChanges` suppression, LC025's path-ambiguity guard for conditionally-reassigned locals, LC009's mutation-as-write-path heuristic for helper-committed saves, and LC008's static-local-function sync boundary. Promote new items only on fresh concrete FP/FN/unsafe-fix/crash evidence. |
-| Low — opportunistic, Tier-1-importance hygiene first | None | LC039 doc expansion, LC028 test depth, LC019 docs/test depth, and LC038 docs/test depth are addressed. Everything else is currently acceptable, explicitly deferred, or appropriately harsh-scored. |
+| Low — opportunistic, Tier-1-importance hygiene first | None | LC039 doc expansion, LC028 test depth, LC019 docs/test depth, LC038 docs/test depth, and LC035 docs/test depth are addressed. Everything else is currently acceptable, explicitly deferred, or appropriately harsh-scored. |
 
 Rejected/deferred-by-design items (LC004 nested-local-function, LC036 method-group, LC040 try/catch + `Select`, LC044 untaken-branch re-attach, LC020 Ordinal flagging, LC015 `TakeLast`/`SkipLast`, LC031 `TakeLast`, LC021 selective filter keys) stay closed — do not re-chase without new evidence. See the 2026-06-04 Rerun tables below for full rationale.
 
@@ -241,16 +249,16 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.6.13**
+Package version: **5.6.14**
 
 Base audited commit: master at `ae15734` (5.6.1 release merge). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), and the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
-Current local verification (2026-06-23, release-bound LC038 docs/test-depth pass):
+Current local verification (2026-06-23, release-bound LC035 docs/test-depth pass):
 
 - `dotnet restore`, `RuleCatalogDocGenerator --check`, `dotnet build --no-restore`, and `SampleDiagnosticsVerifier --frameworks net8.0 net9.0 net10.0` passed.
-- `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1071 tests**.
+- `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1075 tests**.
 - `dotnet test --no-build --verbosity normal` starts the net10.0 leg successfully but cannot complete the local net8.0/net9.0 test legs on this Mac because only arm64 `Microsoft.NETCore.App 10.0.9` is installed; those target-framework test legs remain delegated to GitHub CI.
 
 Historical baselines: 2026-06-04 rerun verified 919 tests at 5.5.13; 2026-05-29 deep rescan verified 828 tests at 5.4.12 (840d00b); the 2026-05-14 fine-comb re-audit (six parallel slices, scores moved on 30 of 44 rules) established the harsh calibration and the DS=5 anchors (LC011 FP/T/DS, LC030 DS, LC036 DS/Imp) that remain the reference for what a `5` requires.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.13</Version>
+        <Version>5.6.14</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC038 excessive eager loading documentation and validation now cover threshold fallback/lowering, transparent EF query options, non-EF Include lookalikes, intentional-load rationale, projection/split-query review guidance, and the LC006 cartesian-explosion boundary.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC035 bulk execute documentation and validation now cover deeper filtered-local and reassignment paths, including overwritten earlier assignments, filtered-local conditional reassignments, multiple optional filtered narrowings, unfiltered catch-path reassignment, and the no-fixer safety rationale.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC035_MissingWhereBeforeExecuteDeleteUpdate/MissingWhereBeforeExecuteDeleteUpdateTests.cs
@@ -134,6 +134,126 @@ namespace TestApp
     }
 
     [Fact]
+    public async Task ExecuteDelete_EarlierConditionalUnfilteredAssignmentOverwrittenByFilteredBase_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class User { public int Id { get; set; } }
+
+    public sealed class Program
+    {
+        public int Run(DbContext db, bool flag)
+        {
+            IQueryable<User> query = db.Set<User>();
+            if (flag)
+            {
+                query = db.Set<User>();
+            }
+
+            query = db.Set<User>().Where(u => u.Id > 10);
+
+            return query.ExecuteDelete();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteDelete_ConditionalReassignToFilteredLocal_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class User { public int Id { get; set; } }
+
+    public sealed class Program
+    {
+        public int Run(DbContext db, bool flag)
+        {
+            var baseQuery = db.Set<User>().Where(u => u.Id > 10);
+            var archived = baseQuery.Where(u => u.Id < 100);
+            IQueryable<User> query = baseQuery;
+
+            if (flag)
+            {
+                query = archived;
+            }
+
+            return query.ExecuteDelete();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteUpdate_MultipleOptionalFilteredReassignments_ShouldNotTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class User { public int Id { get; set; } public bool IsActive { get; set; } }
+
+    public sealed class Program
+    {
+        public int Run(DbContext db, bool activeOnly, bool smallBatch)
+        {
+            var query = db.Set<User>().Where(u => u.Id > 10);
+
+            if (activeOnly)
+            {
+                query = query.Where(u => u.IsActive);
+            }
+
+            if (smallBatch)
+            {
+                query = query.Where(u => u.Id < 100);
+            }
+
+            return query.ExecuteUpdate();
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ExecuteUpdate_CatchPathReassignsToUnfilteredQuery_ShouldTrigger()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"
+namespace TestApp
+{
+    public sealed class User { public int Id { get; set; } }
+
+    public sealed class Program
+    {
+        public int Run(DbContext db)
+        {
+            var query = db.Set<User>().Where(u => u.Id > 10);
+
+            try
+            {
+                query = query.Where(u => u.Id < 100);
+            }
+            catch (System.Exception)
+            {
+                query = db.Set<User>();
+            }
+
+            return {|LC035:query.ExecuteUpdate()|};
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
     public async Task ExecuteDelete_WithWhere_ShouldNotTrigger()
     {
         var test = @"using Microsoft.EntityFrameworkCore;" + EfMock + @"


### PR DESCRIPTION
## Summary
- add LC035 coverage for overwritten earlier unfiltered assignments, conditional filtered-local reassignments, multiple optional filtered narrowings, and unfiltered catch-path reassignment
- expand LC035 docs with every-path filtering guidance, project-local \`Where\` boundaries, and the no-fixer safety rationale
- bump package metadata, changelog, and analyzer-health to 5.6.14

## Impact
This improves confidence in LC035's local-query safety boundary without changing production analyzer behaviour: the rule now has tests around the filtered-base plus conditional-reassignment contract that protects bulk execute calls from table-wide operations.

## Validation
- dotnet restore
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --write
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check
- dotnet build --no-restore
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net8.0 net9.0 net10.0
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter "FullyQualifiedName~LC035_MissingWhereBeforeExecuteDeleteUpdate" --verbosity minimal (22 passed)
- dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal (1075 passed)
- git diff --check
- changed-file hygiene scan for debug prints, TODO/FIXME, and hardcoded secret patterns
- codex review --uncommitted (clean)

Local caveat: this Mac only has arm64 Microsoft.NETCore.App 10.0.9 installed, so full local net8.0/net9.0 test execution is delegated to GitHub CI.