### PR TITLE
docs: add EF Core premature materialization analyzer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ by [George Wall](https://www.georgewall.uk/).
 - **Official package:** [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
 - **Documentation hub:** [georgepwall1991.github.io/LinqContraband](https://georgepwall1991.github.io/LinqContraband/)
 - **EF Core analyzer rules:** [georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/)
+- **Premature materialization guide:** [georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/)
 - **AsNoTracking analyzer guide:** [georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/)
 - **Include analyzer guide:** [georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/)
 - **ExecuteUpdate analyzer guide:** [georgepwall1991.github.io/LinqContraband/ef-core-executeupdate-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-executeupdate-analyzer/)
@@ -78,6 +79,7 @@ The repository keeps the familiar `LC001`-style rule numbering, but the rules no
 For a human-readable guide to the rule groups, see the
 [EF Core analyzer rules page](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/). For loading
 guidance, see the [EF Core Include analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/).
+For early `ToList` and `AsEnumerable` guidance, see the [EF Core premature materialization analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/).
 For tracking mode guidance, see the [EF Core AsNoTracking analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/).
 For set-based writes, see the [EF Core ExecuteUpdate analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-executeupdate-analyzer/).
 For repeated writes, see the [EF Core SaveChanges in loop analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-savechanges-in-loop-analyzer/).

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -72,6 +72,7 @@
           <a href="{{ '/rule-catalog.html' | relative_url }}">Rule catalog</a>
           <a href="{{ '/ef-core-analyzer-rules/' | relative_url }}">Rule guide</a>
           <a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">EF Core guide</a>
+          <a href="{{ '/ef-core-premature-materialization-analyzer/' | relative_url }}">Materialization</a>
           <a href="{{ '/ef-core-include-analyzer/' | relative_url }}">Include guide</a>
           <a href="{{ '/ef-core-asnotracking-analyzer/' | relative_url }}">Tracking guide</a>
           <a href="{{ '/ef-core-executeupdate-analyzer/' | relative_url }}">Bulk writes</a>

--- a/docs/backlink-kit.md
+++ b/docs/backlink-kit.md
@@ -19,6 +19,7 @@ repository or the GitHub Pages documentation hub.
 - Documentation: [https://georgepwall1991.github.io/LinqContraband/](https://georgepwall1991.github.io/LinqContraband/)
 - Rule catalog: [https://georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
 - Rule guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/)
+- Premature materialization guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/)
 - AsNoTracking guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/)
 - Include guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/)
 - ExecuteUpdate guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-executeupdate-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-executeupdate-analyzer/)
@@ -34,6 +35,11 @@ repository or the GitHub Pages documentation hub.
 - EF Core LINQ performance analyzer
 - EF Core analyzer rules
 - Entity Framework Core analyzer rules
+- EF Core premature materialization analyzer
+- EF Core ToList analyzer
+- EF Core AsEnumerable analyzer
+- LINQ ToList performance analyzer
+- EF Core client-side evaluation analyzer
 - EF Core AsNoTracking analyzer
 - EF Core tracking analyzer
 - EF Core Include analyzer
@@ -100,6 +106,12 @@ unsafe raw SQL interpolation, and tracking mistakes.
 
 ```markdown
 [EF Core analyzer rules](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/) groups LinqContraband's 45 diagnostics by query shape, materialization, loading, async execution, tracking, bulk operations, modeling, and raw SQL safety.
+```
+
+## Premature Materialization Guide Link
+
+```markdown
+[EF Core premature materialization analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/) explains how LinqContraband flags ToList before Where, AsEnumerable client-side query work, unbounded materialization, and projection waste.
 ```
 
 ## AsNoTracking Guide Link

--- a/docs/ef-core-analyzer-rules.md
+++ b/docs/ef-core-analyzer-rules.md
@@ -26,7 +26,7 @@ catalog.
 | Rule family | Use it when you want to catch | Starting rules |
 | --- | --- | --- |
 | Query shape and translation | Local methods, unstable ordering, non-translatable overloads, and query shapes that can fall out of SQL translation. | [LC001: local method](/LinqContraband/LC001_LocalMethod.html), [LC015: missing OrderBy](/LinqContraband/LC015_MissingOrderBy.html), [LC024: non-translatable GroupBy](/LinqContraband/LC024_GroupByNonTranslatable.html) |
