### PR TITLE
docs: add EF Core analyzer rules guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ by [George Wall](https://www.georgewall.uk/).
 - **Canonical source:** [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
 - **Official package:** [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
 - **Documentation hub:** [georgepwall1991.github.io/LinqContraband](https://georgepwall1991.github.io/LinqContraband/)
+- **EF Core analyzer rules:** [georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/)
 - **Query performance checklist:** [georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist](https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/)
 - **Link kit:** [georgepwall1991.github.io/LinqContraband/backlink-kit](https://georgepwall1991.github.io/LinqContraband/backlink-kit/)
 
@@ -70,7 +71,9 @@ The repository keeps the familiar `LC001`-style rule numbering, but the rules no
 | Schema & Modeling | LC011, LC027 |
 | Raw SQL & Security | LC018, LC021, LC034, LC037 |
 
-For the full matrix of rule metadata, docs, and sample locations, see [docs/rule-catalog.md](docs/rule-catalog.md).
+For a human-readable guide to the rule groups, see the
+[EF Core analyzer rules page](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/). For the full
+matrix of rule metadata, docs, and sample locations, see [docs/rule-catalog.md](docs/rule-catalog.md).
 
 
 ### LC001: The Local Method Smuggler

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -70,6 +70,7 @@
         <aside class="page-rail" aria-label="Project navigation">
           <p class="page-rail__label">Reference</p>
           <a href="{{ '/rule-catalog.html' | relative_url }}">Rule catalog</a>
+          <a href="{{ '/ef-core-analyzer-rules/' | relative_url }}">Rule guide</a>
           <a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">EF Core guide</a>
           <a href="{{ '/ef-core-query-performance-checklist/' | relative_url }}">Checklist</a>
           <a href="{{ '/ef-core-n-plus-one-query-detector/' | relative_url }}">N+1 detector</a>

--- a/docs/backlink-kit.md
+++ b/docs/backlink-kit.md
@@ -18,6 +18,7 @@ repository or the GitHub Pages documentation hub.
 - Package: [https://www.nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
 - Documentation: [https://georgepwall1991.github.io/LinqContraband/](https://georgepwall1991.github.io/LinqContraband/)
 - Rule catalog: [https://georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
+- Rule guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/)
 - Checklist: [https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/](https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/)
 - N+1 guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/](https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/)
 - Raw SQL guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/)
@@ -27,6 +28,8 @@ repository or the GitHub Pages documentation hub.
 ## Suggested Anchor Text
 
 - EF Core LINQ performance analyzer
+- EF Core analyzer rules
+- Entity Framework Core analyzer rules
 - EF Core query performance checklist
 - Entity Framework Core Roslyn analyzer
 - EF Core N+1 query detector
@@ -76,6 +79,12 @@ unsafe raw SQL interpolation, and tracking mistakes.
 
 ```markdown
 [LinqContraband rule catalog](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html) documents 45 EF Core analyzer rules covering query shape, materialization, loading, async execution, tracking, bulk operations, modeling, and raw SQL safety.
+```
+
+## Rule Guide Link
+
+```markdown
+[EF Core analyzer rules](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/) groups LinqContraband's 45 diagnostics by query shape, materialization, loading, async execution, tracking, bulk operations, modeling, and raw SQL safety.
 ```
 
 ## Checklist Link

--- a/docs/ef-core-analyzer-rules.md
+++ b/docs/ef-core-analyzer-rules.md
@@ -1,0 +1,79 @@
+---
+layout: default
+title: EF Core Analyzer Rules
+description: A practical guide to LinqContraband's 45 EF Core analyzer rules for query performance, loading, tracking, async execution, raw SQL safety, and CI policy.
+permalink: /ef-core-analyzer-rules/
+body_class: page-analyzer-rules
+---
+
+# EF Core Analyzer Rules
+
+LinqContraband provides 45 EF Core analyzer rules for teams that want repeatable query review in the IDE and CI. The
+rules cover LINQ query shape, materialization, loading, async execution, tracking, bulk operations, schema modeling, and
+raw SQL safety.
+
+Install the official analyzer package:
+
+```bash
+dotnet add package LinqContraband
+```
+
+## Rule Families
+
+Use these groups to decide which EF Core diagnostics are most useful for your project before diving into the full rule
+catalog.
+
+| Rule family | Use it when you want to catch | Starting rules |
+| --- | --- | --- |
+| Query shape and translation | Local methods, unstable ordering, non-translatable overloads, and query shapes that can fall out of SQL translation. | [LC001: local method](/LinqContraband/LC001_LocalMethod.html), [LC015: missing OrderBy](/LinqContraband/LC015_MissingOrderBy.html), [LC024: non-translatable GroupBy](/LinqContraband/LC024_GroupByNonTranslatable.html) |
+| Materialization and projection | Early `ToList`, whole-entity fetches, unbounded result sets, and scalar reads that should project in SQL. | [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html), [LC017: whole entity projection](/LinqContraband/LC017_WholeEntityProjection.html), [LC041: scalar projection](/LinqContraband/LC041_SingleEntityScalarProjection.html) |
+| Loading and includes | Missing includes, cartesian explosion, excessive eager loading, deep include chains, and untagged complex queries. | [LC045: missing include](/LinqContraband/LC045_MissingInclude.html), [LC006: cartesian explosion](/LinqContraband/LC006_CartesianExplosion.html), [LC038: excessive eager loading](/LinqContraband/LC038_ExcessiveEagerLoading.html) |
+| Execution and async | Database work inside loops, synchronous EF Core calls in async paths, missing cancellation tokens, and async-stream buffering. | [LC007: database execution inside loop](/LinqContraband/LC007_NPlusOneLooper.html), [LC008: sync-over-async](/LinqContraband/LC008_SyncBlocker.html), [LC026: missing cancellation token](/LinqContraband/LC026_MissingCancellationToken.html) |
+| Tracking and context lifetime | Missing `AsNoTracking`, no-tracking writes, mixed tracking modes, repeated `SaveChanges`, and DbContext lifetime mistakes. | [LC009: missing AsNoTracking](/LinqContraband/LC009_MissingAsNoTracking.html), [LC044: no-tracking modification](/LinqContraband/LC044_AsNoTrackingThenModifySilentWrite.html), [LC030: DbContext lifetime mismatch](/LinqContraband/LC030_DbContextInSingleton.html) |
+| Bulk operations and modeling | Set-based write opportunities, unbounded bulk updates or deletes, missing keys, and missing explicit foreign keys. | [LC032: ExecuteUpdate](/LinqContraband/LC032_ExecuteUpdateForBulkUpdates.html), [LC035: missing Where before bulk execute](/LinqContraband/LC035_MissingWhereBeforeExecuteDeleteUpdate.html), [LC011: missing primary key](/LinqContraband/LC011_EntityMissingPrimaryKey.html) |
+| Raw SQL and security | Interpolated raw SQL, constructed SQL strings, unsafe command SQL, and query-filter bypasses. | [LC018: interpolated raw SQL](/LinqContraband/LC018_AvoidFromSqlRawWithInterpolation.html), [LC034: interpolated command SQL](/LinqContraband/LC034_AvoidExecuteSqlRawWithInterpolation.html), [LC021: IgnoreQueryFilters](/LinqContraband/LC021_AvoidIgnoreQueryFilters.html) |
+
+## Rules To Enable First
+
+For a low-noise rollout, start with the rules that usually represent clear production risk:
+
+```ini
+[*.cs]
+
+# Repeated database work and missing related data
+dotnet_diagnostic.LC007.severity = error
+dotnet_diagnostic.LC045.severity = warning
+
+# Raw SQL and query-filter bypasses
+dotnet_diagnostic.LC018.severity = error
+dotnet_diagnostic.LC034.severity = error
+dotnet_diagnostic.LC037.severity = error
+dotnet_diagnostic.LC021.severity = warning
+
+# Expensive query shapes
+dotnet_diagnostic.LC002.severity = warning
+dotnet_diagnostic.LC031.severity = warning
+```
+
+Keep broader design guidance as warnings until the team has reviewed existing findings. Promote a rule to `error` only
+when it represents project policy and developers have a documented exception path.
+
+## Where Each Rule Fits
+
+- Use the [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/) when you need a
+  reviewer-friendly pull-request aid.
+- Use the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/) when repeated database
+  calls or loading strategy are the main concern.
+- Use the [EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/) when raw SQL,
+  command SQL, or query-filter bypasses need stronger review.
+- Use the [EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/) when selected rules should warn
+  or fail pull requests.
+- Use the [full rule catalog](/LinqContraband/rule-catalog.html) for every rule's severity, category, sample folder, and
+  code-fix status.
+
+## Official Links
+
+- Canonical repository: [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
+- Official NuGet package: [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
+- Documentation hub: [georgepwall1991.github.io/LinqContraband](https://georgepwall1991.github.io/LinqContraband/)
+- Safe install guidance: [Official LinqContraband downloads and authenticity](/LinqContraband/security-and-authenticity/)

--- a/docs/ef-core-linq-performance-analyzer.md
+++ b/docs/ef-core-linq-performance-analyzer.md
@@ -12,6 +12,7 @@ of after a slow production endpoint appears. It runs at compile time and reviews
 reliability, and security issues.
 
 For a reviewer-friendly summary, use the [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/).
+For a rules-by-domain view, see the [EF Core analyzer rules guide](/LinqContraband/ef-core-analyzer-rules/).
 
 Install the official NuGet package:
 
@@ -48,6 +49,7 @@ environments including Visual Studio, Rider, VS Code, and CI builds.
 The full catalog contains 45 rules grouped by domain:
 
 - [Rule catalog](/LinqContraband/rule-catalog.html)
+- [EF Core analyzer rules guide](/LinqContraband/ef-core-analyzer-rules/)
 - [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/)
 - [EF Core N+1 query detector](/LinqContraband/ef-core-n-plus-one-query-detector/)
 - [EF Core raw SQL injection analyzer](/LinqContraband/ef-core-raw-sql-injection-analyzer/)

--- a/docs/ef-core-query-performance-checklist.md
+++ b/docs/ef-core-query-performance-checklist.md
@@ -60,6 +60,8 @@ attributes only when a reviewer has accepted a specific exception.
 ## How To Use This Checklist
 
 - Link it from pull request templates, engineering handbooks, and onboarding docs.
+- Pair it with the [EF Core analyzer rules guide](/LinqContraband/ef-core-analyzer-rules/) when a team needs the
+  broader diagnostic map before choosing severities.
 - Pair it with the [EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/) so the highest-risk
   checklist items become automated build feedback.
 - Send focused topics to the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/) and

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,6 +75,10 @@ body_class: page-home
       <p><a href="{{ '/rule-catalog.html' | relative_url }}">Browse every diagnostic</a> by EF Core domain, severity, and fix availability.</p>
     </article>
     <article class="link-card">
+      <h3>Analyzer rules</h3>
+      <p><a href="{{ '/ef-core-analyzer-rules/' | relative_url }}">Map the rule families</a> for query shape, loading, async execution, tracking, bulk operations, and raw SQL safety.</p>
+    </article>
+    <article class="link-card">
       <h3>EF Core analyzer guide</h3>
       <p><a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">Read the overview</a> for teams comparing compile-time query analysis options.</p>
     </article>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,6 +10,7 @@ Official links:
 - Maintainer: https://www.georgewall.uk/
 - Documentation hub: https://georgepwall1991.github.io/LinqContraband/
 - Rule catalog: https://georgepwall1991.github.io/LinqContraband/rule-catalog.html
+- EF Core analyzer rules: https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/
 - EF Core query performance checklist: https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/
 - EF Core N+1 query detector: https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/
 - EF Core raw SQL injection analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/
@@ -17,9 +18,10 @@ Official links:
 - Authenticity: https://georgepwall1991.github.io/LinqContraband/security-and-authenticity/
 - Link kit: https://georgepwall1991.github.io/LinqContraband/backlink-kit/
 
-Key topics: Entity Framework Core, EF Core, LINQ, IQueryable, Roslyn analyzer, static analysis, query performance, N+1
-queries, EF Core query performance checklist, EF Core N+1 query detector, missing includes, eager loading, raw SQL safety,
-EF Core raw SQL injection analyzer, EF Core query analyzer for CI, pull request diagnostics, .NET.
+Key topics: Entity Framework Core, EF Core, LINQ, IQueryable, Roslyn analyzer, static analysis, EF Core analyzer rules,
+Entity Framework Core analyzer rules, query performance, N+1 queries, EF Core query performance checklist, EF Core N+1
+query detector, missing includes, eager loading, raw SQL safety, EF Core raw SQL injection analyzer, EF Core query
+analyzer for CI, pull request diagnostics, .NET.
 
 Canonical description: LinqContraband is an open-source EF Core LINQ performance analyzer for .NET. It runs as a
 compile-time Roslyn analyzer and helps catch query performance, reliability, and security issues before code reaches

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -9,7 +9,7 @@ permalink: /sitemap.xml
   {% assign priority = "0.6" -%}
   {% if item.url == "/" -%}
     {% assign priority = "1.0" -%}
-  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-query-performance-checklist" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
+  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-analyzer-rules" or item.url contains "ef-core-query-performance-checklist" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
     {% assign priority = "0.9" -%}
   {% elsif item.url contains "backlink-kit" or item.url contains "rule-catalog" -%}
     {% assign priority = "0.8" -%}


### PR DESCRIPTION
## Summary
- Add a new EF Core analyzer rules guide targeting rule-family and Roslyn analyzer search intent.
- Link the guide from README, homepage, docs rail, EF Core overview, checklist, backlink kit, llms.txt, and sitemap priority set.
- Add backlink-kit anchor text and a rule-guide snippet for curators and citation reuse.

## Verification
- Jekyll build for docs via ruby -rjekyll
- Rendered sitemap XML parse and analyzer-rules entry check
- Rendered JSON-LD parse for generated HTML
- Local rendered link check
- Rendered analyzer-rules page marker check
- git diff --check
- Rule catalog check
- dotnet build LinqContraband.sln --configuration Release --no-restore
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --configuration Release --no-build
- SampleDiagnosticsVerifier for net10.0
- codex review --uncommitted