### PR TITLE
chore: release 5.7.5 — reverse the 5.7.4 under-reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.5] - 2026-08-01
+
 ### Fixed
 - LC046 no longer reports operations outside loops whose required arguments provably make them fault before they start. A literal null or blank raw-SQL string, a null `FindAsync` key array, a null required query sequence or callable, a null raw-SQL parameter collection, and a definitely-cancelled token all mean the EF call never begins work, so two such calls cannot overlap. The same proof runs when query construction itself provably faults, such as `FromSqlRaw("")` followed by a terminal.
 - LC046 reports `DbContext.Set<TEntity>(name)` operations again when the name comes from a parameter, field, or call. 5.7.4 required the name to be *provably* non-blank on every path, which silently dropped genuine concurrency diagnostics for the common case of a name the analyzer cannot evaluate. Outside loops LC046 now suppresses only on proof that an argument is invalid, never on absence of proof that it is valid. The loop gate keeps the stricter requirement, which it needs to prove an operation starts on every iteration.

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ When the analyzer cannot prove an EF-backed query shape statically, it **stays q
 ## Install
 
 ```xml
-  <PackageReference Include="LinqContraband" Version="5.7.4" PrivateAssets="all" />
+  <PackageReference Include="LinqContraband" Version="5.7.5" PrivateAssets="all" />
 ```
 
 Or:
 
 ```bash
-dotnet add package LinqContraband --version 5.7.4
+dotnet add package LinqContraband --version 5.7.5
 ```
 
 **No runtime dependency** is added to your app. LinqContraband runs as a Roslyn analyzer during build and in supported IDEs (Visual Studio, Rider, VS Code / C# Dev Kit) and CI.

--- a/docs/analyzer-health.md
+++ b/docs/analyzer-health.md
@@ -6,9 +6,9 @@ This is a deliberately harsh health audit for the **46 analyzers** in `RuleCatal
 
 Release metadata:
 
-- Package version: 5.7.4
-- Base audited commit: 29d3020a64d872f8aed38dd2c214fdfedbc6ace9
-- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.7.4`
+- Package version: 5.7.5
+- Base audited commit: 325bbc2768b22b4fc4cdb73392a238b3cbcfe180
+- Pack verification: `dotnet pack src/LinqContraband/LinqContraband.csproj -c Release -o /tmp/linqcontraband-5.7.5`
 
 ## Rubric
 
@@ -778,9 +778,9 @@ These claims were **not** acted on — do not re-chase without new evidence:
 
 ## Verification Baseline
 
-Package version: **5.7.4**
+Package version: **5.7.5**
 
-Base audited commit: master at `29d3020a64d872f8aed38dd2c214fdfedbc6ace9` (LC046 shared named-`Set` non-blank-name proof across loop and non-loop paths, merged for 5.7.4). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0, the July 2026 raw-SQL/fixer hardening, LC046 concurrent same-context operation detection in 5.7.0, NuGet/GitHub discoverability assets in 5.7.1, LC046 completion-bypass precision hardening in 5.7.2, LC046 loop-built task-list detection with named-`Set` and `CancellationToken.None` review closure in 5.7.3, and the shared named-`Set` non-blank-name proof in 5.7.4.
+Base audited commit: master at `325bbc2768b22b4fc4cdb73392a238b3cbcfe180` (LC046 non-loop argument-fault proof and the 5.7.4 polarity correction, merged for 5.7.5). Since the 2026-06-04 baseline (5.5.13): descriptor hygiene (helpLinkUri on all rules, sealed/FixAll architecture tests), repo/CI hardening, the `IncludePathParser` extraction shared by LC006/LC045, **LC045 shipped in 5.6.0** (four pre-ship review-hardening rounds), the **5.6.1 hot-fix** for the LC045 chained-`?.` StackOverflowException that killed csc on 5.6.0, the July 2026 raw-SQL/fixer hardening, LC046 concurrent same-context operation detection in 5.7.0, NuGet/GitHub discoverability assets in 5.7.1, LC046 completion-bypass precision hardening in 5.7.2, LC046 loop-built task-list detection with named-`Set` and `CancellationToken.None` review closure in 5.7.3, the shared named-`Set` non-blank-name proof in 5.7.4, and the non-loop argument-fault proof with its polarity correction in 5.7.5.
 
 Architecture tests enforce the rule quality contract for public package metadata, code-fix provider exports, documentation drift, repository layout, and `samples/LinqContraband.Sample/sample-diagnostics.json` sample expectations.
 

--- a/src/LinqContraband/LinqContraband.csproj
+++ b/src/LinqContraband/LinqContraband.csproj
@@ -9,7 +9,7 @@
         <NoWarn>$(NoWarn);RS1038;RS2008</NoWarn>
 
         <!-- NuGet Metadata -->
-        <Version>5.7.4</Version>
+        <Version>5.7.5</Version>
         <PackageId>LinqContraband</PackageId>
         <Title>LinqContraband — EF Core LINQ performance analyzer</Title>
         <Authors>George Wall</Authors>
@@ -18,7 +18,7 @@
         <RepositoryUrl>https://github.com/georgepwall1991/LinqContraband</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageProjectUrl>https://georgepwall1991.github.io/LinqContraband/</PackageProjectUrl>
-        <PackageReleaseNotes>LC046 applies the DbContext.Set name validity proof outside loops as well, so two operations rooted at a set name that cannot be proven non-blank are no longer reported as concurrent. EF Core rejects such a name before building a query, so neither operation starts.</PackageReleaseNotes>
+        <PackageReleaseNotes>Recommended for anyone on 5.7.4: that version could silently hide real concurrency bugs, because LC046 stopped reporting named-set operations whose name came from a parameter or field. LC046 now reports them again, and separately no longer produces false positives outside loops for operations whose required arguments provably make them fault before starting, such as null or blank raw SQL, a null key array, or a cancelled token.</PackageReleaseNotes>
         <PackageTags>efcore;entity-framework-core;EntityFrameworkCore;LINQ;IQueryable;NPlusOne;client-side-evaluation;AsNoTracking;DbContext;query-performance;roslyn;roslyn-analyzer;analyzers;static-analysis;performance;sql;csharp;dotnet</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

Release-prep for **5.7.5**, shipping `325bbc2` (#316).

## Why this one matters more than a normal patch

5.7.4 introduced under-reporting: LC046 stopped flagging `db.Set<User>(name)` operations whenever the name came from a parameter or field, so **real concurrency bugs went silently unreported**. 5.7.5 reverses that. The package release notes lead with this, since it changes upgrade urgency for anyone on 5.7.4.

## Changed

- `src/LinqContraband/LinqContraband.csproj` — version + release notes
- `CHANGELOG.md` — `[Unreleased]` to `## [5.7.5] - 2026-08-01`
- `docs/analyzer-health.md` — package version, base audited commit (both places), pack path, version history
- `README.md` — both install pins

## Validation

- `dotnet test LinqContraband.sln --framework net10.0` — **2,628/2,628**
- architecture suite 265/265, including the rule-id contract and baseline/metadata commit match
- `dotnet pack -c Release` — `LinqContraband.5.7.5.nupkg` created
- independent review of the release-prep diff returned no actionable findings; its one observation, that the NuGet-facing notes undersold the regression, was applied

CI covers net8.0 and net9.0, which are not runnable locally.
