### PR TITLE
docs: add EF Core raw SQL SEO guide

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -72,6 +72,7 @@
           <a href="{{ '/rule-catalog.html' | relative_url }}">Rule catalog</a>
           <a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">EF Core guide</a>
           <a href="{{ '/ef-core-n-plus-one-query-detector/' | relative_url }}">N+1 detector</a>
+          <a href="{{ '/ef-core-raw-sql-injection-analyzer/' | relative_url }}">Raw SQL safety</a>
           <a href="{{ '/backlink-kit/' | relative_url }}">Link kit</a>
           <a href="{{ '/security-and-authenticity/' | relative_url }}">Authenticity</a>
         </aside>

--- a/docs/backlink-kit.md
+++ b/docs/backlink-kit.md
@@ -19,6 +19,7 @@ repository or the GitHub Pages documentation hub.
 - Documentation: [https://georgepwall1991.github.io/LinqContraband/](https://georgepwall1991.github.io/LinqContraband/)
 - Rule catalog: [https://georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
 - N+1 guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/](https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/)
+- Raw SQL guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/)
 - Maintainer: [https://www.georgewall.uk/](https://www.georgewall.uk/)
 
 ## Suggested Anchor Text
@@ -27,6 +28,8 @@ repository or the GitHub Pages documentation hub.
 - Entity Framework Core Roslyn analyzer
 - EF Core N+1 query detector
 - EF Core N+1 query detector for .NET
+- EF Core raw SQL injection analyzer
+- EF Core raw SQL safety analyzer
 - LINQ query performance analyzer for .NET
 - LinqContraband Roslyn analyzer
 
@@ -74,6 +77,12 @@ unsafe raw SQL interpolation, and tracking mistakes.
 
 ```markdown
 [EF Core N+1 query detector](https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/) explains how LinqContraband flags loop execution, missing includes, and risky loading patterns at compile time.
+```
+
+## Raw SQL Guide Link
+
+```markdown
+[EF Core raw SQL injection analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/) explains how LinqContraband flags interpolated raw SQL, constructed SQL strings, and risky query-filter bypasses at compile time.
 ```
 
 ## HTML Link

--- a/docs/ef-core-linq-performance-analyzer.md
+++ b/docs/ef-core-linq-performance-analyzer.md
@@ -29,6 +29,7 @@ dotnet add package LinqContraband
 - Bulk update/delete operations without an explicit filter
 
 For a focused walkthrough, see the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/).
+For security-sensitive SQL usage, see the [EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/).
 
 ## Why Compile-Time Analysis Helps
 
@@ -45,6 +46,7 @@ The full catalog contains 45 rules grouped by domain:
 
 - [Rule catalog](/LinqContraband/rule-catalog.html)
 - [EF Core N+1 query detector](/LinqContraband/ef-core-n-plus-one-query-detector/)
+- [EF Core raw SQL injection analyzer](/LinqContraband/ef-core-raw-sql-injection-analyzer/)
 - [LC007: N+1 query loops](/LinqContraband/LC007_NPlusOneLooper.html)
 - [LC045: missing include](/LinqContraband/LC045_MissingInclude.html)
 - [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html)

