### PR TITLE
fix: release 5.7.2 with verified LC046 precision hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.2] - 2026-07-29
+
 ### Fixed
 - LC046 follow-up hardening keeps a concurrent-operation diagnostic when a direct or stored `Task.WhenAny` allocated inside a compatible continuing handler's `try` can fail, when a potentially overflowing checked built-in conversion, user-defined conversion/operator, custom event accessor assignment, possibly-null field-like event receiver, or possibly-null instance-field receiver can throw before that await, when a source-defined replacement-exception constructor can fail before a direct `throw`, or when a terminal-looking opposite branch can reach a compatible continuing outer catch through a prefix statement, return expression, explicit `throw` operand, or custom event accessor. It now keeps overflow-safe checked conversions, field-like events with known receivers, null-conditional field reads, and known non-null field receivers quiet, while routing possible field/event receiver faults only to compatible `NullReferenceException` handlers. A terminal opposite branch remains terminal when a prefix fault has no handler path to the later operation. Terminal nested catches now intercept potential user-code conversion/operator failures, and metadata `Task.FromResult` is routed only as an `OutOfMemoryException` allocation failure so mismatched handlers stay quiet. A stored `Task.WhenAny` created before the `try` remains quiet.
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ When the analyzer cannot prove an EF-backed query shape statically, it **stays q
 ## Install
 
 ```xml
-  <PackageReference Include="LinqContraband" Version="5.7.1" PrivateAssets="all" />
+  <PackageReference Include="LinqContraband" Version="5.7.2" PrivateAssets="all" />
 ```
 
 Or:
 
 ```bash
-dotnet add package LinqContraband --version 5.7.1
+dotnet add package LinqContraband --version 5.7.2
 ```
 
 **No runtime dependency** is added to your app. LinqContraband runs as a Roslyn analyzer during build and in supported IDEs (Visual Studio, Rider, VS Code / C# Dev Kit) and CI.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **46 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.7.1
-- Base audited commit: d375b9ea7f9d5d39d385abf6a8e4ad1e1db10544
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.7.1`
+- Package version: 5.7.2
+- Base audited commit: a4cbfbcd3b2f7ae6282f6065bbd67acafde72c6e
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.7.2`
 
 ## Rubric
 
@@ -750,9 +750,9 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.7.1**
+Package version: **5.7.2**
 
-Base audited commit: master at `d375b9ea7f9d5d39d385abf6a8e4ad1e1db10544` (5.7.0 analyzer state; 5.7.1 is discoverability-only). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0, the July 2026 raw-SQL/fixer hardening, LC046 concurrent same-context operation detection in 5.7.0, and NuGet/GitHub discoverability assets in 5.7.1.
+Base audited commit: master at `a4cbfbcd3b2f7ae6282f6065bbd67acafde72c6e` (LC046 precision-hardening merge for 5.7.2; the later coverage-badge update does not change analyzer source). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0, the July 2026 raw-SQL/fixer hardening, LC046 concurrent same-context operation detection in 5.7.0, and NuGet/GitHub discoverability assets in 5.7.1.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.7.1</Version>
+        <Version>5.7.2</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband — EF Core LINQ performance analyzer</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>Discoverability release: keyword-rich package title, description, and tags for EF Core LINQ performance (N+1, client-side evaluation, AsNoTracking, DbContext, query performance); conversion-funnel README with product-flow visuals; packs assets for NuGet README rendering; adds discoverability metadata tests and package verification. Diagnostic IDs and severities are unchanged.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC046 precision hardening preserves concurrent-operation diagnostics across exceptional completion-bypass paths while avoiding false positives for safe built-in operations, bounded unsigned array lengths, and singleton span task shapes.</PackageReleaseNotes>
         <PackageTags>efcore;entity-framework-core;EntityFrameworkCore;LINQ;IQueryable;NPlusOne;client-side-evaluation;AsNoTracking;DbContext;query-performance;roslyn;roslyn-analyzer;analyzers;static-analysis;performance;sql;csharp;dotnet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary
- Prepare the 5.7.2 patch release for the merged LC046 completion-safety hardening.
- Synchronize package version, release notes, changelog, health metadata, and packaged README install commands.

## Impact
This makes the verified LC046 precision fixes available through NuGet without changing diagnostic IDs or severities.

## Validation
- 2,599 net10 tests passed.
- Solution build completed with zero warnings and zero errors.
- Catalog and sample diagnostics passed on net8, net9, and net10.
- Local release package and packaged README verifier passed.
- Independent Codex review found no actionable issues.