### PR TITLE
chore: prepare 5.6.40 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.40] - 2026-07-08
+
 ### Fixed
 - `LC045` now treats `DbContext.Set<TEntity>()` as a query root when detecting missing includes, including hoisted query locals and entity types without a matching `DbSet` property, and its fixer inserts `.Include(...)` before materialization on those sources.
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **45 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.6.39
-- Base audited commit: 50b10e373738cbc18bfba85f4acb18286ac9e0c7
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.39`
+- Package version: 5.6.40
+- Base audited commit: d1606874781fdf83a48187485132ffc11f5a2961
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.40`
 
 ## Rubric
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.39</Version>
+        <Version>5.6.40</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC001, LC006, LC007, LC009, LC010, LC011, LC013, LC015, LC016, LC017, LC018, LC023, LC024, LC025, LC027, LC030, LC031, LC035, LC036, LC039, LC040, LC041, LC044, and LC045 receive analyzer or fixer precision hardening across query-shape, context-lifetime, tracking, materialization, include, raw-SQL, and bulk-operation boundaries.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC045 now detects missing includes from DbContext.Set&lt;TEntity&gt;() query roots, including hoisted query locals and entity types without matching DbSet properties.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- bump package version to 5.6.40
- move the LC045 Set<TEntity>() root improvement from Unreleased to the 5.6.40 changelog section
- sync analyzer-health package metadata to the merged fix commit d1606874781fdf83a48187485132ffc11f5a2961

## Impact
This patch release ships the LC045 precision improvement for DbContext.Set<TEntity>() query roots while keeping release metadata limited to the established three-file release-prep scope.

## Validation
- dotnet test --framework net10.0 --filter FullyQualifiedName~RuleQualityContractTests (6 passed)
- dotnet test --framework net10.0 (1598 passed)
- dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.40
- git diff --check
- codex review --uncommitted (no actionable regressions)