### PR TITLE
docs: add EF Core query analyzer CI guide

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -73,6 +73,7 @@
           <a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">EF Core guide</a>
           <a href="{{ '/ef-core-n-plus-one-query-detector/' | relative_url }}">N+1 detector</a>
           <a href="{{ '/ef-core-raw-sql-injection-analyzer/' | relative_url }}">Raw SQL safety</a>
+          <a href="{{ '/ef-core-query-analyzer-ci/' | relative_url }}">CI guide</a>
           <a href="{{ '/backlink-kit/' | relative_url }}">Link kit</a>
           <a href="{{ '/security-and-authenticity/' | relative_url }}">Authenticity</a>
         </aside>

--- a/docs/backlink-kit.md
+++ b/docs/backlink-kit.md
@@ -20,6 +20,7 @@ repository or the GitHub Pages documentation hub.
 - Rule catalog: [https://georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
 - N+1 guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/](https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/)
 - Raw SQL guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/)
+- CI guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-query-analyzer-ci/](https://georgepwall1991.github.io/LinqContraband/ef-core-query-analyzer-ci/)
 - Maintainer: [https://www.georgewall.uk/](https://www.georgewall.uk/)
 
 ## Suggested Anchor Text
@@ -30,6 +31,8 @@ repository or the GitHub Pages documentation hub.
 - EF Core N+1 query detector for .NET
 - EF Core raw SQL injection analyzer
 - EF Core raw SQL safety analyzer
+- EF Core query analyzer for CI
+- EF Core analyzer for pull requests
 - LINQ query performance analyzer for .NET
 - LinqContraband Roslyn analyzer
 
@@ -83,6 +86,12 @@ unsafe raw SQL interpolation, and tracking mistakes.
 
 ```markdown
 [EF Core raw SQL injection analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/) explains how LinqContraband flags interpolated raw SQL, constructed SQL strings, and risky query-filter bypasses at compile time.
+```
+
+## CI Guide Link
+
+```markdown
+[EF Core query analyzer for CI](https://georgepwall1991.github.io/LinqContraband/ef-core-query-analyzer-ci/) shows how to run LinqContraband in pull-request builds and promote selected EF Core diagnostics to build-breaking errors.
 ```
 
 ## HTML Link

--- a/docs/ef-core-linq-performance-analyzer.md
+++ b/docs/ef-core-linq-performance-analyzer.md
@@ -30,6 +30,7 @@ dotnet add package LinqContraband
 
 For a focused walkthrough, see the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/).
 For security-sensitive SQL usage, see the [EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/).
+For pull-request enforcement, see the [EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/).
 
 ## Why Compile-Time Analysis Helps
 
@@ -47,6 +48,7 @@ The full catalog contains 45 rules grouped by domain:
 - [Rule catalog](/LinqContraband/rule-catalog.html)
 - [EF Core N+1 query detector](/LinqContraband/ef-core-n-plus-one-query-detector/)
 - [EF Core raw SQL injection analyzer](/LinqContraband/ef-core-raw-sql-injection-analyzer/)
+- [EF Core query analyzer for CI](/LinqContraband/ef-core-query-analyzer-ci/)
 - [LC007: N+1 query loops](/LinqContraband/LC007_NPlusOneLooper.html)
 - [LC045: missing include](/LinqContraband/LC045_MissingInclude.html)
 - [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html)

--- a/docs/ef-core-n-plus-one-query-detector.md
+++ b/docs/ef-core-n-plus-one-query-detector.md
@@ -79,6 +79,9 @@ team feedback at the pull-request stage, before the query has production traffic
 LinqContraband runs as an analyzer package only. It adds no runtime dependency to your application and works with
 Visual Studio, Rider, VS Code, and CI builds.
 
+To make N+1 diagnostics visible on every pull request, see the
+[EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/).
+
 ## Official Links
 
 - Canonical repository: [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)

--- a/docs/ef-core-query-analyzer-ci.md
+++ b/docs/ef-core-query-analyzer-ci.md
@@ -1,0 +1,104 @@
+---
+layout: default
+title: EF Core Query Analyzer for CI
+description: Use LinqContraband as an EF Core query analyzer in CI so pull requests can catch N+1 queries, raw SQL risks, missing includes, and tracking mistakes before merge.
+permalink: /ef-core-query-analyzer-ci/
+body_class: page-ci-guide
+---
+
+# EF Core Query Analyzer for CI
+
+LinqContraband is an EF Core query analyzer for CI pipelines, pull requests, and local builds. It ships as a NuGet
+analyzer package, so ordinary `dotnet build` output can surface risky LINQ and Entity Framework Core query patterns
+before they merge.
+
+Install the official NuGet package in the project that contains your EF Core code:
+
+```bash
+dotnet add package LinqContraband
+```
+
+## Why Run EF Core Analysis in CI
+
+EF Core query mistakes often depend on production-sized data: N+1 loops, unbounded materialization, missing includes,
+raw SQL interpolation, and tracking-mode surprises may not appear in small test databases. A compile-time analyzer gives
+reviewers the same signal on every pull request, without adding a runtime dependency to the application.
+
+Use the CI gate to make the most dangerous diagnostics visible first, then raise selected rules to errors once the team
+has triaged existing warnings.
+
+## Minimal GitHub Actions Check
+
+Run the analyzer through the normal .NET build step. Match the SDK version to your application:
+
+```yaml
+name: ef-core-query-analysis
+
+on:
+  pull_request:
+
+jobs:
+  query-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - run: dotnet restore
+      - run: dotnet build --configuration Release --no-restore
+```
+
+No custom runner, service container, or database connection is required for LinqContraband diagnostics. The analyzer
+reviews C# source during compilation.
+
+## Make Selected Rules Block Pull Requests
+
+Control diagnostic severity with `.editorconfig`. Start by promoting high-confidence security and query-cost rules:
+
+```ini
+[*.cs]
+
+# Repeated database calls and missing includes
+dotnet_diagnostic.LC007.severity = error
+dotnet_diagnostic.LC045.severity = warning
+
+# Raw SQL and filter bypass risks
+dotnet_diagnostic.LC018.severity = error
+dotnet_diagnostic.LC034.severity = error
+dotnet_diagnostic.LC037.severity = error
+dotnet_diagnostic.LC021.severity = warning
+```
+
+This keeps CI focused: dangerous raw SQL construction can fail a build immediately, while broader reliability guidance
+can remain a warning until the team agrees on the policy.
+
+## Rules Worth Surfacing Early
+
+| Rule | CI value |
+| --- | --- |
+| [LC007: database execution inside loop](/LinqContraband/LC007_NPlusOneLooper.html) | Catches N+1 patterns that small test datasets hide. |
+| [LC045: missing include](/LinqContraband/LC045_MissingInclude.html) | Flags navigation access after materialization when the query did not include the navigation. |
+| [LC018: interpolated FromSqlRaw and SqlQueryRaw](/LinqContraband/LC018_AvoidFromSqlRawWithInterpolation.html) | Blocks SQL injection-prone raw query strings. |
+| [LC034: interpolated ExecuteSqlRaw](/LinqContraband/LC034_AvoidExecuteSqlRawWithInterpolation.html) | Blocks SQL injection-prone raw command strings. |
+| [LC037: constructed raw SQL strings](/LinqContraband/LC037_RawSqlStringConstruction.html) | Finds SQL strings built before they reach a raw EF Core API. |
+| [LC021: IgnoreQueryFilters](/LinqContraband/LC021_AvoidIgnoreQueryFilters.html) | Makes tenant, soft-delete, and security-filter bypasses auditable in review. |
+
+## CI Rollout Pattern
+
+1. Add LinqContraband and run CI with default severities.
+2. Fix obvious high-confidence warnings in touched code.
+3. Promote a small rule set to `error` in `.editorconfig`.
+4. Use narrow pragmas or `SuppressMessage` only for reviewed exceptions with a concrete justification.
+5. Expand the enforced rule set once the warning backlog is under control.
+
+For deeper rule detail, browse the [full rule catalog](/LinqContraband/rule-catalog.html), the
+[EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/), and the
+[EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/).
+
+## Official Links
+
+- Canonical repository: [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
+- Official NuGet package: [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
+- Documentation hub: [georgepwall1991.github.io/LinqContraband](https://georgepwall1991.github.io/LinqContraband/)
+- Safe install guidance: [Official LinqContraband downloads and authenticity](/LinqContraband/security-and-authenticity/)

--- a/docs/ef-core-raw-sql-injection-analyzer.md
+++ b/docs/ef-core-raw-sql-injection-analyzer.md
@@ -61,6 +61,9 @@ var users = db.Users.FromSqlRaw(
 LinqContraband does not try to replace a secure code review or threat model. It catches the common raw SQL footguns early
 so reviewers can focus on the cases that genuinely need human judgement.
 
+To make raw SQL diagnostics block or warn in pull requests, see the
+[EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/).
+
 ## Where It Fits
 
 - Pull request checks for APIs, admin tools, and reporting code that use EF Core.

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,6 +87,10 @@ body_class: page-home
       <p><a href="{{ '/ef-core-raw-sql-injection-analyzer/' | relative_url }}">Review the SQL guide</a> for interpolated raw SQL, constructed SQL strings, and query-filter bypasses.</p>
     </article>
     <article class="link-card">
+      <h3>CI enforcement</h3>
+      <p><a href="{{ '/ef-core-query-analyzer-ci/' | relative_url }}">Set up the CI guide</a> for pull-request checks, severity policy, and build-breaking EF Core diagnostics.</p>
+    </article>
+    <article class="link-card">
       <h3>Authenticity</h3>
       <p><a href="{{ '/security-and-authenticity/' | relative_url }}">Verify official links</a> before installing or linking to the project.</p>
     </article>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,12 +12,13 @@ Official links:
 - Rule catalog: https://georgepwall1991.github.io/LinqContraband/rule-catalog.html
 - EF Core N+1 query detector: https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/
 - EF Core raw SQL injection analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/
+- EF Core query analyzer for CI: https://georgepwall1991.github.io/LinqContraband/ef-core-query-analyzer-ci/
 - Authenticity: https://georgepwall1991.github.io/LinqContraband/security-and-authenticity/
 - Link kit: https://georgepwall1991.github.io/LinqContraband/backlink-kit/
 
 Key topics: Entity Framework Core, EF Core, LINQ, IQueryable, Roslyn analyzer, static analysis, query performance, N+1
 queries, EF Core N+1 query detector, missing includes, eager loading, raw SQL safety, EF Core raw SQL injection analyzer,
-.NET.
+EF Core query analyzer for CI, pull request diagnostics, .NET.
 
 Canonical description: LinqContraband is an open-source EF Core LINQ performance analyzer for .NET. It runs as a
 compile-time Roslyn analyzer and helps catch query performance, reliability, and security issues before code reaches

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -9,7 +9,7 @@ permalink: /sitemap.xml
   {% assign priority = "0.6" -%}
   {% if item.url == "/" -%}
     {% assign priority = "1.0" -%}
-  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "security-and-authenticity" -%}
+  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
     {% assign priority = "0.9" -%}
   {% elsif item.url contains "backlink-kit" or item.url contains "rule-catalog" -%}
     {% assign priority = "0.8" -%}


### PR DESCRIPTION
## Summary
- add a targeted EF Core query analyzer for CI landing page
- link it from the homepage, page rail, overview guide, N+1 guide, raw SQL guide, backlink kit, llms.txt, and sitemap priority set
- add pull-request and CI anchor text/snippets for safer backlink/citation use

## Verification
- ruby -rjekyll -e 'Jekyll::Commands::Build.process({"source"=>"docs", "destination"=>"/tmp/linqcontraband-site", "config"=>"docs/_config.yml"})'
- rendered sitemap XML parse and CI guide URL inclusion
- rendered JSON-LD parse for all HTML pages
- rendered local link check
- rendered CI page content check
- git diff --check
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj --configuration Release -- --check
- dotnet build LinqContraband.sln --configuration Release --no-restore
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --configuration Release --no-build --logger "console;verbosity=minimal"
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net10.0
- codex review --uncommitted