### PR TITLE
docs: publish SEO metadata for NuGet discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.33] - 2026-06-26
+
 ### Changed
 - Added canonical SEO and authenticity surfaces for the official LinqContraband project, including a GitHub Pages-ready docs hub, crawler metadata, backlink kit, security policy, README safe-install guidance, and richer NuGet search metadata.
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -393,16 +393,16 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.6.32**
+Package version: **5.6.33**
 
 Base audited commit: master at `ae15734` (5.6.1 release merge). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), and the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 
-Current verification (2026-06-26, release-bound LC016 clock-boundary guidance pass):
+Current verification (2026-06-26, release-bound SEO/authenticity metadata pass):
 
-- `RuleCatalogDocGenerator --check`, `dotnet restore`, `dotnet build --no-restore`, and `SampleDiagnosticsVerifier --frameworks net8.0 net9.0 net10.0` passed locally for this docs/sample pass.
-- Local analyzer-verifier tests are blocked on this Mac by the same pre-existing Roslyn test reference issue reproduced on clean `origin/master` (`CS0518`/missing `System.Object`, `DateTime`, and `IQueryable<>` inside verifier compilations). Local arm64 net8.0/net9.0 testhost runs are also unavailable because only arm64 `Microsoft.NETCore.App 10.0.9` is installed.
+- `dotnet restore LinqContraband.sln`, `RuleCatalogDocGenerator --check`, `dotnet build LinqContraband.sln --configuration Release --no-restore`, `SampleDiagnosticsVerifier --configuration Release --frameworks net10.0`, focused `RuleQualityContractTests` on `net10.0`, Release `dotnet pack`, package metadata readback, `git diff --check`, hygiene scan, and `codex review --uncommitted` passed locally for the SEO/authenticity metadata release.
+- Local broad multi-target analyzer-verifier tests remain limited on this Mac by the same pre-existing Roslyn test reference issue reproduced on clean `origin/master` (`CS0518`/missing `System.Object`, `DateTime`, and `IQueryable<>` inside verifier compilations). Local arm64 net8.0/net9.0 testhost runs are also unavailable because only arm64 `Microsoft.NETCore.App 10.0.9` is installed.
 - Full analyzer test coverage for the release remains delegated to GitHub CI's Ubuntu `dotnet test --no-build --verbosity normal` matrix after PR creation, matching the repository workflow.
 
 Historical baselines: 2026-06-04 rerun verified 919 tests at 5.5.13; 2026-05-29 deep rescan verified 828 tests at 5.4.12 (840d00b); the 2026-05-14 fine-comb re-audit (six parallel slices, scores moved on 30 of 44 rules) established the harsh calibration and the DS=5 anchors (LC011 FP/T/DS, LC030 DS, LC036 DS/Imp) that remain the reference for what a `5` requires.

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.32</Version>
+        <Version>5.6.33</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -17,8 +17,8 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageProjectUrl>https://github.com/georgepwall1991/LinqContraband</PackageProjectUrl>
-        <PackageReleaseNotes>LC016 docs, README guidance, and sample comments now clarify deterministic clock boundaries, injected-clock testability, UTC timestamp preference, provider-specific server-clock alternatives, and the narrow local-variable fixer contract.</PackageReleaseNotes>
+        <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
+        <PackageReleaseNotes>Canonical project metadata, README safe-install guidance, GitHub Pages documentation, sitemap, backlink kit, and authenticity guidance now make the official LinqContraband package easier to find and verify.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>

--- a/tests/LinqContraband.Tests/Architecture/RuleQualityContractTests.cs
+++ b/tests/LinqContraband.Tests/Architecture/RuleQualityContractTests.cs
@@ -15,17 +15,18 @@ namespace LinqContraband.Tests.Architecture;
 public sealed class RuleQualityContractTests
 {
     private const string RepositoryUrl = "https://github.com/georgepwall1991/LinqContraband";
+    private const string ProjectUrl = "https://georgepwall1991.github.io/LinqContraband/";
     private readonly string _repoRoot = RepositoryLayout.GetRepositoryRoot();
 
     [Fact]
-    public void PackageMetadata_PointsToThePublicRepository()
+    public void PackageMetadata_PointsToOfficialProjectSurfaces()
     {
         var properties = LoadPackageProperties();
 
         Assert.Equal("LinqContraband", properties["PackageId"]);
         Assert.Equal("LinqContraband", properties["Title"]);
         Assert.Equal(RepositoryUrl, properties["RepositoryUrl"]);
-        Assert.Equal(RepositoryUrl, properties["PackageProjectUrl"]);
+        Assert.Equal(ProjectUrl, properties["PackageProjectUrl"]);
         Assert.True(properties.TryGetValue("PackageReleaseNotes", out var releaseNotes) && !string.IsNullOrWhiteSpace(releaseNotes));
     }
 


### PR DESCRIPTION
## Summary
- Bump LinqContraband to `5.6.33` so the SEO/authenticity metadata can be published to NuGet.
- Point NuGet `PackageProjectUrl` at the public GitHub Pages hub while keeping `RepositoryUrl` on the official GitHub repository.
- Refresh package release notes, changelog, analyzer-health release baseline, and the package metadata contract test.

## Verification
- `dotnet restore LinqContraband.sln`
- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check`
- `dotnet build LinqContraband.sln --configuration Release --no-restore`
- `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net10.0`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --configuration Release --framework net10.0 --filter FullyQualifiedName~RuleQualityContractTests --verbosity minimal`
- `dotnet pack src/LinqContraband/LinqContraband.csproj --configuration Release --no-build --output /tmp/linqcontraband-5.6.33-pack`
- Package metadata readback from `LinqContraband.5.6.33.nupkg`
- `git diff --check`
- Pre-commit hygiene scan
- `codex review --uncommitted` clean after the final health-tracker sync

## Local caveat
- Broader local multi-target test execution remains limited by the Mac's missing arm64 .NET 8/9 runtimes. The GitHub Ubuntu workflow covers the full release matrix before merge/release.
