### PR TITLE
docs: prepare v5.6.37 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.37] - 2026-07-04
+
 ### Fixed
 - `LC021` now handles EF Core named-filter `IgnoreQueryFilters(filterKeys)` calls safely: extension syntax rewrites back to the query receiver instead of the filter-key argument, while static extension syntax reports and rewrites to the explicit `source` query argument even when named arguments are reordered.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you reference LinqContraband in an article, talk, list, or internal engineering guide, please cite the canonical repository or documentation hub."
 type: software
 title: "LinqContraband"
-version: "5.6.36"
+version: "5.6.37"
 date-released: "2026-07-04"
 abstract: "LinqContraband is an EF Core LINQ performance analyzer and Roslyn analyzer for catching query performance, reliability, and raw SQL safety issues at compile time."
 authors:

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **45 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.6.36
-- Base audited commit: 80f4478d036cd8497e1cc561135d662380c2b205
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.36`
+- Package version: 5.6.37
+- Base audited commit: 51ac011d7062dfb889ed81449ebae776fbb97c96
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.37`
 
 ## Rubric
 
@@ -36,7 +36,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 
 ## Scorecard
 
-> Rows below are the **2026-07-04 current-state audit** — the 2026-06-04 rerun deltas, 2026-06-10 full re-verification, LC045 releases, 2026-07-02 adversarial fixes, 2026-07-03 LC037 hardening, and the 2026-07-04 LC002 `Last*` fixer guard are folded into the rows. Every rule was independently re-checked against current source, tests, docs, samples, and the candidate queue; subsequent hardening has raised the local net10.0 suite to **1226 tests**.
+> Rows below are the **2026-07-04 current-state audit** — the 2026-06-04 rerun deltas, 2026-06-10 full re-verification, LC045 releases, 2026-07-02 adversarial fixes, 2026-07-03 LC037 hardening, and the 2026-07-04 LC002 `Last*` and LC021 named-filter fixer guards are folded into the rows. Every rule was independently re-checked against current source, tests, docs, samples, and the candidate queue; subsequent hardening has raised the local net10.0 suite to **1231 tests**.
 
 | Rule | Title | Domain | Severity | Analyzer | False Positives | Fix Strategy | Tests | Docs/Samples | Importance | Priority | Notes |
 | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
@@ -541,9 +541,9 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.6.36**
+Package version: **5.6.37**
 
-Base audited commit: master at `80f4478` (5.6.36 release candidate state). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0, and the July 2026 raw-SQL/fixer hardening through 5.6.36.
+Base audited commit: master at `51ac011` (5.6.37 release candidate state). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0, and the July 2026 raw-SQL/fixer hardening through 5.6.37.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.36</Version>
+        <Version>5.6.37</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC002 no longer offers the move-before-materialization fixer for ordering-sensitive Last and LastOrDefault continuations after inline materializers, while preserving the diagnostic and safe fixer paths.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC021 now handles EF Core named-filter IgnoreQueryFilters calls safely, including extension syntax and reordered named static arguments.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- bump package metadata to 5.6.37
- move LC021 named-filter hardening entry into the 5.6.37 changelog section
- update citation and analyzer-health release metadata for the merged LC021 commit

## Verification
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --filter FullyQualifiedName~RuleQualityContractTests --verbosity minimal
- dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.37
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-build --verbosity minimal
- dotnet build LinqContraband.sln --no-restore --configuration Release
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release -- --configuration Release --frameworks net8.0 net9.0 net10.0
- git diff --check
- codex review --uncommitted