### PR TITLE
docs: add EF Core N+1 SEO guide

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -27,7 +27,7 @@
   <link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}">
   {% if page.url == "/" %}
   <script type="application/ld+json">
-  [{"@context":"https://schema.org","@type":"WebSite","name":"LinqContraband","url":"{{ '/' | absolute_url }}","description":{{ site.description | jsonify }},"publisher":{"@type":"Person","name":"George Wall","url":"https://www.georgewall.uk/"}},{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"LinqContraband","description":"EF Core LINQ performance analyzer and Roslyn analyzer for catching N+1 queries, client-side evaluation, sync-over-async calls, raw SQL risks, and other query issues at compile time.","codeRepository":"https://github.com/georgepwall1991/LinqContraband","programmingLanguage":"C#","runtimePlatform":".NET","license":"https://github.com/georgepwall1991/LinqContraband/blob/master/LICENSE","image":"{{ share_image }}","creator":{"@type":"Person","name":"George Wall","url":"https://www.georgewall.uk/"},"sameAs":["https://www.nuget.org/packages/LinqContraband","https://github.com/georgepwall1991/LinqContraband","https://www.georgewall.uk/"]}]
+  [{"@context":"https://schema.org","@type":"WebSite","name":"LinqContraband","url":"{{ '/' | absolute_url }}","description":{{ site.description | jsonify }},"publisher":{"@type":"Person","name":"George Wall","url":"https://www.georgewall.uk/"}},{"@context":"https://schema.org","@type":"SoftwareSourceCode","name":"LinqContraband","description":"EF Core LINQ performance analyzer and Roslyn analyzer for catching N+1 queries, client-side evaluation, sync-over-async calls, raw SQL risks, and other query issues at compile time.","codeRepository":"https://github.com/georgepwall1991/LinqContraband","programmingLanguage":"C#","runtimePlatform":".NET","license":"https://github.com/georgepwall1991/LinqContraband/blob/master/LICENSE","image":"{{ share_image }}","creator":{"@type":"Person","name":"George Wall","url":"https://www.georgewall.uk/"},"sameAs":["https://www.nuget.org/packages/LinqContraband","https://github.com/georgepwall1991/LinqContraband","https://www.georgewall.uk/"]},{"@context":"https://schema.org","@type":"SoftwareApplication","name":"LinqContraband","applicationCategory":"DeveloperApplication","applicationSubCategory":"Static analysis tool","operatingSystem":"Windows, macOS, Linux","softwareRequirements":".NET SDK and Entity Framework Core projects","description":"Open-source EF Core LINQ performance analyzer for catching N+1 queries, missing includes, client-side evaluation, sync-over-async calls, raw SQL risks, and tracking mistakes at compile time.","downloadUrl":"https://www.nuget.org/packages/LinqContraband","installUrl":"https://www.nuget.org/packages/LinqContraband","codeRepository":"https://github.com/georgepwall1991/LinqContraband","license":"https://github.com/georgepwall1991/LinqContraband/blob/master/LICENSE","isAccessibleForFree":true,"offers":{"@type":"Offer","price":"0","priceCurrency":"USD","url":"https://www.nuget.org/packages/LinqContraband"},"creator":{"@type":"Person","name":"George Wall","url":"https://www.georgewall.uk/"}}]
   </script>
   {% elsif is_rule_page %}
   <script type="application/ld+json">
@@ -36,6 +36,11 @@
   {% elsif page.title %}
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"TechArticle","headline":{{ page.title | jsonify }},"description":{{ page_description | jsonify }},"url":"{{ page.url | absolute_url }}","image":"{{ share_image }}","about":["Entity Framework Core","Roslyn analyzer","LINQ query performance"],"author":{"@type":"Person","name":"George Wall","url":"https://www.georgewall.uk/"}}
+  </script>
+  {% endif %}
+  {% if page.url != "/" and page.title %}
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"LinqContraband","item":"{{ '/' | absolute_url }}"},{"@type":"ListItem","position":2,"name":{{ page.title | jsonify }},"item":"{{ page.url | absolute_url }}"}]}
   </script>
   {% endif %}
 </head>
@@ -66,6 +71,7 @@
           <p class="page-rail__label">Reference</p>
           <a href="{{ '/rule-catalog.html' | relative_url }}">Rule catalog</a>
           <a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">EF Core guide</a>
+          <a href="{{ '/ef-core-n-plus-one-query-detector/' | relative_url }}">N+1 detector</a>
           <a href="{{ '/backlink-kit/' | relative_url }}">Link kit</a>
           <a href="{{ '/security-and-authenticity/' | relative_url }}">Authenticity</a>
         </aside>

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -301,7 +301,7 @@ a:hover {
 
 .link-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 16px;
 }
 

