### PR TITLE
docs: add EF Core query performance checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ by [George Wall](https://www.georgewall.uk/).
 - **Canonical source:** [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
 - **Official package:** [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
 - **Documentation hub:** [georgepwall1991.github.io/LinqContraband](https://georgepwall1991.github.io/LinqContraband/)
+- **Query performance checklist:** [georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist](https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/)
 - **Link kit:** [georgepwall1991.github.io/LinqContraband/backlink-kit](https://georgepwall1991.github.io/LinqContraband/backlink-kit/)
 
 Install only from NuGet or from this repository. LinqContraband is not distributed as a standalone ZIP installer or

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -71,6 +71,7 @@
           <p class="page-rail__label">Reference</p>
           <a href="{{ '/rule-catalog.html' | relative_url }}">Rule catalog</a>
           <a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">EF Core guide</a>
+          <a href="{{ '/ef-core-query-performance-checklist/' | relative_url }}">Checklist</a>
           <a href="{{ '/ef-core-n-plus-one-query-detector/' | relative_url }}">N+1 detector</a>
           <a href="{{ '/ef-core-raw-sql-injection-analyzer/' | relative_url }}">Raw SQL safety</a>
           <a href="{{ '/ef-core-query-analyzer-ci/' | relative_url }}">CI guide</a>

--- a/docs/backlink-kit.md
+++ b/docs/backlink-kit.md
@@ -18,6 +18,7 @@ repository or the GitHub Pages documentation hub.
 - Package: [https://www.nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
 - Documentation: [https://georgepwall1991.github.io/LinqContraband/](https://georgepwall1991.github.io/LinqContraband/)
 - Rule catalog: [https://georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
+- Checklist: [https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/](https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/)
 - N+1 guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/](https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/)
 - Raw SQL guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/)
 - CI guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-query-analyzer-ci/](https://georgepwall1991.github.io/LinqContraband/ef-core-query-analyzer-ci/)
@@ -26,6 +27,7 @@ repository or the GitHub Pages documentation hub.
 ## Suggested Anchor Text
 
 - EF Core LINQ performance analyzer
+- EF Core query performance checklist
 - Entity Framework Core Roslyn analyzer
 - EF Core N+1 query detector
 - EF Core N+1 query detector for .NET
@@ -74,6 +76,12 @@ unsafe raw SQL interpolation, and tracking mistakes.
 
 ```markdown
 [LinqContraband rule catalog](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html) documents 45 EF Core analyzer rules covering query shape, materialization, loading, async execution, tracking, bulk operations, modeling, and raw SQL safety.
+```
+
+## Checklist Link
+
+```markdown
+[EF Core query performance checklist](https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/) maps common pull-request review questions to LinqContraband analyzer rules for N+1 queries, projection, tracking, raw SQL, and CI severity policy.
 ```
 
 ## N+1 Guide Link

--- a/docs/ef-core-linq-performance-analyzer.md
+++ b/docs/ef-core-linq-performance-analyzer.md
@@ -11,6 +11,8 @@ LinqContraband is a Roslyn analyzer for teams that want Entity Framework Core qu
 of after a slow production endpoint appears. It runs at compile time and reviews LINQ query shapes for performance,
 reliability, and security issues.
 
+For a reviewer-friendly summary, use the [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/).
+
 Install the official NuGet package:
 
 ```bash
@@ -46,6 +48,7 @@ environments including Visual Studio, Rider, VS Code, and CI builds.
 The full catalog contains 45 rules grouped by domain:
 
 - [Rule catalog](/LinqContraband/rule-catalog.html)
+- [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/)
 - [EF Core N+1 query detector](/LinqContraband/ef-core-n-plus-one-query-detector/)
 - [EF Core raw SQL injection analyzer](/LinqContraband/ef-core-raw-sql-injection-analyzer/)
 - [EF Core query analyzer for CI](/LinqContraband/ef-core-query-analyzer-ci/)

--- a/docs/ef-core-query-analyzer-ci.md
+++ b/docs/ef-core-query-analyzer-ci.md
@@ -12,6 +12,9 @@ LinqContraband is an EF Core query analyzer for CI pipelines, pull requests, and
 analyzer package, so ordinary `dotnet build` output can surface risky LINQ and Entity Framework Core query patterns
 before they merge.
 
+For the review questions that this CI gate can automate, use the
+[EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/).
+
 Install the official NuGet package in the project that contains your EF Core code:
 
 ```bash

--- a/docs/ef-core-query-performance-checklist.md
+++ b/docs/ef-core-query-performance-checklist.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: EF Core Query Performance Checklist
+description: A practical EF Core query performance checklist for reviewing LINQ queries, N+1 risks, raw SQL safety, tracking modes, and CI enforcement with LinqContraband.
+permalink: /ef-core-query-performance-checklist/
+body_class: page-performance-checklist
+---
+
+# EF Core Query Performance Checklist
+
+Use this EF Core query performance checklist when reviewing pull requests, tightening team standards, or adding
+compile-time query analysis to CI. It maps common review questions to LinqContraband rules so teams can move repeatable
+feedback out of human memory and into analyzer diagnostics.
+
+Install the official analyzer package:
+
+```bash
+dotnet add package LinqContraband
+```
+
+## Pull Request Checklist
+
+| Check | Why it matters | LinqContraband signal |
+| --- | --- | --- |
+| Avoid database calls inside loops. | Loop execution can turn one request into many database roundtrips. | [LC007: database execution inside loop](/LinqContraband/LC007_NPlusOneLooper.html) |
+| Materialize only after filtering, ordering, and projection. | Early `ToList`, `AsEnumerable`, or `ToArray` can move work from SQL into memory. | [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html) |
+| Use projection when only a few fields are needed. | Loading whole entities increases network, memory, and tracking cost. | [LC017: whole entity projection](/LinqContraband/LC017_WholeEntityProjection.html), [LC041: single entity scalar projection](/LinqContraband/LC041_SingleEntityScalarProjection.html) |
+| Make related data loading explicit. | Missing includes can produce null navigation data, lazy-loading churn, or hidden N+1 behaviour. | [LC045: missing include](/LinqContraband/LC045_MissingInclude.html) |
+| Keep eager loading bounded. | Overusing `Include` can create cartesian explosion or very wide result graphs. | [LC006: cartesian explosion](/LinqContraband/LC006_CartesianExplosion.html), [LC038: excessive eager loading](/LinqContraband/LC038_ExcessiveEagerLoading.html) |
+| Prefer async EF Core APIs in async methods. | Synchronous EF Core calls in async paths block request threads. | [LC008: sync-over-async](/LinqContraband/LC008_SyncBlocker.html) |
+| Pass cancellation tokens through async query APIs. | Long-running queries should respect request cancellation and shutdown paths. | [LC026: missing cancellation token](/LinqContraband/LC026_MissingCancellationToken.html) |
+| Use read-only tracking intentionally. | Tracking every read increases memory and can create confusing mixed-mode behaviour. | [LC009: missing AsNoTracking](/LinqContraband/LC009_MissingAsNoTracking.html), [LC040: mixed tracking modes](/LinqContraband/LC040_MixedTrackingAndNoTracking.html) |
+| Keep raw SQL parameterized. | Interpolation and string construction can turn EF Core raw SQL into injection risk. | [LC018: interpolated raw SQL](/LinqContraband/LC018_AvoidFromSqlRawWithInterpolation.html), [LC034: interpolated command SQL](/LinqContraband/LC034_AvoidExecuteSqlRawWithInterpolation.html), [LC037: constructed raw SQL strings](/LinqContraband/LC037_RawSqlStringConstruction.html) |
+| Review global filter bypasses. | `IgnoreQueryFilters` can skip tenant, soft-delete, or security boundaries. | [LC021: IgnoreQueryFilters](/LinqContraband/LC021_AvoidIgnoreQueryFilters.html) |
+| Bound destructive set-based writes. | Bulk delete/update without a filter can affect more rows than intended. | [LC035: missing Where before bulk execute](/LinqContraband/LC035_MissingWhereBeforeExecuteDeleteUpdate.html) |
+| Tag complex queries before they reach production. | Query tags make expensive SQL easier to trace in database telemetry. | [LC042: missing query tags](/LinqContraband/LC042_MissingQueryTags.html) |
+
+## Quick Severity Policy
+
+Start with analyzer warnings, then promote a focused rule set to errors once the team has cleared existing findings:
+
+```ini
+[*.cs]
+
+# Expensive or risky query shapes
+dotnet_diagnostic.LC002.severity = warning
+dotnet_diagnostic.LC007.severity = error
+dotnet_diagnostic.LC045.severity = warning
+
+# Raw SQL and security-sensitive paths
+dotnet_diagnostic.LC018.severity = error
+dotnet_diagnostic.LC034.severity = error
+dotnet_diagnostic.LC037.severity = error
+dotnet_diagnostic.LC021.severity = warning
+```
+
+Use project-wide `error` severities for rules that represent team policy. Use narrow pragmas or `SuppressMessage`
+attributes only when a reviewer has accepted a specific exception.
+
+## How To Use This Checklist
+
+- Link it from pull request templates, engineering handbooks, and onboarding docs.
+- Pair it with the [EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/) so the highest-risk
+  checklist items become automated build feedback.
+- Send focused topics to the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/) and
+  [EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/) when reviewers need
+  deeper examples.
+- Use the [full rule catalog](/LinqContraband/rule-catalog.html) to tune the exact severity policy for your application.
+
+## Official Links
+
+- Canonical repository: [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
+- Official NuGet package: [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
+- Documentation hub: [georgepwall1991.github.io/LinqContraband](https://georgepwall1991.github.io/LinqContraband/)
+- Safe install guidance: [Official LinqContraband downloads and authenticity](/LinqContraband/security-and-authenticity/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,6 +79,10 @@ body_class: page-home
       <p><a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">Read the overview</a> for teams comparing compile-time query analysis options.</p>
     </article>
     <article class="link-card">
+      <h3>Performance checklist</h3>
+      <p><a href="{{ '/ef-core-query-performance-checklist/' | relative_url }}">Use the review checklist</a> for N+1 risks, projection, tracking, raw SQL, and CI severity policy.</p>
+    </article>
+    <article class="link-card">
       <h3>N+1 query detector</h3>
       <p><a href="{{ '/ef-core-n-plus-one-query-detector/' | relative_url }}">See the N+1 guide</a> for loop execution, missing includes, eager loading trade-offs, and telemetry tags.</p>
     </article>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,6 +10,7 @@ Official links:
 - Maintainer: https://www.georgewall.uk/
 - Documentation hub: https://georgepwall1991.github.io/LinqContraband/
 - Rule catalog: https://georgepwall1991.github.io/LinqContraband/rule-catalog.html
+- EF Core query performance checklist: https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/
 - EF Core N+1 query detector: https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/
 - EF Core raw SQL injection analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/
 - EF Core query analyzer for CI: https://georgepwall1991.github.io/LinqContraband/ef-core-query-analyzer-ci/
@@ -17,8 +18,8 @@ Official links:
 - Link kit: https://georgepwall1991.github.io/LinqContraband/backlink-kit/
 
 Key topics: Entity Framework Core, EF Core, LINQ, IQueryable, Roslyn analyzer, static analysis, query performance, N+1
-queries, EF Core N+1 query detector, missing includes, eager loading, raw SQL safety, EF Core raw SQL injection analyzer,
-EF Core query analyzer for CI, pull request diagnostics, .NET.
+queries, EF Core query performance checklist, EF Core N+1 query detector, missing includes, eager loading, raw SQL safety,
+EF Core raw SQL injection analyzer, EF Core query analyzer for CI, pull request diagnostics, .NET.
 
 Canonical description: LinqContraband is an open-source EF Core LINQ performance analyzer for .NET. It runs as a
 compile-time Roslyn analyzer and helps catch query performance, reliability, and security issues before code reaches

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -9,7 +9,7 @@ permalink: /sitemap.xml
   {% assign priority = "0.6" -%}
   {% if item.url == "/" -%}
     {% assign priority = "1.0" -%}
-  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
+  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-query-performance-checklist" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
     {% assign priority = "0.9" -%}
   {% elsif item.url contains "backlink-kit" or item.url contains "rule-catalog" -%}
     {% assign priority = "0.8" -%}


### PR DESCRIPTION
## Summary
- Add a targeted EF Core query performance checklist page for PR review, analyzer severity policy, and safe install discovery.
- Link the checklist from the README, homepage, docs rail, EF Core overview, CI guide, backlink kit, llms.txt, and sitemap priority set.
- Add checklist anchor text and a curator-ready snippet for backlink/citation use.

## Verification
- Jekyll build for docs via ruby -rjekyll
- Rendered sitemap XML parse and checklist entry check
- Rendered JSON-LD parse for generated HTML
- Local rendered link check
- Rendered checklist content check
- git diff --check
- Rule catalog check
- dotnet build LinqContraband.sln --configuration Release --no-restore
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --configuration Release --no-build
- SampleDiagnosticsVerifier for net10.0
- codex review --uncommitted