### PR TITLE
docs: require semantic navigation for analyzer work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,14 @@ Roslyn analyzer repo. Package: `LinqContraband` (NuGet). Health tracker: **`docs
 - **Build/test:** `dbt` / `dtt` from repo root (or `dotnet test` on `LinqContraband.sln`).
 - **Cross-review:** `codex review --uncommitted` before PR on non-trivial changes.
 
+## Analyzer navigation gate
+
+Before broad text search or release review on analyzer work, use semantic tooling first:
+
+- **dotnet-lsp first:** run workspace/document symbol lookup for the target rule, then references on changed helpers or public entry points, and use diagnostics when available before full tests.
+- **Rider MCP when exposed:** use Rider-backed project context or inspections for Roslyn changes when the `rider` MCP is available in the active Codex session.
+- **Text search second:** use code search/power scripts only to confirm semantic findings, locate non-C# artifacts, or when LSP/Rider is unavailable; state the fallback in the final summary.
+
 ## Load-bearing facts
 
 - One focused rule per batch unless health doc names a tightly coupled pair.


### PR DESCRIPTION
## Summary
- add an explicit analyzer navigation gate to the LinqContraband agent router
- require dotnet-lsp symbols/references/diagnostics before broad text search or release review
- document Rider MCP usage when exposed and require fallback disclosure when semantic tools are unavailable

## Verification
- git diff --check
- dotnet test --framework net10.0