### PR TITLE
docs: stop publishing internal maintenance docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,3 +11,5 @@ defaults:
       layout: default
 exclude:
   - .jekyll-cache
+  - adding_new_analyzer.md
+  - analyzer-health.md


### PR DESCRIPTION
## Summary
- Exclude docs/adding_new_analyzer.md and docs/analyzer-health.md from the Jekyll Pages build.
- Keep both files tracked because they are active internal repo/process docs referenced from contributor or release-health material.
- Audit found no tracked temp files, archives, binaries, empty files, stale coverage artifacts, or safe-to-delete shared tooling files.

## Verification
- ruby -rjekyll -e 'Jekyll::Commands::Build.process({"source"=>"docs", "destination"=>"/tmp/linqcontraband-tidy-site", "config"=>"docs/_config.yml"})'
- Rendered output check: adding_new_analyzer.md, analyzer-health.md, adding_new_analyzer.html, and analyzer-health.html are absent from the generated site.
- Rendered local link check.
- git diff --check and staged diff --check.
- dotnet restore.
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj --configuration Release -- --check.
- dotnet build LinqContraband.sln --configuration Release --no-restore: 0 errors, 151 expected sample analyzer warnings.
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --configuration Release --no-build --logger "console;verbosity=minimal": 1159/1159 passed.
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net10.0.
- codex review --uncommitted: no actionable defects.

## Local runtime note
- This machine currently has only .NET 10 runtimes installed, so local test execution was limited to net10.0. CI remains the full multi-target proof.