### PR TITLE
docs: add EF Core pagination OrderBy analyzer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ by [George Wall](https://www.georgewall.uk/).
 - **Official package:** [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
 - **Documentation hub:** [georgepwall1991.github.io/LinqContraband](https://georgepwall1991.github.io/LinqContraband/)
 - **EF Core analyzer rules:** [georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/)
+- **Pagination OrderBy guide:** [georgepwall1991.github.io/LinqContraband/ef-core-pagination-orderby-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-pagination-orderby-analyzer/)
 - **Premature materialization guide:** [georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/)
 - **AsNoTracking analyzer guide:** [georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/)
 - **Include analyzer guide:** [georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/)
@@ -80,6 +81,7 @@ For a human-readable guide to the rule groups, see the
 [EF Core analyzer rules page](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/). For loading
 guidance, see the [EF Core Include analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/).
 For early `ToList` and `AsEnumerable` guidance, see the [EF Core premature materialization analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/).
+For missing `OrderBy` before `Skip`, `Take`, `Last`, `ElementAt`, or `Chunk`, use the [EF Core pagination OrderBy analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-pagination-orderby-analyzer/).
 For tracking mode guidance, see the [EF Core AsNoTracking analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/).
 For set-based writes, see the [EF Core ExecuteUpdate analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-executeupdate-analyzer/).
 For repeated writes, see the [EF Core SaveChanges in loop analyzer guide](https://georgepwall1991.github.io/LinqContraband/ef-core-savechanges-in-loop-analyzer/).

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -72,6 +72,7 @@
           <a href="{{ '/rule-catalog.html' | relative_url }}">Rule catalog</a>
           <a href="{{ '/ef-core-analyzer-rules/' | relative_url }}">Rule guide</a>
           <a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">EF Core guide</a>
+          <a href="{{ '/ef-core-pagination-orderby-analyzer/' | relative_url }}">Pagination</a>
           <a href="{{ '/ef-core-premature-materialization-analyzer/' | relative_url }}">Materialization</a>
           <a href="{{ '/ef-core-include-analyzer/' | relative_url }}">Include guide</a>
           <a href="{{ '/ef-core-asnotracking-analyzer/' | relative_url }}">Tracking guide</a>

--- a/docs/backlink-kit.md
+++ b/docs/backlink-kit.md
@@ -19,6 +19,7 @@ repository or the GitHub Pages documentation hub.
 - Documentation: [https://georgepwall1991.github.io/LinqContraband/](https://georgepwall1991.github.io/LinqContraband/)
 - Rule catalog: [https://georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
 - Rule guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/)
+- Pagination OrderBy guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-pagination-orderby-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-pagination-orderby-analyzer/)
 - Premature materialization guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/)
 - AsNoTracking guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/)
 - Include guide: [https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/](https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/)
@@ -35,6 +36,11 @@ repository or the GitHub Pages documentation hub.
 - EF Core LINQ performance analyzer
 - EF Core analyzer rules
 - Entity Framework Core analyzer rules
+- EF Core pagination analyzer
+- EF Core Skip Take OrderBy analyzer
+- EF Core missing OrderBy analyzer
+- EF Core unordered pagination analyzer
+- EF Core deterministic pagination analyzer
 - EF Core premature materialization analyzer
 - EF Core ToList analyzer
 - EF Core AsEnumerable analyzer
@@ -106,6 +112,12 @@ unsafe raw SQL interpolation, and tracking mistakes.
 
 ```markdown
 [EF Core analyzer rules](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/) groups LinqContraband's 45 diagnostics by query shape, materialization, loading, async execution, tracking, bulk operations, modeling, and raw SQL safety.
+```
+
+## Pagination OrderBy Guide Link
+
+```markdown
+[EF Core pagination OrderBy analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-pagination-orderby-analyzer/) explains how LinqContraband flags missing OrderBy before Skip, Take, Last, ElementAt, Chunk, and misplaced OrderBy calls.
 ```
 
 ## Premature Materialization Guide Link

--- a/docs/ef-core-analyzer-rules.md
+++ b/docs/ef-core-analyzer-rules.md
@@ -25,7 +25,7 @@ catalog.
 
 | Rule family | Use it when you want to catch | Starting rules |
 | --- | --- | --- |
-| Query shape and translation | Local methods, unstable ordering, non-translatable overloads, and query shapes that can fall out of SQL translation. | [LC001: local method](/LinqContraband/LC001_LocalMethod.html), [LC015: missing OrderBy](/LinqContraband/LC015_MissingOrderBy.html), [LC024: non-translatable GroupBy](/LinqContraband/LC024_GroupByNonTranslatable.html) |
+| Query shape and translation | Local methods, unstable ordering, non-translatable overloads, and query shapes that can fall out of SQL translation. | [LC001: local method](/LinqContraband/LC001_LocalMethod.html), [LC015: missing OrderBy](/LinqContraband/LC015_MissingOrderBy.html), [EF Core pagination OrderBy analyzer](/LinqContraband/ef-core-pagination-orderby-analyzer/) |
 | Materialization and projection | Early `ToList`, whole-entity fetches, unbounded result sets, and scalar reads that should project in SQL. | [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html), [LC017: whole entity projection](/LinqContraband/LC017_WholeEntityProjection.html), [EF Core premature materialization analyzer](/LinqContraband/ef-core-premature-materialization-analyzer/) |
 | Loading and includes | Missing includes, cartesian explosion, excessive eager loading, deep include chains, and untagged complex queries. | [LC045: missing include](/LinqContraband/LC045_MissingInclude.html), [LC006: cartesian explosion](/LinqContraband/LC006_CartesianExplosion.html), [EF Core Include analyzer](/LinqContraband/ef-core-include-analyzer/) |
 | Execution and async | Database work inside loops, synchronous EF Core calls in async paths, repeated saves, missing cancellation tokens, and async-stream buffering. | [LC007: database execution inside loop](/LinqContraband/LC007_NPlusOneLooper.html), [LC008: sync-over-async](/LinqContraband/LC008_SyncBlocker.html), [LC010: SaveChanges loop](/LinqContraband/LC010_SaveChangesInLoop.html) |
@@ -52,6 +52,7 @@ dotnet_diagnostic.LC021.severity = warning
 
 # Expensive query shapes
 dotnet_diagnostic.LC002.severity = warning
+dotnet_diagnostic.LC015.severity = warning
 dotnet_diagnostic.LC031.severity = warning
 ```
 
@@ -62,6 +63,8 @@ when it represents project policy and developers have a documented exception pat
 
 - Use the [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/) when you need a
   reviewer-friendly pull-request aid.
+- Use the [EF Core pagination OrderBy analyzer guide](/LinqContraband/ef-core-pagination-orderby-analyzer/) when missing
+  `OrderBy` before `Skip`, `Take`, `Last`, `ElementAt`, or `Chunk` is the main concern.
 - Use the [EF Core premature materialization analyzer guide](/LinqContraband/ef-core-premature-materialization-analyzer/)
   when early `ToList`, `AsEnumerable`, unbounded materialization, or projection waste are the main concern.
 - Use the [EF Core Include analyzer guide](/LinqContraband/ef-core-include-analyzer/) when missing related data,

--- a/docs/ef-core-linq-performance-analyzer.md
+++ b/docs/ef-core-linq-performance-analyzer.md
@@ -34,6 +34,7 @@ dotnet add package LinqContraband
 
 For Include and eager-loading review, see the [EF Core Include analyzer guide](/LinqContraband/ef-core-include-analyzer/).
 For a focused walkthrough, see the [EF Core N+1 query detector guide](/LinqContraband/ef-core-n-plus-one-query-detector/).
+For deterministic pagination, see the [EF Core pagination OrderBy analyzer guide](/LinqContraband/ef-core-pagination-orderby-analyzer/).
 For early `ToList`, `ToArray`, and `AsEnumerable` review, see the
 [EF Core premature materialization analyzer guide](/LinqContraband/ef-core-premature-materialization-analyzer/).
 For security-sensitive SQL usage, see the [EF Core raw SQL injection analyzer guide](/LinqContraband/ef-core-raw-sql-injection-analyzer/).
@@ -58,6 +59,7 @@ The full catalog contains 45 rules grouped by domain:
 - [Rule catalog](/LinqContraband/rule-catalog.html)
 - [EF Core analyzer rules guide](/LinqContraband/ef-core-analyzer-rules/)
 - [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/)
+- [EF Core pagination OrderBy analyzer](/LinqContraband/ef-core-pagination-orderby-analyzer/)
 - [EF Core premature materialization analyzer](/LinqContraband/ef-core-premature-materialization-analyzer/)
 - [EF Core Include analyzer](/LinqContraband/ef-core-include-analyzer/)
 - [EF Core N+1 query detector](/LinqContraband/ef-core-n-plus-one-query-detector/)

--- a/docs/ef-core-pagination-orderby-analyzer.md
+++ b/docs/ef-core-pagination-orderby-analyzer.md
@@ -1,0 +1,125 @@
+---
+layout: default
+title: EF Core Pagination OrderBy Analyzer
+description: Use LinqContraband as an EF Core pagination analyzer for missing OrderBy before Skip, Take, Last, ElementAt, Chunk, and misplaced OrderBy calls.
+permalink: /ef-core-pagination-orderby-analyzer/
+body_class: page-pagination-orderby-analyzer
+---
+
+# EF Core Pagination OrderBy Analyzer
+
+LinqContraband includes an EF Core pagination analyzer for query shapes where row order matters. It catches missing
+`OrderBy` before `Skip`, `Take`, `Last`, `ElementAt`, and `Chunk`, plus `OrderBy` calls that appear after pagination has
+already selected an unstable page.
+
+Install the official analyzer package:
+
+```bash
+dotnet add package LinqContraband
+```
+
+## Why Pagination Needs a Stable Order
+
+SQL result order is not guaranteed unless the query asks for one. A query can look stable on a developer machine, then
+return duplicate or missing rows in production after an index change, statistics update, or different execution plan.
+
+```csharp
+var page = await db.Users
+    .Where(user => user.IsActive)
+    .Skip(pageIndex * pageSize)
+    .Take(pageSize)
+    .ToListAsync();
+```
+
+That is not deterministic pagination. The database is free to choose any row order before applying the page window.
+
+Prefer an explicit order before the page boundary:
+
+```csharp
+var page = await db.Users
+    .Where(user => user.IsActive)
+    .OrderBy(user => user.Id)
+    .Skip(pageIndex * pageSize)
+    .Take(pageSize)
+    .ToListAsync();
+```
+
+## What The Analyzer Flags
+
+| Rule | Finds | Why it matters |
+| --- | --- | --- |
+| [LC015: missing OrderBy](/LinqContraband/LC015_MissingOrderBy.html) | `Skip`, `Take`, `Last`, `LastOrDefault`, `ElementAt`, `ElementAtOrDefault`, and `Chunk` on unordered EF Core queries. | Pagination, positional access, and "last row" lookups need a stable order. |
+| [LC015: misplaced OrderBy](/LinqContraband/LC015_MissingOrderBy.html) | `OrderBy` after `Skip` or `Take`. | Sorting an already selected page does not make the page selection deterministic. |
+| [LC005: multiple OrderBy](/LinqContraband/LC005_MultipleOrderBy.html) | A later `OrderBy` that resets an earlier sort. | Accidental sort reset can hide the intended page order. |
+| [LC031: unbounded materialization](/LinqContraband/LC031_UnboundedQueryMaterialization.html) | Broad reads without a bound. | Pagination should be explicit when a query can return many rows. |
+
+## Misplaced OrderBy Example
+
+This sorts only the arbitrary 25 rows already chosen by `Take`:
+
+```csharp
+var products = await db.Products
+    .Take(25)
+    .OrderBy(product => product.Name)
+    .ToListAsync();
+```
+
+Move the ordering before `Take`:
+
+```csharp
+var products = await db.Products
+    .OrderBy(product => product.Name)
+    .Take(25)
+    .ToListAsync();
+```
+
+When the sort column can tie, add a stable tiebreaker:
+
+```csharp
+var products = await db.Products
+    .OrderBy(product => product.Name)
+    .ThenBy(product => product.Id)
+    .Skip(pageIndex * pageSize)
+    .Take(pageSize)
+    .ToListAsync();
+```
+
+## Safer Pagination Patterns
+
+- Order by a primary key when any stable order is acceptable.
+- Order by the business sort column and then by a unique tiebreaker for visible lists.
+- Use every part of a composite key when the key is the ordering contract.
+- Keep `OrderBy` before `Skip`, `Take`, `Last`, `ElementAt`, or `Chunk`.
+- Do not rely on insertion order, clustered-index luck, or "natural" database order.
+
+## Review Checklist
+
+1. Does every `Skip` or `Take` have an upstream `OrderBy`?
+2. Does visible sorting include a deterministic tiebreaker when values can tie?
+3. Is `OrderBy` placed before the page boundary rather than after it?
+4. Could a second `OrderBy` reset an earlier `OrderBy` that the query depends on?
+5. Does the query also need a `Take` or page size bound before materialization?
+
+## CI Severity Starter
+
+Unordered pagination is usually a production reliability issue, so LC015 is a good early warning:
+
+```ini
+[*.cs]
+
+# Deterministic pagination and row order
+dotnet_diagnostic.LC015.severity = warning
+dotnet_diagnostic.LC005.severity = warning
+dotnet_diagnostic.LC031.severity = warning
+```
+
+Use the [EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/) when these diagnostics should run
+on every pull request. Use the [EF Core query performance checklist](/LinqContraband/ef-core-query-performance-checklist/)
+when reviewers need the broader query-performance context.
+
+## Official Links
+
+- Canonical repository: [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
+- Official NuGet package: [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
+- Full rule catalog: [georgepwall1991.github.io/LinqContraband/rule-catalog.html](https://georgepwall1991.github.io/LinqContraband/rule-catalog.html)
+- Safe install guidance: [Official LinqContraband downloads and authenticity](/LinqContraband/security-and-authenticity/)

--- a/docs/ef-core-query-performance-checklist.md
+++ b/docs/ef-core-query-performance-checklist.md
@@ -24,6 +24,7 @@ dotnet add package LinqContraband
 | --- | --- | --- |
 | Avoid database calls inside loops. | Loop execution can turn one request into many database roundtrips. | [LC007: database execution inside loop](/LinqContraband/LC007_NPlusOneLooper.html) |
 | Batch `SaveChanges` outside loops unless each item needs its own commit boundary. | Repeated saves can turn one unit of work into many transactions and partial-progress states. | [LC010: SaveChanges inside loop](/LinqContraband/LC010_SaveChangesInLoop.html) |
+| Order before pagination or positional access. | Unordered `Skip`, `Take`, `Last`, `ElementAt`, or `Chunk` queries can return unstable rows. | [LC015: missing OrderBy](/LinqContraband/LC015_MissingOrderBy.html), [EF Core pagination OrderBy analyzer](/LinqContraband/ef-core-pagination-orderby-analyzer/) |
 | Materialize only after filtering, ordering, and projection. | Early `ToList`, `AsEnumerable`, or `ToArray` can move work from SQL into memory. | [LC002: premature materialization](/LinqContraband/LC002_PrematureMaterialization.html), [EF Core premature materialization analyzer](/LinqContraband/ef-core-premature-materialization-analyzer/) |
 | Use projection when only a few fields are needed. | Loading whole entities increases network, memory, and tracking cost. | [LC017: whole entity projection](/LinqContraband/LC017_WholeEntityProjection.html), [LC041: single entity scalar projection](/LinqContraband/LC041_SingleEntityScalarProjection.html) |
 | Make related data loading explicit. | Missing includes can produce null navigation data, lazy-loading churn, or hidden N+1 behaviour. | [LC045: missing include](/LinqContraband/LC045_MissingInclude.html) |
@@ -46,6 +47,7 @@ Start with analyzer warnings, then promote a focused rule set to errors once the
 
 # Expensive or risky query shapes
 dotnet_diagnostic.LC002.severity = warning
+dotnet_diagnostic.LC015.severity = warning
 dotnet_diagnostic.LC007.severity = error
 dotnet_diagnostic.LC045.severity = warning
 
@@ -66,6 +68,8 @@ attributes only when a reviewer has accepted a specific exception.
   broader diagnostic map before choosing severities.
 - Pair it with the [EF Core query analyzer CI guide](/LinqContraband/ef-core-query-analyzer-ci/) so the highest-risk
   checklist items become automated build feedback.
+- Use the [EF Core pagination OrderBy analyzer guide](/LinqContraband/ef-core-pagination-orderby-analyzer/) when
+  unordered `Skip`, `Take`, `Last`, `ElementAt`, `Chunk`, or misplaced `OrderBy` calls need focused guidance.
 - Use the [EF Core premature materialization analyzer guide](/LinqContraband/ef-core-premature-materialization-analyzer/)
   when early `ToList`, `AsEnumerable`, unbounded materialization, or projection waste need focused guidance.
 - Send focused topics to the [EF Core Include analyzer guide](/LinqContraband/ef-core-include-analyzer/), the

--- a/docs/index.html
+++ b/docs/index.html
@@ -91,6 +91,10 @@ body_class: page-home
       <p><a href="{{ '/ef-core-premature-materialization-analyzer/' | relative_url }}">Review early ToList</a>, AsEnumerable boundaries, unbounded materialization, and projection waste.</p>
     </article>
     <article class="link-card">
+      <h3>Pagination OrderBy analyzer</h3>
+      <p><a href="{{ '/ef-core-pagination-orderby-analyzer/' | relative_url }}">Review deterministic paging</a> for Skip, Take, Last, ElementAt, Chunk, and misplaced OrderBy calls.</p>
+    </article>
+    <article class="link-card">
       <h3>Include analyzer</h3>
       <p><a href="{{ '/ef-core-include-analyzer/' | relative_url }}">Tune loading rules</a> for missing includes, cartesian explosion, deep eager-loading chains, and query tags.</p>
     </article>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,6 +11,7 @@ Official links:
 - Documentation hub: https://georgepwall1991.github.io/LinqContraband/
 - Rule catalog: https://georgepwall1991.github.io/LinqContraband/rule-catalog.html
 - EF Core analyzer rules: https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/
+- EF Core pagination OrderBy analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-pagination-orderby-analyzer/
 - EF Core premature materialization analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-premature-materialization-analyzer/
 - EF Core AsNoTracking analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-asnotracking-analyzer/
 - EF Core Include analyzer: https://georgepwall1991.github.io/LinqContraband/ef-core-include-analyzer/
@@ -24,7 +25,8 @@ Official links:
 - Link kit: https://georgepwall1991.github.io/LinqContraband/backlink-kit/
 
 Key topics: Entity Framework Core, EF Core, LINQ, IQueryable, Roslyn analyzer, static analysis, EF Core analyzer rules,
-Entity Framework Core analyzer rules, EF Core premature materialization analyzer, EF Core ToList analyzer, EF Core
+Entity Framework Core analyzer rules, EF Core pagination analyzer, EF Core Skip Take OrderBy analyzer, EF Core
+missing OrderBy analyzer, EF Core premature materialization analyzer, EF Core ToList analyzer, EF Core
 AsEnumerable analyzer, EF Core AsNoTracking analyzer, EF Core tracking analyzer, EF Core Include
 analyzer, EF Core missing Include analyzer, EF Core eager loading analyzer, query performance, N+1 queries, EF Core query
 performance checklist, EF Core N+1 query detector, missing includes, eager loading, raw SQL safety, EF Core raw SQL
@@ -32,6 +34,9 @@ injection analyzer, EF Core query analyzer for CI, pull request diagnostics, .NE
 
 Materialization topics: ToList before Where, ToList before Select, ToArray before OrderBy, AsEnumerable client-side
 query work, premature materialization, unbounded ToList, LINQ ToList performance analyzer, client-side evaluation.
+
+Pagination topics: missing OrderBy before Skip, missing OrderBy before Take, EF Core unordered pagination, deterministic
+pagination, Skip Take OrderBy analyzer, Last without OrderBy, ElementAt without OrderBy, misplaced OrderBy after Take.
 
 Bulk write topics: EF Core ExecuteUpdate analyzer, EF Core ExecuteDelete analyzer, EF Core bulk update analyzer,
 ExecuteUpdate, ExecuteUpdateAsync, ExecuteDelete, ExecuteDeleteAsync, RemoveRange, missing Where before bulk writes.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -9,7 +9,7 @@ permalink: /sitemap.xml
   {% assign priority = "0.6" -%}
   {% if item.url == "/" -%}
     {% assign priority = "1.0" -%}
-  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-analyzer-rules" or item.url contains "ef-core-premature-materialization-analyzer" or item.url contains "ef-core-asnotracking-analyzer" or item.url contains "ef-core-include-analyzer" or item.url contains "ef-core-executeupdate-analyzer" or item.url contains "ef-core-savechanges-in-loop-analyzer" or item.url contains "ef-core-query-performance-checklist" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
+  {% elsif item.url contains "ef-core-linq-performance-analyzer" or item.url contains "ef-core-analyzer-rules" or item.url contains "ef-core-pagination-orderby-analyzer" or item.url contains "ef-core-premature-materialization-analyzer" or item.url contains "ef-core-asnotracking-analyzer" or item.url contains "ef-core-include-analyzer" or item.url contains "ef-core-executeupdate-analyzer" or item.url contains "ef-core-savechanges-in-loop-analyzer" or item.url contains "ef-core-query-performance-checklist" or item.url contains "ef-core-n-plus-one-query-detector" or item.url contains "ef-core-raw-sql-injection-analyzer" or item.url contains "ef-core-query-analyzer-ci" or item.url contains "security-and-authenticity" -%}
     {% assign priority = "0.9" -%}
   {% elsif item.url contains "backlink-kit" or item.url contains "rule-catalog" -%}
     {% assign priority = "0.8" -%}


### PR DESCRIPTION
## Summary
- Add an EF Core pagination OrderBy analyzer guide for LC015, LC005, and LC031 search intent.
- Link the guide from the README, homepage, docs rail, analyzer rules guide, EF Core overview, checklist, backlink kit, llms.txt, and sitemap.
- Expand backlink and LLM coverage for missing OrderBy before Skip/Take, unordered pagination, deterministic pagination, Last/ElementAt without OrderBy, and misplaced OrderBy searches.

## Verification
- ruby -rjekyll -e 'Jekyll::Commands::Build.process({"source"=>"docs", "destination"=>"/tmp/linqcontraband-pagination-site", "config"=>"docs/_config.yml"})'
- Rendered sitemap check: 61 URLs, new pagination page included at priority 0.9.
- Rendered JSON-LD parse check.
- Rendered local link check.
- Rendered pagination page marker check.
- Rendered llms.txt marker check.
- git diff --check and staged diff --check.
- dotnet restore.
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj --configuration Release -- --check.
- dotnet build LinqContraband.sln --configuration Release --no-restore: 0 errors, 151 expected sample analyzer warnings.
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --configuration Release --no-build --logger "console;verbosity=minimal": 1159/1159 passed.
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --frameworks net10.0.
- codex review --uncommitted: no actionable defects.

## Local runtime note
- This machine currently has only .NET 10 runtimes installed, so local test execution was limited to net10.0. CI remains the full multi-target proof.