### PR TITLE
docs: prepare v5.6.42 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.42] - 2026-07-08
+
 ### Fixed
 - `LC030` now resolves concrete singleton implementations returned directly from `AddSingleton<TService>(..., provider => new Implementation(...))` factories, tightens DI-call recognition to real `IServiceCollection` extension methods, and reports multiple stored `DbContext` diagnostics in deterministic source order.
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **45 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.6.41
-- Base audited commit: 5b8c3f1277dea073a0766d2f9951e3d650249eae
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.41`
+- Package version: 5.6.42
+- Base audited commit: 076d403934fac572ff933780c8bda3f50e30cbd7
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.42`
 
 ## Rubric
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.41</Version>
+        <Version>5.6.42</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC006 now fixes static EntityFrameworkQueryableExtensions.Include(...) chains by inserting AsSplitQuery() on the real query source argument instead of rewriting the extension type name.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC030 now resolves direct factory-created singleton implementations and tightens DI registration recognition to IServiceCollection extension methods.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- bump package metadata to 5.6.42 for the LC030 singleton-registration hardening
- add the 5.6.42 changelog entry
- update analyzer-health release metadata to the LC030 merge commit and pack path

## Verification
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --filter FullyQualifiedName~RuleQualityContractTests --no-restore (6 passed)
- dotnet test LinqContraband.sln --framework net10.0 --no-restore (1604 passed)
- dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.42
- git diff --check
- codex review --uncommitted (clean)

CI covers the net8/net9 legs.