### PR TITLE
chore: prepare LinqContraband 5.6.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.44] - 2026-07-14
+
 ### Fixed
 - `LC045` now resolves exact static/named Queryable and EF query sources, preserves `AsQueryable`, `IgnoreAutoIncludes`, and `FromSql*` paths, detects supported `ToHashSet*` and query-root `ElementAt*` overloads, and analyses direct property subpatterns plus exact inline materialized-collection callbacks while their source generation remains active. Framework-namespace lookalikes, effectful callback chains, entity-returning projections, multi-source operators, temporal APIs, `Find*`, async streams, and repository-query roots remain conservative boundaries.
 - `LC045` now follows materialized entities through intra-procedural control flow, preserving missing-`Include` diagnostics that occur before a later escape or reassignment and allowing navigation writes to satisfy later reads only for the same entity origin when the write occurs on every path to the read.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **45 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.6.43
-- Base audited commit: 53b08de0b14fa5fe22c651f7541d6a535f717276
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.43`
+- Package version: 5.6.44
+- Base audited commit: 0bb2787b8e5bed9bbd35f9c3991ffdd21b0f7118
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.44`
 
 ## Rubric
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.43</Version>
+        <Version>5.6.44</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC010 now reports SaveChanges calls hidden behind local delegates, method groups, helper callbacks, and loop-carried delegate paths while preserving documented fresh-context and stable-guard boundaries.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC045 now proves exact query consumers, materializer overloads, and active callback provenance while preserving conservative lookalike, projection, and fixer boundaries.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- bump LinqContraband to 5.6.44
- publish LC045 query-consumer hardening release notes
- sync analyzer-health release metadata to fix commit 0bb2787b8e5bed9bbd35f9c3991ffdd21b0f7118

## Validation
- RuleQualityContractTests passed: 6 tests
- full net10.0 suite passed: 1,912 tests
- Release build passed with 0 warnings and 0 errors
- package created at /tmp/linqcontraband-5.6.44/LinqContraband.5.6.44.nupkg
- independent Claude metadata review returned no actionable findings
- diff is exactly the established three-file release slice