### PR TITLE
docs: add author links to strengthen project trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ by [George Wall](https://www.georgewall.uk/).
 
 - **Canonical source:** [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband)
 - **Official package:** [nuget.org/packages/LinqContraband](https://www.nuget.org/packages/LinqContraband)
+- **Maintainer site:** [georgewall.uk](https://www.georgewall.uk/)
 - **Documentation hub:** [georgepwall1991.github.io/LinqContraband](https://georgepwall1991.github.io/LinqContraband/)
 - **EF Core analyzer rules:** [georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules](https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/)
 - **Async query guide:** [georgepwall1991.github.io/LinqContraband/ef-core-async-query-analyzer](https://georgepwall1991.github.io/LinqContraband/ef-core-async-query-analyzer/)

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -56,6 +56,7 @@
         <a href="{{ '/rule-catalog.html' | relative_url }}">Rules</a>
         <a href="{{ '/ef-core-linq-performance-analyzer/' | relative_url }}">Guide</a>
         <a href="{{ '/security-and-authenticity/' | relative_url }}">Authenticity</a>
+        <a href="https://www.georgewall.uk/">Author</a>
         <a href="https://www.nuget.org/packages/LinqContraband">NuGet</a>
         <a href="https://github.com/georgepwall1991/LinqContraband">GitHub</a>
       </div>

--- a/docs/backlink-kit.md
+++ b/docs/backlink-kit.md
@@ -135,6 +135,18 @@ unsafe raw SQL interpolation, and tracking mistakes.
 [LinqContraband](https://github.com/georgepwall1991/LinqContraband) is an EF Core LINQ performance analyzer for catching query issues at compile time.
 ```
 
+## Maintainer Link
+
+```markdown
+[George Wall](https://www.georgewall.uk/) maintains LinqContraband, an open-source EF Core LINQ performance analyzer for .NET.
+```
+
+## Author Profile Link
+
+```markdown
+LinqContraband is maintained by [George Wall](https://www.georgewall.uk/) and published from the canonical repository at [github.com/georgepwall1991/LinqContraband](https://github.com/georgepwall1991/LinqContraband).
+```
+
 ## Documentation Link
 
 ```markdown

--- a/docs/index.html
+++ b/docs/index.html
@@ -147,6 +147,10 @@ body_class: page-home
       <p><a href="{{ '/security-and-authenticity/' | relative_url }}">Verify official links</a> before installing or linking to the project.</p>
     </article>
     <article class="link-card">
+      <h3>Maintainer</h3>
+      <p><a href="https://www.georgewall.uk/">Visit George Wall's site</a> for the author profile and other maintained projects.</p>
+    </article>
+    <article class="link-card">
       <h3>Link kit</h3>
       <p><a href="{{ '/backlink-kit/' | relative_url }}">Copy safe snippets</a> for articles, newsletters, tool lists, docs, and talks.</p>
     </article>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,6 +8,7 @@ Official links:
 - Source: https://github.com/georgepwall1991/LinqContraband
 - Package: https://www.nuget.org/packages/LinqContraband
 - Maintainer: https://www.georgewall.uk/
+- Maintainer profile: George Wall, https://www.georgewall.uk/
 - Documentation hub: https://georgepwall1991.github.io/LinqContraband/
 - Rule catalog: https://georgepwall1991.github.io/LinqContraband/rule-catalog.html
 - EF Core analyzer rules: https://georgepwall1991.github.io/LinqContraband/ef-core-analyzer-rules/
@@ -73,6 +74,6 @@ analyzer, async stream buffering, await foreach, IAsyncEnumerable buffering.
 Write batching topics: EF Core SaveChanges in loop analyzer, EF Core SaveChanges analyzer, EF Core batch SaveChanges
 analyzer, SaveChanges inside foreach, SaveChangesAsync inside loop, N+1 writes, repeated database writes.
 
-Canonical description: LinqContraband is an open-source EF Core LINQ performance analyzer for .NET. It runs as a
-compile-time Roslyn analyzer and helps catch query performance, reliability, and security issues before code reaches
-production.
+Canonical description: LinqContraband is an open-source EF Core LINQ performance analyzer for .NET, maintained by
+George Wall at https://www.georgewall.uk/. It runs as a compile-time Roslyn analyzer and helps catch query performance,
+reliability, and security issues before code reaches production.


### PR DESCRIPTION
## Summary
- add a visible Author link to the documentation navigation
- add a homepage maintainer card pointing to George Wall's site
- add maintainer backlink snippets and clearer LLM/README maintainer signals

## Verification
- ruby -rjekyll -e 'Jekyll::Commands::Build.process({"source"=>"docs", "destination"=>"/tmp/linqcontraband-author-link-site", "config"=>"docs/_config.yml"})'
- rendered author-link checks across 66 HTML pages and https://www.georgewall.uk/ returned 200
- git diff --check
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --configuration Release --logger "console;verbosity=minimal"
- codex review --uncommitted