-| Materialization and projection | Early `ToList`, whole-entity fetches, unbounded result sets, and scalar reads that should project in SQL. | [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html), [LC017: whole entity projection](/LinqContraband/LC017_WholeEntityProjection.html), [LC041: scalar projection](/LinqContraband/LC041_SingleEntityScalarProjection.html) |
+| Materialization and projection | Early `ToList`, whole-entity fetches, unbounded result sets, and scalar reads that should project in SQL. | [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html), [LC017: whole entity projection](/LinqContraband/LC017_WholeEntityProjection.html), [EF Core premature materialization analyzer](/LinqContraband/ef-core-premature-materialization-analyzer/) |
 | Loading and includes | Missing includes, cartesian explosion, excessive eager loading, deep include chains, and untagged complex queries. | [LC045: missing include](/LinqContraband/LC045_MissingInclude.html), [LC006: cartesian explosion](/LinqContraband/LC006_CartesianExplosion.html), [EF Core Include analyzer](/LinqContraband/ef-core-include-analyzer/) |
 | Execution and async | Database work inside loops, synchronous EF Core calls in async paths, repeated saves, missing cancellation tokens, and async-stream buffering. | [LC007: database execution inside loop](/LinqContraband/LC007_NPlusOneLooper.html), [LC008: sync-over-async](/LinqContraband/LC008_SyncBlocker.html), [LC010: SaveChanges loop](/LinqContraband/LC010_SaveChangesInLoop.html) |
 | Tracking and context lifetime | Missing `AsNoTracking`, no-tracking writes, mixed tracking modes, repeated `SaveChanges`, and DbContext lifetime mistakes. | [LC009: missing AsNoTracking](/LinqContraband/LC009_MissingAsNoTracking.html), [LC044: no-tracking modification](/LinqContraband/LC044_AsNoTrackingThenModifySilentWrite.html), [EF Core AsNoTracking analyzer](/LinqContraband/ef-core-asnotracking-analyzer/) |
@@ -62,6 +62,8 @@ when it represents project policy and developers have a documented exception pat
 
 - Use the [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/) when you need a
   reviewer-friendly pull-request aid.
+- Use the [EF Core premature materialization analyzer guide](/LinqContraband/ef-core-premature-materialization-analyzer/)
+  when early `ToList`, `AsEnumerable`, unbounded materialization, or projection waste are the main concern.
 - Use the [EF Core Include analyzer guide](/LinqContraband/ef-core-include-analyzer/) when missing related data,
   cartesian explosion, or over-eager loading are the main concern.
 - Use the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/) when repeated database

--- a/docs/ef-core-linq-performance-analyzer.md
+++ b/docs/ef-core-linq-performance-analyzer.md
@@ -34,6 +34,8 @@ dotnet add package LinqContraband
 
 For Include and eager-loading review, see the [EF Core Include analyzer guide](/LinqContraband/ef-core-include-analyzer/).
 For a focused walkthrough, see the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/).
+For early `ToList`, `ToArray`, and `AsEnumerable` review, see the
+[EF Core premature materialization analyzer guide](/LinqContraband/ef-core-premature-materialization-analyzer/).
 For security-sensitive SQL usage, see the [EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/).
 For tracking-mode mistakes, see the [EF Core AsNoTracking analyzer guide](/LinqContraband/ef-core-asnotracking-analyzer/).
 For set-based write review, see the [EF Core ExecuteUpdate analyzer guide](/LinqContraband/ef-core-executeupdate-analyzer/).
@@ -56,6 +58,7 @@ The full catalog contains 45 rules grouped by domain:
 - [Rule catalog](/LinqContraband/rule-catalog.html)
 - [EF Core analyzer rules guide](/LinqContraband/ef-core-analyzer-rules/)
 - [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/)
+- [EF Core premature materialization analyzer](/LinqContraband/ef-core-premature-materialization-analyzer/)
 - [EF Core Include analyzer](/LinqContraband/ef-core-include-analyzer/)
 - [EF Core N+1 query detector](/LinqContraband/ef-core-n-plus-one-query-detector/)
 - [EF Core raw SQL injection analyzer](/LinqContraband/ef-core-raw-sql-injection-analyzer/)

