### PR TITLE
chore: release 5.7.0 — ship LC046 concurrency detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.0] - 2026-07-22
+
 ### Added
 - `LC046` detects overlapping EF Core async queries, saves, finds, loads, set-based commands, and relational raw commands that are proven to share one `DbContext`, including direct task overlap and `Task.WhenAll(Enumerable.Select(...))` fan-out, while keeping sequential awaits, separate or per-item contexts, branch-exclusive flow, escaped or reassigned state, repository queries, and custom lookalikes quiet.
 

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **46 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.6.47
-- Base audited commit: 6695bc235252a3a35b2acbb493c87973021995d5
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.6.47`
+- Package version: 5.7.0
+- Base audited commit: d375b9ea7f9d5d39d385abf6a8e4ad1e1db10544
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.7.0`
 
 ## Rubric
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.6.47</Version>
+        <Version>5.7.0</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC044 now detects silent writes through nested graph paths, executed delegate and control-flow paths, throw-operand catch transfers, and equivalent override or interface navigation dispatch while preserving conservative precision boundaries.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC046 detects proven overlapping Entity Framework Core operations on one DbContext, including direct, discarded, delayed-await, task-combinator, synchronous-completion, selector fan-out, exhaustive-branch, and statically repeated loop shapes, while preserving conservative context and control-flow boundaries.</PackageReleaseNotes>
         <PackageTags>EFCore;EntityFrameworkCore;LINQ;IQueryable;Analyzer;RoslynAnalyzer;StaticAnalysis;CodeAnalysis;Performance;QueryPerformance;NPlusOne;SQL;DotNet;NuGet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- release LC046 concurrent same-`DbContext` operation detection as LinqContraband 5.7.0
- move the verified LC046 changelog entry from Unreleased into the dated 5.7.0 section
- anchor analyzer-health release evidence to merged feature commit `d375b9e`

## Scope
This release PR intentionally changes exactly three files: package metadata, changelog, and analyzer-health release metadata. Analyzer implementation and tests were merged separately in #305.

## Validation
- `dotnet build LinqContraband.sln -c Release --no-restore`: 0 warnings, 0 errors
- full net10.0 suite: 2,483 passed
- `RuleCatalogDocGenerator --check`: passed
- package: `/tmp/linqcontraband-5.7.0/LinqContraband.5.7.0.nupkg`
- package contents: analyzer DLL, README, icon, and metadata present
- nuspec version: 5.7.0
- nuspec release notes: LC046 same-context concurrency scope verified
