### PR TITLE
chore: prepare 5.6.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.15] - 2026-06-23
+
+### Changed
+- `LC026` cancellation-token validation now locks multi-token fixer selection, including `ct` preference when `cancellationToken` is unavailable, readable property tokens, field-token replacement for `CancellationToken.None`, and named-default replacement when multiple tokens exist. The docs now explain the local token-selection contract, field/property handling, ambiguity boundaries, and why the fixer does not synthesize new tokens.
+
 ## [5.6.14] - 2026-06-23
 
 ### Changed

--- a/docs/LC026_MissingCancellationToken.md
+++ b/docs/LC026_MissingCancellationToken.md
@@ -1,57 +1,102 @@
-# Spec: LC026 - Missing CancellationToken in Async Call
+# LC026: Missing CancellationToken in Async Call
 
-## Goal
-Detect usage of EF Core async methods (such as `ToListAsync`, `FirstOrDefaultAsync`, and `SaveChangesAsync`) that are called without a meaningful `CancellationToken` when one is available in scope.
+## What It Flags
 
-## The Problem
-Async database operations can take a long time. In a web application, if a user cancels their request or navigates away, the server should stop processing that request to save resources. If you don't pass a `CancellationToken` to EF Core, the database query will continue to run to completion even if no one is waiting for the result. This wastes database connections, CPU, and memory.
+LC026 reports EF Core async calls that can accept a `CancellationToken` but omit it, pass `default`, or pass `CancellationToken.None` while a usable token is available at the call site.
 
-### Example Violation
 ```csharp
 public async Task<List<User>> GetUsers(CancellationToken ct)
 {
-    // Violation: CancellationToken is available but not passed to EF.
-    return await db.Users.ToListAsync();
+    return await db.Users.ToListAsync(); // LC026
 }
 ```
 
-### The Fix
-Pass the available `CancellationToken` to the async method.
+```csharp
+public async Task Save(CancellationToken cancellationToken)
+{
+    await db.SaveChangesAsync(CancellationToken.None); // LC026
+}
+```
+
+## Why It Matters
+
+Database work can continue long after the request, worker, or background operation that started it has been cancelled. Passing the available token lets EF Core and the provider stop query execution, release connections sooner, and avoid doing work no caller still needs.
+
+The rule is informational because cancellation plumbing is sometimes policy-driven. It is still worth keeping visible on request paths, hosted services, and any expensive query or save operation.
+
+## Safer Shape
+
+Pass the token that represents the current operation.
 
 ```csharp
 public async Task<List<User>> GetUsers(CancellationToken ct)
 {
-    // Correct: The query will stop if the token is cancelled
     return await db.Users.ToListAsync(ct);
 }
 ```
 
-## Analyzer Logic
+For named optional arguments, keep the argument name and replace only the ignored token value.
 
-### ID: `LC026`
-### Category: `Reliability`
-### Severity: `Info`
-
-### Algorithm
-1.  **Target Methods**: Intercept invocations of methods ending in `Async` that belong to `Microsoft.EntityFrameworkCore`.
-2.  **Parameter Check**: Check if the method signature accepts a `CancellationToken`.
-3.  **Scope Check**: Only report when a `CancellationToken` local, parameter, field, or readable property is available at the call site (the fixer references it by bare name, which binds to `this.<member>` for fields/properties).
-4.  **Argument Check**: Report when the target token parameter is omitted, passed `default`, or passed `CancellationToken.None`.
-5.  **Fix Strategy**: Prefer a variable named `cancellationToken`, then `ct`, then the first available token. The fixer appends the token when the optional argument was omitted and replaces an explicit `default`, named `cancellationToken: default`, or `CancellationToken.None` argument when one was already supplied.
-
-## Test Cases
-
-### Violations
 ```csharp
-await db.Users.ToListAsync(); // Missing
-await db.Users.ToListAsync(default); // Explicit default token
-await db.Users.ToListAsync(CancellationToken.None); // Ignores available token
-await db.SaveChangesAsync(); // Missing
+await db.Users.ToListAsync(cancellationToken: cancellationToken);
 ```
 