--- a/docs/ef-core-premature-materialization-analyzer.md
+++ b/docs/ef-core-premature-materialization-analyzer.md
@@ -1,0 +1,128 @@
+---
+layout: default
+title: EF Core Premature Materialization Analyzer
+description: Use LinqContraband as an EF Core premature materialization analyzer for ToList before Where, AsEnumerable client-side query work, unbounded ToList calls, and projection review.
+permalink: /ef-core-premature-materialization-analyzer/
+body_class: page-premature-materialization-analyzer
+---
+
+# EF Core Premature Materialization Analyzer
+
+LinqContraband is an EF Core premature materialization analyzer for .NET projects that want `ToList`, `ToArray`,
+`AsEnumerable`, and projection mistakes to show up during development and CI. It helps reviewers catch query work that
+accidentally moves from SQL into memory before production row counts make the cost obvious.
+
+Install the official analyzer package:
+
+```bash
+dotnet add package LinqContraband
+```
+
+## What Premature Materialization Looks Like
+
+The risky shape is an EF Core query that crosses into LINQ-to-Objects before the filter, sort, projection, or aggregate
+has finished:
+
+```csharp
+var users = db.Users
+    .ToList()
+    .Where(user => user.IsActive)
+    .OrderBy(user => user.LastLogin);
+```
+
+`ToList()` and `ToArray()` execute the query immediately. `AsEnumerable()` is a little different: it does not fetch rows
+by itself, but it changes the rest of the chain to `Enumerable`, so later operators are no longer provider-translated.
+
+The safer shape keeps query work in SQL until the final materializer:
+
+```csharp
+var users = await db.Users
+    .Where(user => user.IsActive)
+    .OrderBy(user => user.LastLogin)
+    .ToListAsync();
+```
+
+## LinqContraband Rules That Help
+
+| Rule | What it detects | Review direction |
+| --- | --- | --- |
+| [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html) | Inline `ToList`, `ToArray`, or `AsEnumerable` followed by provider-safe `Where`, `Select`, `OrderBy`, `Count`, and related operators. | Move the filter, sort, projection, or aggregate before the materializer. |
+| [LC031: unbounded query materialization](/LinqContraband/LC031_UnboundedQueryMaterialization.html) | Broad `ToList` or similar materialization where the query has no proven row bound. | Add ordered pagination, `Take`, a single-row terminal, or a reviewed suppression for intentional full scans. |
+| [LC017: whole entity projection](/LinqContraband/LC017_WholeEntityProjection.html) | Large entity loads where later code uses only a small subset of properties. | Project the fields or DTO shape the caller actually needs. |
+| [LC041: single entity scalar projection](/LinqContraband/LC041_SingleEntityScalarProjection.html) | Single-entity materialization when the caller reads one scalar value. | Project the scalar in SQL before materialization. |
+| [LC001: local method in IQueryable](/LinqContraband/LC001_LocalMethod.html) | Row-dependent local helpers inside translation-critical query lambdas. | Rewrite to translatable expressions or make the client boundary explicit and late. |
+
+## Safer Query Patterns
+
+Move filters before materialization:
+
+```csharp
+var activeUsers = await db.Users
+    .Where(user => user.IsActive)
+    .ToListAsync();
+```
+
+Project only the data the caller needs:
+
+```csharp
+var summaries = await db.Users
+    .Where(user => user.IsActive)
+    .Select(user => new UserSummary(user.Id, user.DisplayName))
+    .ToListAsync();
+```
+
+Bound broad result sets:
+
+```csharp
+var page = await db.Users
+    .OrderBy(user => user.Id)
+    .Skip(pageIndex * pageSize)
+    .Take(pageSize)
+    .ToListAsync();
+```
+
+Keep client-side work explicit when it is intentional:
+
+```csharp
+var snapshot = await db.Users
+    .Where(user => user.IsActive)
+    .ToListAsync();
+
+var sortedForDisplay = snapshot
+    .OrderBy(user => NaturalSortKey(user.DisplayName))
+    .ToList();
+```
+
+## Review Checklist
+
+1. Does every `ToList`, `ToArray`, or `AsEnumerable` happen after the SQL-side filters, ordering, projection, and bounds?
+2. Is an `AsEnumerable` boundary deliberate, or did it quietly move later operators into memory?
+3. Could the query project a DTO or scalar instead of a full entity?
+4. Is the result set bounded with ordered pagination, `Take`, or a single-row terminal?
+5. If client-side work is required, is the boundary obvious and close to a comment or suppression that explains why?
+
+## CI Severity Starter
+
+Start with early materialization and broad reads as warnings, then promote them where the team has a clear exception
+process:
+
+```ini
+[*.cs]
+
+# Materialization and projection risk
+dotnet_diagnostic.LC002.severity = warning
+dotnet_diagnostic.LC031.severity = warning
+dotnet_diagnostic.LC017.severity = suggestion
+dotnet_diagnostic.LC041.severity = suggestion
+```
+
+Use the [EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/) when these diagnostics should run
+on every pull request. Use the [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/)
+when reviewers need the broader query-performance context.
+
+## Official Links
+
+- Canonical repository: [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
+- Official NuGet package: [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
+- Full rule catalog: [georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
+- Safe install guidance: [Official LinqContraband downloads and authenticity](/LinqContraband/security-and-authenticity/)

--- a/docs/ef-core-query-performance-checklist.md
+++ b/docs/ef-core-query-performance-checklist.md
@@ -24,7 +24,7 @@ dotnet add package LinqContraband
 | --- | --- | --- |
 | Avoid database calls inside loops. | Loop execution can turn one request into many database roundtrips. | [LC007: database execution inside loop](/LinqContraband/LC007_NPlusOneLooper.html) |
 | Batch `SaveChanges` outside loops unless each item needs its own commit boundary. | Repeated saves can turn one unit of work into many transactions and partial-progress states. | [LC010: SaveChanges inside loop](/LinqContraband/LC010_SaveChangesInLoop.html) |
-| Materialize only after filtering, ordering, and projection. | Early `ToList`, `AsEnumerable`, or `ToArray` can move work from SQL into memory. | [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html) |
+| Materialize only after filtering, ordering, and projection. | Early `ToList`, `AsEnumerable`, or `ToArray` can move work from SQL into memory. | [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html), [EF Core premature materialization analyzer](/LinqContraband/ef-core-premature-materialization-analyzer/) |
 | Use projection when only a few fields are needed. | Loading whole entities increases network, memory, and tracking cost. | [LC017: whole entity projection](/LinqContraband/LC017_WholeEntityProjection.html), [LC041: single entity scalar projection](/LinqContraband/LC041_SingleEntityScalarProjection.html) |
 | Make related data loading explicit. | Missing includes can produce null navigation data, lazy-loading churn, or hidden N+1 behaviour. | [LC045: missing include](/LinqContraband/LC045_MissingInclude.html) |
 | Keep eager loading bounded. | Overusing `Include` can create cartesian explosion or very wide result graphs. | [LC006: cartesian explosion](/LinqContraband/LC006_CartesianExplosion.html), [LC038: excessive eager loading](/LinqContraband/LC038_ExcessiveEagerLoading.html) |
@@ -66,6 +66,8 @@ attributes only when a reviewer has accepted a specific exception.
   broader diagnostic map before choosing severities.
 - Pair it with the [EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/) so the highest-risk
   checklist items become automated build feedback.
+- Use the [EF Core premature materialization analyzer guide](/LinqContraband/ef-core-premature-materialization-analyzer/)
+  when early `ToList`, `AsEnumerable`, unbounded materialization, or projection waste need focused guidance.
 - Send focused topics to the [EF Core Include analyzer guide](/LinqContraband/ef-core-include-analyzer/), the
   [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/), and the
   [EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/) when reviewers need

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,6 +87,10 @@ body_class: page-home
       <p><a href="{{ '/ef-core-query-performance-checklist/' | relative_url }}">Use the review checklist</a> for N+1 risks, projection, tracking, raw SQL, and CI severity policy.</p>
     </article>
     <article class="link-card">
+      <h3>Premature materialization analyzer</h3>
+      <p><a href="{{ '/ef-core-premature-materialization-analyzer/' | relative_url }}">Review early ToList</a>, AsEnumerable boundaries, unbounded materialization, and projection waste.</p>
+    </article>
+    <article class="link-card">
       <h3>Include analyzer</h3>
       <p><a href="{{ '/ef-core-include-analyzer/' | relative_url }}">Tune loading rules</a> for missing includes, cartesian explosion, deep eager-loading chains, and query tags.</p>
     </article>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,6 +11,7 @@ Official links:
 - Documentation hub: https://georgepwall1991.github.io/LinqContraband/
 - Rule catalog: https://georgepwall1991.github.io/LinqContraband/rule-catalog.html
 - EF Core analyzer rules: https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/
+- EF Core premature materialization analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/
 - EF Core AsNoTracking analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/
 - EF Core Include analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/
 - EF Core ExecuteUpdate analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-executeupdate-analyzer/
@@ -23,10 +24,14 @@ Official links:
 - Link kit: https://georgepwall1991.github.io/LinqContraband/backlink-kit/
 
 Key topics: Entity Framework Core, EF Core, LINQ, IQueryable, Roslyn analyzer, static analysis, EF Core analyzer rules,
-Entity Framework Core analyzer rules, EF Core AsNoTracking analyzer, EF Core tracking analyzer, EF Core Include
+Entity Framework Core analyzer rules, EF Core premature materialization analyzer, EF Core ToList analyzer, EF Core
+AsEnumerable analyzer, EF Core AsNoTracking analyzer, EF Core tracking analyzer, EF Core Include
 analyzer, EF Core missing Include analyzer, EF Core eager loading analyzer, query performance, N+1 queries, EF Core query
 performance checklist, EF Core N+1 query detector, missing includes, eager loading, raw SQL safety, EF Core raw SQL
 injection analyzer, EF Core query analyzer for CI, pull request diagnostics, .NET.
+
+Materialization topics: ToList before Where, ToList before Select, ToArray before OrderBy, AsEnumerable client-side
+query work, premature materialization, unbounded ToList, LINQ ToList performance analyzer, client-side evaluation.
 
 Bulk write topics: EF Core ExecuteUpdate analyzer, EF Core ExecuteDelete analyzer, EF Core bulk update analyzer,
 ExecuteUpdate, ExecuteUpdateAsync, ExecuteDelete, ExecuteDeleteAsync, RemoveRange, missing Where before bulk writes.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -9,7 +9,7 @@ permalink: /sitemap.xml
   {% assign priority = "0.6" -%}
   {% if item.url == "/" -%}
     {% assign priority = "1.0" -%}
-  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-analyzer-rules" or item.url contains "ef-core-asnotracking-analyzer" or item.url contains "ef-core-include-analyzer" or item.url contains "ef-core-executeupdate-analyzer" or item.url contains "ef-core-savechanges-in-loop-analyzer" or item.url contains "ef-core-query-performance-checklist" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
+  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-analyzer-rules" or item.url contains "ef-core-premature-materialization-analyzer" or item.url contains "ef-core-asnotracking-analyzer" or item.url contains "ef-core-include-analyzer" or item.url contains "ef-core-executeupdate-analyzer" or item.url contains "ef-core-savechanges-in-loop-analyzer" or item.url contains "ef-core-query-performance-checklist" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
     {% assign priority = "0.9" -%}
   {% elsif item.url contains "backlink-kit" or item.url contains "rule-catalog" -%}
     {% assign priority = "0.8" -%}


### PR DESCRIPTION
## Summary
- Add an EF Core premature materialization / ToList analyzer guide covering LC002, LC031, LC017, LC041, and LC001 search intent.
- Link the guide from the README, homepage, docs rail, analyzer rules guide, EF Core overview, checklist, backlink kit, llms.txt, and sitemap.
- Expand backlink and LLM coverage for ToList before Where/Select, AsEnumerable client-side query work, unbounded ToList, and LINQ ToList performance searches.

## Verification
- ruby -rjekyll -e 'Jekyll::Commands::Build.process({"source"=>"docs", "destination"=>"/tmp/linqcontraband-site", "config"=>"docs/_config.yml"})'
- Rendered sitemap check: 60 URLs, new materialization page included at priority 0.9.
- Rendered JSON-LD parse check.
- Rendered local link check.
- Rendered materialization page marker check.
- Rendered llms.txt marker check.
- git diff --check and staged diff --check.
- dotnet restore.
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj --configuration Release -- --check.
- dotnet build LinqContraband.sln --configuration Release --no-restore: 0 errors, 151 expected sample analyzer warnings.
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --configuration Release --no-build --logger "console;verbosity=minimal": 1159/1159 passed.
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net10.0.
- codex review --uncommitted: no actionable defects.

## Local runtime note
- This machine currently has only .NET 10 runtimes installed, so local test execution was limited to net10.0. CI remains the full multi-target proof.