### PR TITLE
docs: add EF Core Include analyzer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ by [George Wall](https://www.georgewall.uk/).
 - **Documentation hub:** [georgepwall1991.github.io/LinqContraband](https://georgepwall1991.github.io/LinqContraband/)
 - **EF Core analyzer rules:** [georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/)
 - **AsNoTracking analyzer guide:** [georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/)
+- **Include analyzer guide:** [georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/)
 - **Query performance checklist:** [georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist](https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/)
 - **Link kit:** [georgepwall1991.github.io/LinqContraband/backlink-kit](https://georgepwall1991.github.io/LinqContraband/backlink-kit/)
 
@@ -73,8 +74,9 @@ The repository keeps the familiar `LC001`-style rule numbering, but the rules no
 | Raw SQL & Security | LC018, LC021, LC034, LC037 |
 
 For a human-readable guide to the rule groups, see the
-[EF Core analyzer rules page](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/). For tracking
-mode guidance, see the [EF Core AsNoTracking analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/).
+[EF Core analyzer rules page](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/). For loading
+guidance, see the [EF Core Include analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/).
+For tracking mode guidance, see the [EF Core AsNoTracking analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/).
 For the full matrix of rule metadata, docs, and sample locations, see [docs/rule-catalog.md](docs/rule-catalog.md).
 
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -72,6 +72,7 @@
           <a href="{{ '/rule-catalog.html' | relative_url }}">Rule catalog</a>
           <a href="{{ '/ef-core-analyzer-rules/' | relative_url }}">Rule guide</a>
           <a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">EF Core guide</a>
+          <a href="{{ '/ef-core-include-analyzer/' | relative_url }}">Include guide</a>
           <a href="{{ '/ef-core-asnotracking-analyzer/' | relative_url }}">Tracking guide</a>
           <a href="{{ '/ef-core-query-performance-checklist/' | relative_url }}">Checklist</a>
           <a href="{{ '/ef-core-n-plus-one-query-detector/' | relative_url }}">N+1 detector</a>

--- a/docs/backlink-kit.md
+++ b/docs/backlink-kit.md
@@ -20,6 +20,7 @@ repository or the GitHub Pages documentation hub.
 - Rule catalog: [https://georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
 - Rule guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/)
 - AsNoTracking guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/)
+- Include guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/)
 - Checklist: [https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/](https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/)
 - N+1 guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/](https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/)
 - Raw SQL guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/)
@@ -33,6 +34,9 @@ repository or the GitHub Pages documentation hub.
 - Entity Framework Core analyzer rules
 - EF Core AsNoTracking analyzer
 - EF Core tracking analyzer
+- EF Core Include analyzer
+- EF Core missing Include analyzer
+- EF Core eager loading analyzer
 - EF Core query performance checklist
 - Entity Framework Core Roslyn analyzer
 - EF Core N+1 query detector
@@ -94,6 +98,12 @@ unsafe raw SQL interpolation, and tracking mistakes.
 
 ```markdown
 [EF Core AsNoTracking analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/) explains how LinqContraband flags missing no-tracking reads, unsafe no-tracking writes, mixed tracking modes, and silent SaveChanges failures.
+```
+
+## Include Guide Link
+
+```markdown
+[EF Core Include analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/) explains how LinqContraband flags missing includes, cartesian explosion, conditional Include paths, deep ThenInclude chains, excessive eager loading, and missing query tags.
 ```
 
 ## Checklist Link

--- a/docs/ef-core-analyzer-rules.md
+++ b/docs/ef-core-analyzer-rules.md
@@ -27,7 +27,7 @@ catalog.
 | --- | --- | --- |
 | Query shape and translation | Local methods, unstable ordering, non-translatable overloads, and query shapes that can fall out of SQL translation. | [LC001: local method](/LinqContraband/LC001_LocalMethod.html), [LC015: missing OrderBy](/LinqContraband/LC015_MissingOrderBy.html), [LC024: non-translatable GroupBy](/LinqContraband/LC024_GroupByNonTranslatable.html) |
 | Materialization and projection | Early `ToList`, whole-entity fetches, unbounded result sets, and scalar reads that should project in SQL. | [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html), [LC017: whole entity projection](/LinqContraband/LC017_WholeEntityProjection.html), [LC041: scalar projection](/LinqContraband/LC041_SingleEntityScalarProjection.html) |
