### PR TITLE
chore: release 5.7.4 — shared LC046 set-name proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.4] - 2026-08-01
+
 ### Fixed
 - LC046 now applies the `DbContext.Set<TEntity>(name)` non-blank-name proof at context-origin resolution as well as inside loops. Two operations rooted at a set name that cannot be proven non-blank are no longer reported as concurrent, because EF Core rejects a null or whitespace name before constructing a query, so neither operation starts. A proven non-blank name still reports.
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ When the analyzer cannot prove an EF-backed query shape statically, it **stays q
 ## Install
 
 ```xml
-  <PackageReference Include="LinqContraband" Version="5.7.3" PrivateAssets="all" />
+  <PackageReference Include="LinqContraband" Version="5.7.4" PrivateAssets="all" />
 ```
 
 Or:
 
 ```bash
-dotnet add package LinqContraband --version 5.7.3
+dotnet add package LinqContraband --version 5.7.4
 ```
 
 **No runtime dependency** is added to your app. LinqContraband runs as a Roslyn analyzer during build and in supported IDEs (Visual Studio, Rider, VS Code / C# Dev Kit) and CI.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **46 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.7.3
-- Base audited commit: 540bbf5b2e387c0b9460088830d96030db390891
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.7.3`
+- Package version: 5.7.4
+- Base audited commit: 29d3020a64d872f8aed38dd2c214fdfedbc6ace9
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.7.4`
 
 ## Rubric
 
@@ -770,9 +770,9 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.7.3**
+Package version: **5.7.4**
 
-Base audited commit: master at `540bbf5b2e387c0b9460088830d96030db390891` (LC046 loop-built task-list detection plus named-`Set` and `CancellationToken.None` review closure, merged for 5.7.3). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0, the July 2026 raw-SQL/fixer hardening, LC046 concurrent same-context operation detection in 5.7.0, NuGet/GitHub discoverability assets in 5.7.1, LC046 completion-bypass precision hardening in 5.7.2, and LC046 loop-built task-list detection with named-`Set` and `CancellationToken.None` review closure in 5.7.3.
+Base audited commit: master at `29d3020a64d872f8aed38dd2c214fdfedbc6ace9` (LC046 shared named-`Set` non-blank-name proof across loop and non-loop paths, merged for 5.7.4). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0, the July 2026 raw-SQL/fixer hardening, LC046 concurrent same-context operation detection in 5.7.0, NuGet/GitHub discoverability assets in 5.7.1, LC046 completion-bypass precision hardening in 5.7.2, LC046 loop-built task-list detection with named-`Set` and `CancellationToken.None` review closure in 5.7.3, and the shared named-`Set` non-blank-name proof in 5.7.4.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.7.3</Version>
+        <Version>5.7.4</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband — EF Core LINQ performance analyzer</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC046 now detects EF Core async tasks accumulated into a stable framework list inside a provably repeated loop, no longer reports a loop rooted at a DbContext.Set name that cannot be proven non-blank, and no longer lets CancellationToken.None hide a real overlap.</PackageReleaseNotes>
+        <PackageReleaseNotes>LC046 applies the DbContext.Set name validity proof outside loops as well, so two operations rooted at a set name that cannot be proven non-blank are no longer reported as concurrent. EF Core rejects such a name before building a query, so neither operation starts.</PackageReleaseNotes>
         <PackageTags>efcore;entity-framework-core;EntityFrameworkCore;LINQ;IQueryable;NPlusOne;client-side-evaluation;AsNoTracking;DbContext;query-performance;roslyn;roslyn-analyzer;analyzers;static-analysis;performance;sql;csharp;dotnet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

Release-prep for **5.7.4**, shipping the LC046 non-loop set-name fix merged in `29d3020` (#314).

## Changed

- `src/LinqContraband/LinqContraband.csproj` — `<Version>` 5.7.3 → 5.7.4, `<PackageReleaseNotes>`
- `CHANGELOG.md` — `[Unreleased]` → `## [5.7.4] - 2026-08-01`
- `docs/analyzer-health.md` — package version, base audited commit (both places, full SHA), pack path, version history
- `README.md` — both install pins

## What ships to consumers

LC046 applies the `DbContext.Set<TEntity>(name)` non-blank-name proof outside loops as well as inside them. Two operations rooted at a set name that cannot be proven non-blank are no longer reported as concurrent, because EF Core rejects such a name before building a query, so neither operation starts. A proven non-blank name still reports.

## Validation

- `dotnet test LinqContraband.sln --framework net10.0` — **2,624/2,624**
- architecture suite 265/265, including the rule-id contract and the baseline/metadata commit match
- `dotnet pack -c Release` — `LinqContraband.5.7.4.nupkg` created
- independent review of this release-prep diff returned no actionable findings

CI covers net8.0 and net9.0, which are not runnable locally.