--- a/docs/ef-core-raw-sql-injection-analyzer.md
+++ b/docs/ef-core-raw-sql-injection-analyzer.md
@@ -1,0 +1,76 @@
+---
+layout: default
+title: EF Core Raw SQL Injection Analyzer
+description: Use LinqContraband as an EF Core raw SQL injection analyzer that flags interpolated SQL, constructed SQL strings, and unsafe query-filter bypasses at compile time.
+permalink: /ef-core-raw-sql-injection-analyzer/
+body_class: page-raw-sql-analyzer
+---
+
+# EF Core Raw SQL Injection Analyzer
+
+LinqContraband is a compile-time EF Core raw SQL injection analyzer for .NET teams that want unsafe SQL construction to
+fail in review and CI instead of waiting for a security incident. It ships as a Roslyn analyzer package and flags risky
+raw SQL patterns while developers are writing Entity Framework Core code.
+
+Install the official NuGet package:
+
+```bash
+dotnet add package LinqContraband
+```
+
+## Why Raw SQL Needs Static Analysis
+
+EF Core provides safe APIs for interpolated SQL, but it also exposes raw-string APIs for cases where teams need full
+control. Those raw APIs are easy to misuse when a query starts as a string literal and later grows user input, string
+concatenation, or interpolation.
+
+```csharp
+var users = db.Users.FromSqlRaw($"SELECT * FROM Users WHERE Name = '{name}'");
+```
+
+That code compiles. The dangerous part is not obvious at the call site unless the reviewer knows the exact EF Core API
+families and the difference between raw SQL and parameterized interpolation.
+
+## LinqContraband Rules That Help
+
+| Rule | What it detects | Safer direction |
+| --- | --- | --- |
+| [LC018: interpolated FromSqlRaw and SqlQueryRaw](/LinqContraband/LC018_AvoidFromSqlRawWithInterpolation.html) | Interpolated or concatenated SQL passed to raw query APIs. | Prefer parameterized APIs such as `FromSql`/`FromSqlInterpolated` or explicit parameters. |
+| [LC034: interpolated ExecuteSqlRaw](/LinqContraband/LC034_AvoidExecuteSqlRawWithInterpolation.html) | Interpolated or concatenated SQL passed to raw command APIs. | Prefer `ExecuteSql`/interpolated APIs or explicit `DbParameter` values. |
+| [LC037: constructed raw SQL strings](/LinqContraband/LC037_RawSqlStringConstruction.html) | SQL strings built from interpolation, concatenation, `string.Format`, or similar construction before `FromSqlRaw`. | Keep SQL constant and parameterize values. |
+| [LC021: IgnoreQueryFilters](/LinqContraband/LC021_AvoidIgnoreQueryFilters.html) | Query filter bypasses that can skip multi-tenant, soft-delete, or security filters. | Keep bypasses explicit, reviewed, and documented. |
+
+## Safer EF Core Patterns
+
+Prefer EF Core's parameterized interpolation APIs where possible:
+
+```csharp
+var users = db.Users.FromSql($"SELECT * FROM Users WHERE Name = {name}");
+```
+
+When a raw API is necessary, keep SQL text constant and pass values as parameters:
+
+```csharp
+var nameParameter = new SqlParameter("@name", name);
+
+var users = db.Users.FromSqlRaw(
+    "SELECT * FROM Users WHERE Name = @name",
+    nameParameter);
+```
+
+LinqContraband does not try to replace a secure code review or threat model. It catches the common raw SQL footguns early
+so reviewers can focus on the cases that genuinely need human judgement.
+
+## Where It Fits
+
+- Pull request checks for APIs, admin tools, and reporting code that use EF Core.
+- Migration from ad hoc SQL strings toward parameterized EF Core APIs.
+- Security reviews where raw SQL and query-filter bypasses need a searchable compile-time signal.
+- Teams that want raw SQL safety guidance in Visual Studio, Rider, VS Code, and CI.
+
+## Official Links
+
+- Canonical repository: [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
+- Official NuGet package: [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
+- Full rule catalog: [georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
+- Safe install guidance: [Official LinqContraband downloads and authenticity](/LinqContraband/security-and-authenticity/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -83,6 +83,10 @@ body_class: page-home
       <p><a href="{{ '/ef-core-n-plus-one-query-detector/' | relative_url }}">See the N+1 guide</a> for loop execution, missing includes, eager loading trade-offs, and telemetry tags.</p>
     </article>
     <article class="link-card">
+      <h3>Raw SQL safety</h3>
+      <p><a href="{{ '/ef-core-raw-sql-injection-analyzer/' | relative_url }}">Review the SQL guide</a> for interpolated raw SQL, constructed SQL strings, and query-filter bypasses.</p>
+    </article>
+    <article class="link-card">
       <h3>Authenticity</h3>
       <p><a href="{{ '/security-and-authenticity/' | relative_url }}">Verify official links</a> before installing or linking to the project.</p>
     </article>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,11 +11,13 @@ Official links:
 - Documentation hub: https://georgepwall1991.github.io/LinqContraband/
 - Rule catalog: https://georgepwall1991.github.io/LinqContraband/rule-catalog.html
 - EF Core N+1 query detector: https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/
+- EF Core raw SQL injection analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/
 - Authenticity: https://georgepwall1991.github.io/LinqContraband/security-and-authenticity/
 - Link kit: https://georgepwall1991.github.io/LinqContraband/backlink-kit/
 
 Key topics: Entity Framework Core, EF Core, LINQ, IQueryable, Roslyn analyzer, static analysis, query performance, N+1
-queries, EF Core N+1 query detector, missing includes, eager loading, raw SQL safety, .NET.
+queries, EF Core N+1 query detector, missing includes, eager loading, raw SQL safety, EF Core raw SQL injection analyzer,
+.NET.
 
 Canonical description: LinqContraband is an open-source EF Core LINQ performance analyzer for .NET. It runs as a
 compile-time Roslyn analyzer and helps catch query performance, reliability, and security issues before code reaches

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -9,7 +9,7 @@ permalink: /sitemap.xml
   {% assign priority = "0.6" -%}
   {% if item.url == "/" -%}
     {% assign priority = "1.0" -%}
-  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "security-and-authenticity" -%}
+  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "security-and-authenticity" -%}
     {% assign priority = "0.9" -%}
   {% elsif item.url contains "backlink-kit" or item.url contains "rule-catalog" -%}
     {% assign priority = "0.8" -%}


### PR DESCRIPTION
## Summary
- add a targeted EF Core raw SQL injection analyzer landing page
- link it from the homepage, page rail, performance guide, link kit, llms.txt, and sitemap priority set
- expand backlink snippets and anchor text for raw SQL safety searches

## Verification
- ruby -rjekyll -e 'Jekyll::Commands::Build.process({"source"=>"docs", "destination"=>"/tmp/linqcontraband-site", "config"=>"docs/_config.yml"})'
- rendered sitemap XML parse and raw SQL URL inclusion
- rendered JSON-LD parse for all HTML pages
- rendered local link check
- git diff --check
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj --configuration Release -- --check
- dotnet build LinqContraband.sln --configuration Release --no-restore
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --configuration Release --no-build --logger "console;verbosity=minimal"
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net10.0
- codex review --uncommitted