### PR TITLE
docs: prepare 5.6.43 release metadata for LC010

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.43] - 2026-07-08
+
 ### Fixed
 - `LC010` now reports `SaveChanges` and `SaveChangesAsync` calls hidden behind local delegate variables, aliases, compound or self-combining delegate subscriptions, conditional delegate initializers or invocation, delegate call chains, setup helpers including nested live helper calls and wrapper setup helpers, local invoker callback helpers, loop-carried assignments, or method groups when the delegate is invoked inside a loop, including loop-variant branch-exiting or opposite-branch delegate paths, assignments after invocation inside loop-called wrapper delegates, local functions, or callback helpers, and conditionally assigned delegates that can carry a loop-local context into later iterations, while preserving fresh loop-local contexts, fresh contexts passed directly or through wrapper delegate parameters unless those parameters are reassigned on a path that can reach the save or forwarding call, delegate removals without clearing duplicate subscriptions, branch-exclusive or branch-exiting delegate paths with stable guards, branch-exclusive conditional initializer arms with stable guards, negated-guard delegate paths, called-helper delegate overwrites, return-exiting retries, retry-only loops, switch-local retry breaks, and same-path reassignment boundaries.
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **45 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.6.42
-- Base audited commit: 076d403934fac572ff933780c8bda3f50e30cbd7
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.42`
+- Package version: 5.6.43
+- Base audited commit: 53b08de0b14fa5fe22c651f7541d6a535f717276
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.43`
 
 ## Rubric
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.42</Version>
+        <Version>5.6.43</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC030 now resolves direct factory-created singleton implementations and tightens DI registration recognition to IServiceCollection extension methods.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC010 now reports SaveChanges calls hidden behind local delegates, method groups, helper callbacks, and loop-carried delegate paths while preserving documented fresh-context and stable-guard boundaries.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- bump package metadata to 5.6.43 for the LC010 delegate-flow hardening
- move the LC010 changelog entry into the 5.6.43 release section
- sync analyzer-health release metadata and pack verification path

## Validation
- dotnet restore LinqContraband.sln
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --filter FullyQualifiedName~RuleQualityContractTests --no-restore --verbosity minimal (6 passed)
- dotnet test tests/LinqContraband.Tests/LinqContraband.Tests.csproj --framework net10.0 --no-restore --verbosity minimal (1706 passed)
- dotnet build src/LinqContraband/LinqContraband.csproj -c Release --no-restore
- dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.43
- git diff --check
- Claude independent review: No actionable findings

CI covers net8.0/net9.0 in addition to the local net10.0 run.