### PR TITLE
docs: prepare v5.6.35 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.35] - 2026-07-04
+
 ### Fixed
 - `LC037` now detects `StringBuilder` SQL assembled through separate `Append(...)` statements before `ToString()` reaches a raw SQL sink, including null-conditional appends, local dynamic and method-call append values, loop-carried and compound-assigned append locals, caught-throw continuations with exact, alias, ordinary base, user-defined base, and framework base exception catches, copied builder expressions, constructor copies from tainted builders, and conditional builder aliases, while keeping constant-only, branch-selected literal, path-dominated constant append-local overwrite, per-iteration constant reset, variable-capacity constructor, constant compound-assignment, terminating-branch local, fluent `Clear()` reset, try/catch-contained branch clear, catch-exiting throw, guaranteed `finally` clear, short-circuit reset, terminating guard, and definitely cleared builder flows precise.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you reference LinqContraband in an article, talk, list, or internal engineering guide, please cite the canonical repository or documentation hub."
 type: software
 title: "LinqContraband"
-version: "5.6.34"
-date-released: "2026-07-02"
+version: "5.6.35"
+date-released: "2026-07-04"
 abstract: "LinqContraband is an EF Core LINQ performance analyzer and Roslyn analyzer for catching query performance, reliability, and raw SQL safety issues at compile time."
 authors:
   - family-names: "Wall"

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -4,6 +4,12 @@ Reviewed: 2026-07-04 (45-rule current-state audit — one read-only reviewer per
 
 This is a deliberately harsh health audit for the **45 analyzers** in `RuleCatalog`. The catalog currently declares 30 rules with code fixes and 15 manual-only rules with explicit rationale. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
+Release metadata:
+
+- Package version: 5.6.35
+- Base audited commit: 0cafc5f024a4485f4561b1b9fdaa4998c64ee130
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.35`
+
 ## Rubric
 
 | Metric | Meaning |

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.34</Version>
+        <Version>5.6.35</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>Hardens analyzer crash and fixer edge cases across LC003, LC008, LC011, LC014, LC026, LC032, and LC037, with regression coverage and refreshed analyzer-health documentation.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC037 now detects StringBuilder SQL assembled through separate Append statements before ToString reaches raw SQL sinks, with regression coverage and refreshed analyzer-health planning metadata.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- bump package, citation, and release metadata to v5.6.35
- move the LC037 StringBuilder statement-flow hardening changelog entry into the v5.6.35 section
- record the release-prep pack command in analyzer-health metadata

## Validation
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --filter FullyQualifiedName~RuleQualityContractTests --verbosity minimal (6/6)
- dotnet build src/LinqContraband/LinqContraband.csproj -c Release
- dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.35 --no-build
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-build --verbosity minimal (1224/1224)
- git diff --check
- codex review --uncommitted (clean after citation metadata sync)

CI covers net8.0/net9.0 in addition to the local net10.0 runtime.