--- a/docs/backlink-kit.md
+++ b/docs/backlink-kit.md
@@ -18,6 +18,7 @@ repository or the GitHub Pages documentation hub.
 - Package: [https://www.nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
 - Documentation: [https://georgepwall1991.github.io/LinqContraband/](https://georgepwall1991.github.io/LinqContraband/)
 - Rule catalog: [https://georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
+- N+1 guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/](https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/)
 - Maintainer: [https://www.georgewall.uk/](https://www.georgewall.uk/)
 
 ## Suggested Anchor Text
@@ -25,6 +26,7 @@ repository or the GitHub Pages documentation hub.
 - EF Core LINQ performance analyzer
 - Entity Framework Core Roslyn analyzer
 - EF Core N+1 query detector
+- EF Core N+1 query detector for .NET
 - LINQ query performance analyzer for .NET
 - LinqContraband Roslyn analyzer
 
@@ -66,6 +68,12 @@ unsafe raw SQL interpolation, and tracking mistakes.
 
 ```markdown
 [LinqContraband rule catalog](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html) documents 45 EF Core analyzer rules covering query shape, materialization, loading, async execution, tracking, bulk operations, modeling, and raw SQL safety.
+```
+
+## N+1 Guide Link
+
+```markdown
+[EF Core N+1 query detector](https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/) explains how LinqContraband flags loop execution, missing includes, and risky loading patterns at compile time.
 ```
 
 ## HTML Link

--- a/docs/ef-core-linq-performance-analyzer.md
+++ b/docs/ef-core-linq-performance-analyzer.md
@@ -28,6 +28,8 @@ dotnet add package LinqContraband
 - Silent no-tracking writes and mixed tracking modes
 - Bulk update/delete operations without an explicit filter
 
+For a focused walkthrough, see the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/).
+
 ## Why Compile-Time Analysis Helps
 
 EF Core problems often hide behind ordinary-looking LINQ. A query can compile, pass local testing, and still create a
@@ -42,6 +44,7 @@ environments including Visual Studio, Rider, VS Code, and CI builds.
 The full catalog contains 45 rules grouped by domain:
 
 - [Rule catalog](/LinqContraband/rule-catalog.html)
+- [EF Core N+1 query detector](/LinqContraband/ef-core-n-plus-one-query-detector/)
 - [LC007: N+1 query loops](/LinqContraband/LC007_NPlusOneLooper.html)
 - [LC045: missing include](/LinqContraband/LC045_MissingInclude.html)
 - [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html)

--- a/docs/ef-core-n-plus-one-query-detector.md
+++ b/docs/ef-core-n-plus-one-query-detector.md
@@ -1,0 +1,87 @@
+---
+layout: default
+title: EF Core N+1 Query Detector
+description: Use LinqContraband as an EF Core N+1 query detector that flags database calls inside loops, missing includes, and loading patterns before production.
+permalink: /ef-core-n-plus-one-query-detector/
+body_class: page-n-plus-one-detector
+---
+
+# EF Core N+1 Query Detector
+
+LinqContraband is a compile-time EF Core N+1 query detector for .NET projects. It uses Roslyn analyzers to flag risky
+query and loading patterns while you are still in the IDE or CI build, before the code becomes a slow endpoint.
+
+Install the official NuGet package:
+
+```bash
+dotnet add package LinqContraband
+```
+
+## What N+1 Looks Like in EF Core
+
+The classic N+1 shape is a query that loads a set of entities, then performs more database work once per row:
+
+```csharp
+var users = await db.Users.ToListAsync();
+
+foreach (var user in users)
+{
+    var orders = await db.Orders.Where(order => order.UserId == user.Id).ToListAsync();
+    Console.WriteLine($"{user.Name}: {orders.Count}");
+}
+```
+
+This can turn one request into dozens, hundreds, or thousands of database roundtrips. It often looks harmless in code
+review because each individual query is small.
+
+## LinqContraband Rules That Help
+
+| Rule | What it detects | Why it matters |
+| --- | --- | --- |
+| [LC007: database execution inside loop](/LinqContraband/LC007_NPlusOneLooper.html) | EF Core query execution from `for`, `foreach`, `while`, and related loop bodies. | Prevents repeated database calls from scaling with row count. |
+| [LC045: missing include](/LinqContraband/LC045_MissingInclude.html) | Navigation access after materialization when the query did not include the navigation. | Catches missing eager loading before it becomes lazy-loading churn or null/empty navigation data. |
+| [LC006: multiple collection includes](/LinqContraband/LC006_CartesianExplosion.html) | Sibling collection includes that may cause cartesian explosion. | Helps balance the "fix N+1 with Include" path against over-eager loading. |
+| [LC038: excessive eager loading](/LinqContraband/LC038_ExcessiveEagerLoading.html) | Queries that include more navigations than the configured threshold. | Keeps eager loading intentional instead of turning every query into a wide graph fetch. |
+| [LC042: missing query tags](/LinqContraband/LC042_MissingQueryTags.html) | Complex query shapes without `TagWith`. | Makes expensive queries easier to identify in database telemetry. |
+
+## Safer Fix Patterns
+
+Prefer set-based queries, projection, and explicit loading boundaries:
+
+```csharp
+var userSummaries = await db.Users
+    .Select(user => new
+    {
+        user.Name,
+        OrderCount = user.Orders.Count
+    })
+    .ToListAsync();
+```
+
+When you genuinely need related entities, make the loading strategy explicit:
+
+```csharp
+var users = await db.Users
+    .Include(user => user.Orders)
+    .AsSplitQuery()
+    .ToListAsync();
+```
+
+LinqContraband does not blindly demand `Include()` everywhere. It pairs N+1 detection with rules for cartesian
+explosion, deep include chains, excessive eager loading, and whole-entity projection so the fix remains appropriate for
+the query.
+
+## Why Compile-Time Detection Helps
+
+N+1 queries are easy to miss in unit tests because small test datasets hide the cost. A compile-time analyzer gives the
+team feedback at the pull-request stage, before the query has production traffic and real row counts behind it.
+
+LinqContraband runs as an analyzer package only. It adds no runtime dependency to your application and works with
+Visual Studio, Rider, VS Code, and CI builds.
+
+## Official Links
+
+- Canonical repository: [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
+- Official NuGet package: [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
+- Full rule catalog: [georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
+- Safe install guidance: [Official LinqContraband downloads and authenticity](/LinqContraband/security-and-authenticity/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,6 +79,10 @@ body_class: page-home
       <p><a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">Read the overview</a> for teams comparing compile-time query analysis options.</p>
     </article>
     <article class="link-card">
+      <h3>N+1 query detector</h3>
+      <p><a href="{{ '/ef-core-n-plus-one-query-detector/' | relative_url }}">See the N+1 guide</a> for loop execution, missing includes, eager loading trade-offs, and telemetry tags.</p>
+    </article>
+    <article class="link-card">
       <h3>Authenticity</h3>
       <p><a href="{{ '/security-and-authenticity/' | relative_url }}">Verify official links</a> before installing or linking to the project.</p>
     </article>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,11 +10,12 @@ Official links:
 - Maintainer: https://www.georgewall.uk/
 - Documentation hub: https://georgepwall1991.github.io/LinqContraband/
 - Rule catalog: https://georgepwall1991.github.io/LinqContraband/rule-catalog.html
+- EF Core N+1 query detector: https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/
 - Authenticity: https://georgepwall1991.github.io/LinqContraband/security-and-authenticity/
 - Link kit: https://georgepwall1991.github.io/LinqContraband/backlink-kit/
 
 Key topics: Entity Framework Core, EF Core, LINQ, IQueryable, Roslyn analyzer, static analysis, query performance, N+1
-queries, raw SQL safety, .NET.
+queries, EF Core N+1 query detector, missing includes, eager loading, raw SQL safety, .NET.
 
 Canonical description: LinqContraband is an open-source EF Core LINQ performance analyzer for .NET. It runs as a
 compile-time Roslyn analyzer and helps catch query performance, reliability, and security issues before code reaches

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -9,7 +9,7 @@ permalink: /sitemap.xml
   {% assign priority = "0.6" -%}
   {% if item.url == "/" -%}
     {% assign priority = "1.0" -%}
-  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "security-and-authenticity" -%}
+  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "security-and-authenticity" -%}
     {% assign priority = "0.9" -%}
   {% elsif item.url contains "backlink-kit" or item.url contains "rule-catalog" -%}
     {% assign priority = "0.8" -%}


### PR DESCRIPTION
## Summary
- added a focused EF Core N+1 query detector landing page with examples and links into LC007, LC045, LC006, LC038, and LC042
- linked the new page from the home page, EF Core analyzer guide, backlink kit, llms.txt, and page rail
- added SoftwareApplication and breadcrumb JSON-LD plus sitemap priority coverage for the new topic page

## Verification
- curl -I -L https://georgepwall1991.github.io/LinqContraband/ returned 200 before changes
- ruby -rjekyll -e 'Jekyll::Commands::Build.process({"source"=>"docs", "destination"=>"/tmp/linqcontraband-site", "config"=>"docs/_config.yml"})'
- rendered new page exists with title, description, canonical URL, TechArticle JSON-LD, and BreadcrumbList JSON-LD
- rendered sitemap XML parses and includes https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/
- all rendered JSON-LD parses
- rendered local links resolve
- git diff --check / git diff --cached --check
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj --configuration Release -- --check
- dotnet build LinqContraband.sln --configuration Release --no-restore
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --configuration Release --no-build --logger "console;verbosity=minimal" (1159 passed)
- codex review --uncommitted