### PR TITLE
chore: prepare 5.6.39 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.39] - 2026-07-05
+
 ### Fixed
 - `LC009` now treats nested member-state writes rooted in a materialized entity, such as `user.Profile.DisplayName = name`, as write paths, so it no longer suggests `AsNoTracking()` when a helper later commits that tracked graph mutation.
 - `LC017` now withholds its anonymous-projection fixer when downstream usage includes cast, interface, or conversion-based entity property access such as `((IHasName)e).Name` or `((IHasName)e)?.Name`, preventing partial projections that leave code depending on the original entity shape.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **45 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.6.38
-- Base audited commit: 17c91ccb40f7c5bce8bbabe2a21b00e1792ab9ba
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.38`
+- Package version: 5.6.39
+- Base audited commit: 50b10e373738cbc18bfba85f4acb18286ac9e0c7
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.39`
 
 ## Rubric
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.38</Version>
+        <Version>5.6.39</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC012 now offers its RemoveRange(query) to ExecuteDelete fixer for provably irrelevant later saves while withholding unsafe cross-context, helper, and multi-source rewrites.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC001, LC006, LC007, LC009, LC010, LC011, LC013, LC015, LC016, LC017, LC018, LC023, LC024, LC025, LC027, LC030, LC031, LC035, LC036, LC039, LC040, LC041, LC044, and LC045 receive analyzer or fixer precision hardening across query-shape, context-lifetime, tracking, materialization, include, raw-SQL, and bulk-operation boundaries.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- bump LinqContraband package metadata to 5.6.39
- move the accumulated analyzer-hardening changelog entries into the 5.6.39 release section
- update analyzer-health release metadata to the merged stack commit and pack path

## Impact
Ships the consolidated analyzer-health hardening stack now merged to master.

## Validation
- dotnet test --framework net10.0 --filter FullyQualifiedName~RuleQualityContractTests
- dotnet test LinqContraband.sln --framework net10.0 --verbosity minimal (1358 passed)
- dotnet run --project tools/RuleCatalogDocGenerator/RuleCatalogDocGenerator.csproj -- --check
- dotnet build LinqContraband.sln --no-restore --configuration Release --verbosity minimal
- dotnet run --project tools/SampleDiagnosticsVerifier/SampleDiagnosticsVerifier.csproj --configuration Release
- dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.39
- git diff --check
- codex review --uncommitted