### PR TITLE
chore: prepare LinqContraband 5.6.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.46] - 2026-07-16
+
 ### Fixed
 - `LC034` no longer offers the `ExecuteSql`/`ExecuteSqlAsync` rewrite when an interpolated hole occupies a structural SQL position, lies inside a bracketed, double-quoted, or backtick-delimited identifier or PostgreSQL dollar-quoted literal, follows a provider-style backslash-escaped quote, is formatted or aligned, is adjacent to another hole, uses `char`, a custom, generic, enum, or framework-type lookalike value, or belongs to provider-commented, batched, or multi-statement SQL, including separator-free non-DML statements. Quote tracking now ignores apostrophes inside delimited identifiers, complete direct scalar `INSERT ... VALUES (...)` rows (including multiple rows) are recognised without treating table, column, or SQL-expression holes as values, and FixAll handles mixed synchronous/asynchronous calls; automatic fixes remain limited to proven core-library scalar values in unambiguous `UPDATE`/`DELETE`/`INSERT` value positions while the security diagnostic stays available for manual allow-listing or redesign.
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **45 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.6.45
-- Base audited commit: 207bbdb48ecb3f317f60302d18516a7f88ff464c
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.45`
+- Package version: 5.6.46
+- Base audited commit: c63e8d67d66e9ea11ba57aefa3c47b483077036d
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.46`
 
 ## Rubric
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.45</Version>
+        <Version>5.6.46</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC045 now honours exact model-level AutoInclude configuration while preserving diagnostics for disabled, indirect, conditional, and aliased configuration paths.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC034 now limits ExecuteSql rewrites to proven scalar value positions and keeps structural, provider-literal, formatted, batched, and ambiguous interpolation manual.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- release the LC034 structural SQL fixer hardening as v5.6.46
- synchronize package version and LC034-only release notes
- record fix merge `c63e8d67d66e9ea11ba57aefa3c47b483077036d` in analyzer health

## Validation
- `dotnet build LinqContraband.sln -c Release --no-restore` — passed, 0 warnings/errors
- `dotnet test ... --framework net10.0 --filter FullyQualifiedName~RuleQualityContractTests` — 6/6 passed
- full net10.0 suite — 1,979/1,979 passed
- packed `/tmp/linqcontraband-5.6.46/LinqContraband.5.6.46.nupkg`; nuspec version and LC034 release notes verified
- Codex metadata review — no actionable findings

CI covers net8.0, net9.0, and net10.0.