### PR TITLE
chore: prepare 5.6.41 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.41] - 2026-07-08
+
 ### Fixed
 - `LC006` now fixes static `EntityFrameworkQueryableExtensions.Include(...)` chains by inserting `AsSplitQuery()` on the real query source argument instead of rewriting the extension type name and producing invalid code.
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **45 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.6.40
-- Base audited commit: d1606874781fdf83a48187485132ffc11f5a2961
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.40`
+- Package version: 5.6.41
+- Base audited commit: 5b8c3f1277dea073a0766d2f9951e3d650249eae
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.41`
 
 ## Rubric
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.40</Version>
+        <Version>5.6.41</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC045 now detects missing includes from DbContext.Set&lt;TEntity&gt;() query roots, including hoisted query locals and entity types without matching DbSet properties.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC006 now fixes static EntityFrameworkQueryableExtensions.Include(...) chains by inserting AsSplitQuery() on the real query source argument instead of rewriting the extension type name.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- bump package metadata to `5.6.41`
- move the `LC006` changelog entry into the `5.6.41` release section
- update analyzer-health release metadata and pack command for `5.6.41`

## Impact
This prepares the LC006 static Include fixer hardening for the GitHub release and NuGet publish workflow without widening the release-prep scope beyond the expected three metadata files.

## Validation
- `dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj -f net10.0 --filter "FullyQualifiedName~RuleQualityContractTests"` passed: 6 tests
- `dotnet test LinqContraband.sln --framework net10.0` passed: 1601 tests
- `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.41` succeeded
- `git diff --check` clean
- `codex review --uncommitted` found no actionable issues

CI covers net8.0/net9.0 target frameworks that are not installed locally.