-### Valid
+## Token Selection
+
+LC026 only reports when a token is available in local scope. The fixer uses this selection order:
+
+1. A token named `cancellationToken`.
+2. A token named `ct`.
+3. The first available token discovered by the compiler at the invocation location.
+
+Eligible tokens can be:
+
+- method or lambda parameters
+- locals
+- fields
+- readable properties
+
+Fields and properties are inserted by bare name, which binds correctly to instance members from an instance method.
+
+```csharp
+private CancellationToken RequestAborted { get; }
+
+public async Task<List<User>> Load(DbSet<User> users)
+{
+    return await users.ToListAsync(RequestAborted);
+}
+```
+
+When several domain-specific tokens are in scope, the rule deliberately does not infer business intent beyond the simple naming preference above. Rename the intended token to `cancellationToken` or `ct`, pass it manually, or suppress the diagnostic if a different token boundary is intentional.
+
+## What Counts as Missing
+
+These shapes report when a usable token is in scope:
+
+```csharp
+await db.Users.ToListAsync();
+await db.Users.ToListAsync(default);
+await db.Users.ToListAsync(cancellationToken: default);
+await db.Users.ToListAsync(CancellationToken.None);
+await db.SaveChangesAsync();
+```
+
+These shapes stay quiet:
+
 ```csharp
 await db.Users.ToListAsync(cancellationToken);
-await db.SaveChangesAsync(ct);
-await db.Users.ToListAsync(); // No token available in scope, so this stays silent
+await db.Users.ToListAsync(ct);
+await db.Users.ToListAsync(); // no CancellationToken is available in scope
 ```