-| Loading and includes | Missing includes, cartesian explosion, excessive eager loading, deep include chains, and untagged complex queries. | [LC045: missing include](/LinqContraband/LC045_MissingInclude.html), [LC006: cartesian explosion](/LinqContraband/LC006_CartesianExplosion.html), [LC038: excessive eager loading](/LinqContraband/LC038_ExcessiveEagerLoading.html) |
+| Loading and includes | Missing includes, cartesian explosion, excessive eager loading, deep include chains, and untagged complex queries. | [LC045: missing include](/LinqContraband/LC045_MissingInclude.html), [LC006: cartesian explosion](/LinqContraband/LC006_CartesianExplosion.html), [EF Core Include analyzer](/LinqContraband/ef-core-include-analyzer/) |
 | Execution and async | Database work inside loops, synchronous EF Core calls in async paths, missing cancellation tokens, and async-stream buffering. | [LC007: database execution inside loop](/LinqContraband/LC007_NPlusOneLooper.html), [LC008: sync-over-async](/LinqContraband/LC008_SyncBlocker.html), [LC026: missing cancellation token](/LinqContraband/LC026_MissingCancellationToken.html) |
 | Tracking and context lifetime | Missing `AsNoTracking`, no-tracking writes, mixed tracking modes, repeated `SaveChanges`, and DbContext lifetime mistakes. | [LC009: missing AsNoTracking](/LinqContraband/LC009_MissingAsNoTracking.html), [LC044: no-tracking modification](/LinqContraband/LC044_AsNoTrackingThenModifySilentWrite.html), [EF Core AsNoTracking analyzer](/LinqContraband/ef-core-asnotracking-analyzer/) |
 | Bulk operations and modeling | Set-based write opportunities, unbounded bulk updates or deletes, missing keys, and missing explicit foreign keys. | [LC032: ExecuteUpdate](/LinqContraband/LC032_ExecuteUpdateForBulkUpdates.html), [LC035: missing Where before bulk execute](/LinqContraband/LC035_MissingWhereBeforeExecuteDeleteUpdate.html), [LC011: missing primary key](/LinqContraband/LC011_EntityMissingPrimaryKey.html) |
@@ -62,6 +62,8 @@ when it represents project policy and developers have a documented exception pat
 
 - Use the [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/) when you need a
   reviewer-friendly pull-request aid.
+- Use the [EF Core Include analyzer guide](/LinqContraband/ef-core-include-analyzer/) when missing related data,
+  cartesian explosion, or over-eager loading are the main concern.
 - Use the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/) when repeated database
   calls or loading strategy are the main concern.
 - Use the [EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/) when raw SQL,

