### PR TITLE
chore: prepare LinqContraband 5.6.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.45] - 2026-07-16
+
 ### Fixed
 - `LC045` now honours exact top-level `OnModelCreating` configuration that marks the queried entity's navigation with EF Core `AutoInclude()`, including constructed generic contexts, while keeping `IgnoreAutoIncludes()`, fluent, explicit, conditional, or runtime-valued disablement, early-exit or deferred configuration, later unproven model-configuration boundaries, hidden override slots, shadowed methods, and different context/navigation paths diagnostic.
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **45 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.6.44
-- Base audited commit: 0bb2787b8e5bed9bbd35f9c3991ffdd21b0f7118
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.44`
+- Package version: 5.6.45
+- Base audited commit: 207bbdb48ecb3f317f60302d18516a7f88ff464c
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.45`
 
 ## Rubric
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.44</Version>
+        <Version>5.6.45</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC045 now proves exact query consumers, materializer overloads, and active callback provenance while preserving conservative lookalike, projection, and fixer boundaries.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC045 now honours exact model-level AutoInclude configuration while preserving diagnostics for disabled, indirect, conditional, and aliased configuration paths.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Release

Prepare LinqContraband 5.6.45 for the merged LC045 model-level `AutoInclude()` precision improvement.

## Scope

- bump the package and release notes to 5.6.45
- cut the 5.6.45 changelog section dated 2026-07-16
- sync analyzer-health release metadata to audited master commit `207bbdb48ecb3f317f60302d18516a7f88ff464c`

## Verification

- Release build: clean (0 warnings, 0 errors)
- Full tests on net10.0: 1,932 passed
- Rule quality contract: 6 passed
- Package: `LinqContraband.5.6.45.nupkg` packed successfully to `/tmp/linqcontraband-5.6.45`
- NuGet manifest reports version 5.6.45 and the LC045 release notes
- Codex-only release review completed; its one date finding was corrected

CI covers the repository's remaining target frameworks.