+
+## Boundaries
+
+LC026 is a local rule. It does not trace tokens through service abstractions, infer whether a field represents the current request, or decide between multiple domain-specific tokens such as `shutdownToken` and `requestAborted`.
+
+It also only targets EF Core async methods that expose a `CancellationToken` parameter. Non-EF async APIs are outside this rule's scope.
+
+## Fix Strategy
+
+The code fix appends the selected token when the token argument is omitted. When the call already supplies `default`, `cancellationToken: default`, or `CancellationToken.None`, the fixer replaces that argument instead of appending a duplicate.
+
+No rewrite is offered when no usable token exists, because creating a fresh token source would not connect the database operation to the caller's cancellation boundary.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -59,7 +59,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | LC023 | Prefer Find/FindAsync for primary key lookups | Materialization & Projection | Info | 4 | 4 | 4 | 4 | 4 | 3 | Low | Careful key/Async detection with a shipped fixer; **the Round-2 query-filter hazard is closed (2026-06-10)** — the rule now stays silent for entities with a visible `HasQueryFilter(...)` (OnModelCreating or configuration-class), because `Find`'s change-tracker hit bypasses global query filters and the rewrite could resurrect soft-deleted/other-tenant rows (verified against the EF Core 9 `EntityFinder` source: only the database fallback applies filters). The gate keys on the DbSet's entity type (so a base-class `Id` doesn't dodge it), walks base types (EF declares filters on the hierarchy root), and resolves the non-generic `Entity(typeof(X)).HasQueryFilter(...)` builder; lookalike-`HasQueryFilter` and different-entity guards are locked in; 26 tests. Residual (documented): a filter configured in another assembly is invisible, and there is still no dedicated fixer-edge test file. |
 | LC024 | GroupBy with non-translatable projection | Query Shape & Translation | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Strong fluent and query-syntax coverage (25 tests); `Any`/`All` are recognised aggregates and an aggregate whose receiver chain roots at `g` through translatable operators (`Where`/`Select`/`OrderBy`/`Distinct`) is accepted, while non-aggregate terminals still report. Manual-only is correct — the fix depends on business intent. |
 | LC025 | AsNoTracking with Update/Remove | Change Tracking & Context Lifetime | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Sound dataflow over nearest origins, foreach paths, and explicit `Entry.State`; honours the **last** tracking directive (5.5.6) and stays quiet on constructed-object projections. **The deferred path-insensitivity item is closed (2026-06-10)**: when the latest origin before the write is conditional relative to the use and the latest *unconditional fallback* disagrees on tracking-ness (superseded history doesn't count), the verdict is path-dependent and the rule stays quiet — while unconditional latest origins, agreeing fallbacks, and same-branch reassign+write shapes all keep firing (locked in by 6 new tests; 31 total). T moves 3→4 with the conditional-reassignment family covered. |
-| LC026 | Missing CancellationToken in async call | Execution & Async | Info | 3 | 3 | 4 | 3 | 3 | 3 | Low | Deliberately simple pattern matcher; 5.5.13 extended token discovery to fields and readable properties (fixer passes them by name). The ambiguous-token boundary (multiple tokens in scope, naming-heuristic preference) remains a real noise source, and tests are thin on multi-token scenarios. |
+| LC026 | Missing CancellationToken in async call | Execution & Async | Info | 3 | 3 | 4 | 4 | 4 | 3 | Low | Deliberately simple pattern matcher; 5.5.13 extended token discovery to fields and readable properties (fixer passes them by name). Coverage now locks multi-token fixer selection (`cancellationToken`/`ct` preference), readable property tokens, field-token replacement for `CancellationToken.None`, and named-default replacement with multiple tokens (21 tests). Analyzer/FP stay `3` because domain-specific token intent is still intentionally local and ambiguous. |
 | LC027 | Missing explicit foreign key property | Schema & Modeling | Info | 4 | 4 | 4 | 3 | 4 | 3 | Low | Solid modeling rule for explicit-FK teams (respects `[ForeignKey]`, owned types, conventional and configured shadow FKs; type-inferring fixer with 5.5.1 CRLF fix). 14 tests are light on inherited configurations and chained Fluent-builder patterns. |
 | LC028 | Deep ThenInclude chain | Loading & Includes | Warning | 3 | 3 | 4 | 3 | 4 | 3 | Low | Configurable-depth heuristic (editorconfig `max_depth`, default 3) with 11 test methods. Coverage now locks configured-threshold overrides, invalid-config fallback to the default threshold, sibling include-chain depth resets, and per-chain reporting when multiple sibling chains exceed the threshold. Manual-only stance is appropriate for a review-flag rule. |
 | LC029 | Redundant identity Select | Materialization & Projection | Info | 4 | 4 | 4 | 2 | 4 | 2 | Low | Cosmetic cleanup rule; 5 test methods total and no guidance on intentional materialization-boundary uses of `Select(x => x)`. Low importance is the point — no further investment warranted. |
@@ -174,6 +174,14 @@ Focused coverage and documentation pass on the bulk execute safety rule.
 | --- | --- | --- |
 | LC035 | **T 3→4** | Added coverage for overwritten earlier unfiltered assignments, conditional reassignment to another filtered local, multiple optional filtered narrowings, and unfiltered catch-path reassignment. Expanded the doc with every-path filtering guidance, project-local `Where` boundaries, and the no-fixer rationale. DS stays 4; the doc was already adequate, but now mirrors the analyzer's local-assignment contract more directly. |
 
+## 2026-06-23 LC026 docs/test-depth pass
+
+Focused coverage and documentation pass on the cancellation-token async-call rule.
+
+| Rule | Change | Why |
+| --- | --- | --- |
+| LC026 | **T 3→4, DS 3→4** | Added multi-token fixer coverage for `ct` preference when `cancellationToken` is unavailable, readable property tokens, field-token replacement for `CancellationToken.None`, and named-default replacement when multiple tokens exist. Expanded the doc with the local token-selection contract, field/property handling, ambiguity boundaries, and the no-new-token fixer rationale. Analyzer/FP stay 3 because the rule deliberately avoids inferring business intent between domain-specific tokens. |
+
 ## Planning Shortlist
 
 Work flows to rules that are high in the Importance Ranking **and** carry health gaps.
@@ -182,7 +190,7 @@ Work flows to rules that are high in the Importance Ranking **and** carry health
 | --- | --- | --- |
 | High | None | No crash, unsafe-fix-in-the-wild, or security FN is currently open. Promote on fresh concrete FP/FN/unsafe-fix/crash evidence only. |
 | Medium — next batch, in order | None | The entire 2026-06-10 Medium tier has shipped: LC045's adversarial pass (no crash shapes survived, five null-conditional FNs fixed), LC023's `HasQueryFilter` gate (the catalog's last live shipped-fix hazard), LC012's same-instance + branch-exclusivity precision for the `SaveChanges` suppression, LC025's path-ambiguity guard for conditionally-reassigned locals, LC009's mutation-as-write-path heuristic for helper-committed saves, and LC008's static-local-function sync boundary. Promote new items only on fresh concrete FP/FN/unsafe-fix/crash evidence. |
-| Low — opportunistic, Tier-1-importance hygiene first | None | LC039 doc expansion, LC028 test depth, LC019 docs/test depth, LC038 docs/test depth, and LC035 docs/test depth are addressed. Everything else is currently acceptable, explicitly deferred, or appropriately harsh-scored. |
+| Low — opportunistic, Tier-1-importance hygiene first | None | LC039 doc expansion, LC028 test depth, LC019 docs/test depth, LC038 docs/test depth, LC035 docs/test depth, and LC026 docs/test depth are addressed. Everything else is currently acceptable, explicitly deferred, or appropriately harsh-scored. |
 
 Rejected/deferred-by-design items (LC004 nested-local-function, LC036 method-group, LC040 try/catch + `Select`, LC044 untaken-branch re-attach, LC020 Ordinal flagging, LC015 `TakeLast`/`SkipLast`, LC031 `TakeLast`, LC021 selective filter keys) stay closed — do not re-chase without new evidence. See the 2026-06-04 Rerun tables below for full rationale.
 
@@ -249,16 +257,16 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.6.14**
+Package version: **5.6.15**
 
 Base audited commit: master at `ae15734` (5.6.1 release merge). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), and the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
-Current local verification (2026-06-23, release-bound LC035 docs/test-depth pass):
+Current local verification (2026-06-23, release-bound LC026 docs/test-depth pass):
 
 - `dotnet restore`, `RuleCatalogDocGenerator --check`, `dotnet build --no-restore`, and `SampleDiagnosticsVerifier --frameworks net8.0 net9.0 net10.0` passed.
-- `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1075 tests**.
+- `dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal` passed with **1079 tests**.
 - `dotnet test --no-build --verbosity normal` starts the net10.0 leg successfully but cannot complete the local net8.0/net9.0 test legs on this Mac because only arm64 `Microsoft.NETCore.App 10.0.9` is installed; those target-framework test legs remain delegated to GitHub CI.
 
 Historical baselines: 2026-06-04 rerun verified 919 tests at 5.5.13; 2026-05-29 deep rescan verified 828 tests at 5.4.12 (840d00b); the 2026-05-14 fine-comb re-audit (six parallel slices, scores moved on 30 of 44 rules) established the harsh calibration and the DS=5 anchors (LC011 FP/T/DS, LC030 DS, LC036 DS/Imp) that remain the reference for what a `5` requires.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.14</Version>
+        <Version>5.6.15</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC035 bulk execute documentation and validation now cover deeper filtered-local and reassignment paths, including overwritten earlier assignments, filtered-local conditional reassignments, multiple optional filtered narrowings, unfiltered catch-path reassignment, and the no-fixer safety rationale.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC026 cancellation-token documentation and validation now cover multi-token fixer selection, including ct preference, readable property tokens, field-token replacement for CancellationToken.None, named-default replacement with multiple tokens, and the rule's local ambiguity boundary.</PackageReleaseNotes>
         <PackageTags>EFCore;Linq;Analyzer;Performance;Roslyn;CodeAnalysis;SQL;EntityFramework;DotNet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Analyzers/LC026_MissingCancellationToken/MissingCancellationTokenEdgeCasesTests.cs
+++ b/tests/LinqContraband.Tests/Analyzers/LC026_MissingCancellationToken/MissingCancellationTokenEdgeCasesTests.cs
@@ -75,6 +75,174 @@ namespace LinqContraband.Test
     }
 
     [Fact]
+    public async Task ShortCtName_IsUsedWhenCancellationTokenNameIsUnavailable()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public async Task TestMethod(DbSet<User> query, CancellationToken requestAborted, CancellationToken ct)
+        {
+            var users = await {|LC026:query.ToListAsync()|};
+        }
+    }
+}";
+
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public async Task TestMethod(DbSet<User> query, CancellationToken requestAborted, CancellationToken ct)
+        {
+            var users = await query.ToListAsync(ct);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task ReadablePropertyToken_IsUsedWhenNoParameterTokenExists()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        private CancellationToken RequestAborted { get; }
+
+        public async Task TestMethod(DbSet<User> query)
+        {
+            var users = await {|LC026:query.ToListAsync()|};
+        }
+    }
+}";
+
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        private CancellationToken RequestAborted { get; }
+
+        public async Task TestMethod(DbSet<User> query)
+        {
+            var users = await query.ToListAsync(RequestAborted);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task FieldToken_ReplacesCancellationTokenNone_WhenNoCloserTokenExists()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        private CancellationToken _shutdownToken;
+
+        public async Task TestMethod(DbSet<User> query)
+        {
+            var users = await {|LC026:query.ToListAsync(CancellationToken.None)|};
+        }
+    }
+}";
+
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        private CancellationToken _shutdownToken;
+
+        public async Task TestMethod(DbSet<User> query)
+        {
+            var users = await query.ToListAsync(_shutdownToken);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
+    public async Task NamedDefaultArgument_UsesPreferredTokenWhenMultipleTokensExist()
+    {
+        var test = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public async Task TestMethod(DbSet<User> query, CancellationToken ct, CancellationToken cancellationToken)
+        {
+            var users = await {|LC026:query.ToListAsync(cancellationToken: default)|};
+        }
+    }
+}";
+
+        var fixedCode = @"using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;" + EFCoreMock + @"
+namespace LinqContraband.Test
+{
+    public class User { public int Id { get; set; } }
+
+    public class TestClass
+    {
+        public async Task TestMethod(DbSet<User> query, CancellationToken ct, CancellationToken cancellationToken)
+        {
+            var users = await query.ToListAsync(cancellationToken: cancellationToken);
+        }
+    }
+}";
+
+        await VerifyFix.VerifyCodeFixAsync(test, fixedCode);
+    }
+
+    [Fact]
     public async Task DefaultTokenInNestedLocalFunction_UsesNestedScopeToken()
     {
         var test = @"using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
## Summary
- add LC026 coverage for multi-token fixer selection: `ct` fallback, readable property tokens, field-token replacement for `CancellationToken.None`, and named-default replacement when multiple tokens exist
- expand LC026 docs with the local token-selection contract, field/property handling, ambiguity boundaries, and no-new-token fixer rationale
- bump package metadata, changelog, and analyzer-health to 5.6.15

## Impact
This improves confidence in LC026's cancellation-propagation guidance without changing production analyzer semantics. The rule's existing simple token-selection contract is now executable and documented, especially around ambiguous multi-token scopes.

## Validation
- dotnet restore
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --write
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check
- dotnet build --no-restore
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net8.0 net9.0 net10.0
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --no-restore --framework net10.0 --filter "FullyQualifiedName~LC026_MissingCancellationToken" --verbosity minimal (21 passed)
- dotnet test LinqContraband.sln --no-build --framework net10.0 --verbosity normal (1079 passed)
- git diff --check
- changed-file hygiene scan for debug prints, TODO/FIXME, and hardcoded secret patterns (only benign `CancellationToken cancellationToken = default` test mock signature matched)
- codex review --uncommitted (clean; independently reran full net10 with 1079 passed)

Local caveat: this Mac only has arm64 Microsoft.NETCore.App 10.0.9 installed, so full local net8.0/net9.0 test execution is delegated to GitHub CI.