--- a/docs/ef-core-include-analyzer.md
+++ b/docs/ef-core-include-analyzer.md
@@ -1,0 +1,119 @@
+---
+layout: default
+title: EF Core Include Analyzer
+description: Use LinqContraband as an EF Core Include analyzer for missing includes, N+1 loading, cartesian explosion, deep ThenInclude chains, excessive eager loading, and query tags.
+permalink: /ef-core-include-analyzer/
+body_class: page-include-analyzer
+---
+
+# EF Core Include Analyzer
+
+LinqContraband is an EF Core `Include` analyzer for .NET projects that want loading problems to appear during
+development instead of after a slow endpoint reaches production. It catches missing related data, lazy-loading churn,
+cartesian explosion risks, and over-eager graphs at compile time.
+
+Install the official analyzer package:
+
+```bash
+dotnet add package LinqContraband
+```
+
+## Why Include Needs Review
+
+`Include()` can fix a missing navigation, but it can also create a much larger query than the caller needs. A useful
+review has to answer both questions:
+
+- Did the query load the related data that the code reads after materialization?
+- Did the fix keep the eager-loading graph bounded enough for production row counts?
+
+The common failure shape is a materialized entity followed by navigation access:
+
+```csharp
+var orders = db.Orders.ToList();
+
+foreach (var order in orders)
+{
+    Console.WriteLine(order.Customer.Name);
+}
+```
+
+With lazy loading enabled, that can become an extra database query per row. Without lazy loading, the navigation may be
+null or empty. Adding `Include()` can be right, but a projection may be cheaper when the caller only needs a few fields.
+
+## LinqContraband Rules That Help
+
+| Rule | What it detects | Review direction |
+| --- | --- | --- |
+| [LC045: missing include](/LinqContraband/LC045_MissingInclude.html) | Navigation access after materialization when the query did not include the navigation. | Add the missing `Include`/`ThenInclude` path or project the needed values in SQL. |
+| [LC006: cartesian explosion risk](/LinqContraband/LC006_CartesianExplosion.html) | Sibling collection includes without an effective `AsSplitQuery()`. | Use `AsSplitQuery()` when the split-query trade-off is acceptable, or keep a reviewed single query with justification. |
+| [LC019: conditional include expression](/LinqContraband/LC019_ConditionalInclude.html) | Conditional navigation choices inside `Include` or `ThenInclude` paths. | Split the query branch before `Include`, eager-load both explicit paths, or project a conditional result shape. |
+| [LC028: deep ThenInclude chain](/LinqContraband/LC028_DeepThenInclude.html) | `ThenInclude` chains deeper than the configured review threshold. | Prefer focused projections, split queries, or a documented threshold/suppression for known aggregate loads. |
+| [LC038: excessive eager loading](/LinqContraband/LC038_ExcessiveEagerLoading.html) | Too many `Include`/`ThenInclude` calls on one provable EF query root. | Check whether every navigation is used and whether unrelated branches should be loaded separately. |
+| [LC042: missing query tags](/LinqContraband/LC042_MissingQueryTags.html) | Complex EF query shapes without `TagWith(...)` or `TagWithCallSite()`. | Add a stable tag so expensive Include graphs can be found in logs, profilers, and query plans. |
+
+## Safer Loading Patterns
+
+Project when the caller only needs a read model:
+
+```csharp
+var rows = await db.Orders
+    .Select(order => new OrderRow
+    {
+        Id = order.Id,
+        CustomerName = order.Customer.Name,
+        OpenLineCount = order.Lines.Count(line => line.IsOpen)
+    })
+    .ToListAsync();
+```
+
+Use explicit eager loading when the caller genuinely needs the entity graph:
+
+```csharp
+var orders = await db.Orders
+    .Include(order => order.Customer)
+    .Include(order => order.Lines)
+    .AsSplitQuery()
+    .TagWith("Orders screen: customer and line graph")
+    .ToListAsync();
+```
+
+Split conditional loading before the Include chain:
+
+```csharp
+var query = includeBilling
+    ? db.Orders.Include(order => order.Customer.BillingAddress)
+    : db.Orders.Include(order => order.Customer.ShippingAddress);
+```
+
+Do not treat `Include()` as the default fix for every navigation warning. For list screens, API responses, and
+dashboards, a projection often gives EF Core a smaller SQL shape and avoids tracking a graph that the caller never
+edits.
+
+## CI Severity Starter
+
+Start with the correctness and production-cost rules, then tune the advisory thresholds to the project:
+
+```ini
+[*.cs]
+
+# Missing related data and hidden N+1 loading
+dotnet_diagnostic.LC045.severity = warning
+
+# Eager-loading cost review
+dotnet_diagnostic.LC006.severity = warning
+dotnet_diagnostic.LC019.severity = warning
+dotnet_diagnostic.LC028.severity = suggestion
+dotnet_diagnostic.LC038.severity = suggestion
+dotnet_diagnostic.LC042.severity = suggestion
+```
+
+Use the [EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/) when these diagnostics should run
+on every pull request. Use the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/)
+when loop execution and missing related data are the main concern.
+
+## Official Links
+
+- Canonical repository: [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
+- Official NuGet package: [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
+- Full rule catalog: [georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
+- Safe install guidance: [Official LinqContraband downloads and authenticity](/LinqContraband/security-and-authenticity/)

--- a/docs/ef-core-linq-performance-analyzer.md
+++ b/docs/ef-core-linq-performance-analyzer.md
@@ -31,6 +31,7 @@ dotnet add package LinqContraband
 - Silent no-tracking writes and mixed tracking modes
 - Bulk update/delete operations without an explicit filter
 
+For Include and eager-loading review, see the [EF Core Include analyzer guide](/LinqContraband/ef-core-include-analyzer/).
 For a focused walkthrough, see the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/).
 For security-sensitive SQL usage, see the [EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/).
 For tracking-mode mistakes, see the [EF Core AsNoTracking analyzer guide](/LinqContraband/ef-core-asnotracking-analyzer/).
@@ -52,6 +53,7 @@ The full catalog contains 45 rules grouped by domain:
 - [Rule catalog](/LinqContraband/rule-catalog.html)
 - [EF Core analyzer rules guide](/LinqContraband/ef-core-analyzer-rules/)
 - [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/)
+- [EF Core Include analyzer](/LinqContraband/ef-core-include-analyzer/)
 - [EF Core N+1 query detector](/LinqContraband/ef-core-n-plus-one-query-detector/)
 - [EF Core raw SQL injection analyzer](/LinqContraband/ef-core-raw-sql-injection-analyzer/)
 - [EF Core AsNoTracking analyzer](/LinqContraband/ef-core-asnotracking-analyzer/)

--- a/docs/ef-core-n-plus-one-query-detector.md
+++ b/docs/ef-core-n-plus-one-query-detector.md
@@ -69,7 +69,8 @@ var users = await db.Users
 
 LinqContraband does not blindly demand `Include()` everywhere. It pairs N+1 detection with rules for cartesian
 explosion, deep include chains, excessive eager loading, and whole-entity projection so the fix remains appropriate for
-the query.
+the query. For the loading-specific rule set, see the
+[EF Core Include analyzer guide](/LinqContraband/ef-core-include-analyzer/).
 
 ## Why Compile-Time Detection Helps
 

--- a/docs/ef-core-query-performance-checklist.md
+++ b/docs/ef-core-query-performance-checklist.md
@@ -64,7 +64,8 @@ attributes only when a reviewer has accepted a specific exception.
   broader diagnostic map before choosing severities.
 - Pair it with the [EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/) so the highest-risk
   checklist items become automated build feedback.
-- Send focused topics to the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/) and
+- Send focused topics to the [EF Core Include analyzer guide](/LinqContraband/ef-core-include-analyzer/), the
+  [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/), and the
   [EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/) when reviewers need
   deeper examples.
 - Use the [EF Core AsNoTracking analyzer guide](/LinqContraband/ef-core-asnotracking-analyzer/) when read-only query

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,6 +87,10 @@ body_class: page-home
       <p><a href="{{ '/ef-core-query-performance-checklist/' | relative_url }}">Use the review checklist</a> for N+1 risks, projection, tracking, raw SQL, and CI severity policy.</p>
     </article>
     <article class="link-card">
+      <h3>Include analyzer</h3>
+      <p><a href="{{ '/ef-core-include-analyzer/' | relative_url }}">Tune loading rules</a> for missing includes, cartesian explosion, deep eager-loading chains, and query tags.</p>
+    </article>
+    <article class="link-card">
       <h3>AsNoTracking analyzer</h3>
       <p><a href="{{ '/ef-core-asnotracking-analyzer/' | relative_url }}">Review tracking rules</a> for read-only queries, no-tracking writes, mixed modes, and silent SaveChanges failures.</p>
     </article>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,6 +12,7 @@ Official links:
 - Rule catalog: https://georgepwall1991.github.io/LinqContraband/rule-catalog.html
 - EF Core analyzer rules: https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/
 - EF Core AsNoTracking analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/
+- EF Core Include analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/
 - EF Core query performance checklist: https://georgepwall1991.github.io/LinqContraband/ef-core-query-performance-checklist/
 - EF Core N+1 query detector: https://georgepwall1991.github.io/LinqContraband/ef-core-n-plus-one-query-detector/
 - EF Core raw SQL injection analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-raw-sql-injection-analyzer/
@@ -20,9 +21,10 @@ Official links:
 - Link kit: https://georgepwall1991.github.io/LinqContraband/backlink-kit/
 
 Key topics: Entity Framework Core, EF Core, LINQ, IQueryable, Roslyn analyzer, static analysis, EF Core analyzer rules,
-Entity Framework Core analyzer rules, EF Core AsNoTracking analyzer, EF Core tracking analyzer, query performance, N+1
-queries, EF Core query performance checklist, EF Core N+1 query detector, missing includes, eager loading, raw SQL
-safety, EF Core raw SQL injection analyzer, EF Core query analyzer for CI, pull request diagnostics, .NET.
+Entity Framework Core analyzer rules, EF Core AsNoTracking analyzer, EF Core tracking analyzer, EF Core Include
+analyzer, EF Core missing Include analyzer, EF Core eager loading analyzer, query performance, N+1 queries, EF Core query
+performance checklist, EF Core N+1 query detector, missing includes, eager loading, raw SQL safety, EF Core raw SQL
+injection analyzer, EF Core query analyzer for CI, pull request diagnostics, .NET.
 
 Canonical description: LinqContraband is an open-source EF Core LINQ performance analyzer for .NET. It runs as a
 compile-time Roslyn analyzer and helps catch query performance, reliability, and security issues before code reaches

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -9,7 +9,7 @@ permalink: /sitemap.xml
   {% assign priority = "0.6" -%}
   {% if item.url == "/" -%}
     {% assign priority = "1.0" -%}
-  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-analyzer-rules" or item.url contains "ef-core-asnotracking-analyzer" or item.url contains "ef-core-query-performance-checklist" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
+  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-analyzer-rules" or item.url contains "ef-core-asnotracking-analyzer" or item.url contains "ef-core-include-analyzer" or item.url contains "ef-core-query-performance-checklist" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
     {% assign priority = "0.9" -%}
   {% elsif item.url contains "backlink-kit" or item.url contains "rule-catalog" -%}
     {% assign priority = "0.8" -%}


### PR DESCRIPTION
## Summary
- Add an EF Core Include/eager-loading guide for LC045, LC006, LC019, LC028, LC038, and LC042 search intent.
- Link the new guide from README, homepage, docs rail, analyzer rules guide, EF Core overview, N+1 guide, checklist, backlink kit, llms.txt, and sitemap.
- Add backlink-kit anchor text and snippet coverage for Include, missing Include, and eager-loading search phrases.

## Verification
- `ruby -rjekyll -e 'Jekyll::Commands::Build.process({"source"=>"docs", "destination"=>"/tmp/linqcontraband-site", "config"=>"docs/_config.yml"})'`
- Rendered sitemap XML parse and Include guide URL check
- Rendered JSON-LD parse
- Rendered local link check
- Rendered Include page marker check
- Rendered llms.txt marker check
- `git diff --check`
- `dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj --configuration Release -- --check`
- `dotnet build LinqContraband.sln --configuration Release --no-restore`
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --configuration Release --no-build --logger "console;verbosity=minimal"` (1159/1159)
- `dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net10.0`
- `codex review --uncommitted` (no actionable defects)

Note: the plain `jekyll` executable is not on this local PATH, so the site was verified with the repo-compatible `ruby -rjekyll` invocation. Full multi-target test execution remains limited locally by missing arm64 .NET 8/9 runtimes; `net10.0` passed.
